### PR TITLE
chore(pnpm): disable dependency build scripts on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,10 +206,7 @@
         "node": "^22"
     },
     "pnpm": {
-        "onlyBuiltDependencies": [
-            "@sentry/cli",
-            "esbuild"
-        ],
+        "onlyBuiltDependencies": [],
         "overrides": {
             "@babel/runtime@<7.26.10": "7.26.10",
             "avsc": "git://github.com/Irys-xyz/avsc#a730cc8018b79e114b6a3381bbb57760a24c6cef",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ catalogs:
     '@vitest/coverage-v8': 3.2.6
     vitest: 3.2.6
 autoInstallPeers: true
+ignoreScripts: true
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
   - '@codama/*'


### PR DESCRIPTION
## Description

Hardens dependency installation against arbitrary build/postinstall scripts:

-   Empties `pnpm.onlyBuiltDependencies` in `package.json` so no package is allowlisted to run build scripts (previously `@sentry/cli`, `esbuild`).
-   Adds `ignoreScripts: true` to `pnpm-workspace.yaml` so dependency lifecycle scripts are skipped on install.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): build tooling / supply-chain hardening

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

N/A — no UI changes.

## Testing

Ran a clean `pnpm i --frozen-lockfile` and confirmed dependency build/postinstall scripts no longer execute and the install completes without the previously allowlisted builds.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

[HOO-728](https://linear.app/solana-fndn/issue/HOO-728)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] CI/CD checks pass on the PR
