### PR TITLE
refactor(instruction-card): share card chrome via surface context

### DIFF
--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -1,4 +1,5 @@
 import { BaseInstructionCard } from '@components/common/BaseInstructionCard';
+import { type InstructionSurface, InstructionSurfaceProvider } from '@entities/instruction-card';
 import { isParsedInstruction, toParsedTransaction, useInstructionParser } from '@entities/instruction-parser';
 import { AssociatedTokenDetailsCard } from '@features/decode-instruction-associated-token';
 import { LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
@@ -33,6 +34,16 @@ import { UnknownDetailsCard } from './UnknownDetailsCard';
 
 const INSPECTOR_RESULT = { err: null };
 const INSPECTOR_SIGNATURE = '';
+
+const INSPECTOR_SURFACE: InstructionSurface = {
+    // The inspector resolves an address against the transaction under inspection
+    // rather than linking out to its account page.
+    Address: AddressWithContextCell,
+    Shell: InspectorInstructionCardComponent,
+    result: INSPECTOR_RESULT,
+    // `InspectorInstructionCard` renders its own Program row, so the fields must not.
+    showProgramField: false,
+};
 
 export function InstructionsSection({
     message,
@@ -78,7 +89,7 @@ export function InstructionsSection({
         : {};
 
     return (
-        <>
+        <InstructionSurfaceProvider surface={INSPECTOR_SURFACE}>
             {transactionMessage.instructions.map((ix, index) => {
                 const batchInnerCards = batchByIndex[index]?.map((innerIx, childIndex) => (
                     <ErrorBoundary key={childIndex} fallback={null}>
@@ -96,7 +107,7 @@ export function InstructionsSection({
                     />
                 );
             })}
-        </>
+        </InstructionSurfaceProvider>
     );
 }
 

--- a/app/components/instruction/__tests__/SystemDetailsCard.spec.tsx
+++ b/app/components/instruction/__tests__/SystemDetailsCard.spec.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { TxInstructionSurface } from '@entities/instruction-card';
 import {
     createInstructionParserDispatcher,
     isParsedInstruction,
@@ -42,7 +43,15 @@ describe('instruction::SystemDetailsCard', () => {
                 <ClusterProvider>
                     <TransactionsProvider>
                         <AccountsProvider>
-                            <SystemDetailsCard index={index} ix={parsedIx} raw={ti} result={{ err: null }} tx={tx} />
+                            <TxInstructionSurface result={{ err: null }}>
+                                <SystemDetailsCard
+                                    index={index}
+                                    ix={parsedIx}
+                                    raw={ti}
+                                    result={{ err: null }}
+                                    tx={tx}
+                                />
+                            </TxInstructionSurface>
                         </AccountsProvider>
                     </TransactionsProvider>
                 </ClusterProvider>
@@ -69,7 +78,15 @@ describe('instruction::SystemDetailsCard', () => {
                 <ClusterProvider>
                     <TransactionsProvider>
                         <AccountsProvider>
-                            <SystemDetailsCard index={index} ix={parsedIx} raw={ti} result={{ err: null }} tx={tx} />
+                            <TxInstructionSurface result={{ err: null }}>
+                                <SystemDetailsCard
+                                    index={index}
+                                    ix={parsedIx}
+                                    raw={ti}
+                                    result={{ err: null }}
+                                    tx={tx}
+                                />
+                            </TxInstructionSurface>
                         </AccountsProvider>
                     </TransactionsProvider>
                 </ClusterProvider>

--- a/app/components/instruction/system/AllocateDetailsCard.tsx
+++ b/app/components/instruction/system/AllocateDetailsCard.tsx
@@ -1,49 +1,8 @@
-import { Address } from '@components/common/Address';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, bytes, defineInstructionCard } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { AllocateInfo } from './types';
 
-export function AllocateDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: AllocateInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Allocate Account"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Account Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.account} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Allocated Data Size</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">{info.space} byte(s)</BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const AllocateDetailsCard = defineInstructionCard<AllocateInfo>({
+    fields: info => [address('Account Address', info.account), bytes('Allocated Data Size', info.space)],
+    title: 'System Program: Allocate Account',
+});

--- a/app/components/instruction/system/AllocateWithSeedDetailsCard.tsx
+++ b/app/components/instruction/system/AllocateWithSeedDetailsCard.tsx
@@ -1,73 +1,14 @@
-import { Address } from '@components/common/Address';
-import { Copyable } from '@components/common/Copyable';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, bytes, defineInstructionCard, seed } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { AllocateWithSeedInfo } from './types';
 
-export function AllocateWithSeedDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: AllocateWithSeedInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Allocate Account w/ Seed"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Account Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.account} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Base Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.base} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Seed</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Copyable text={info.seed}>
-                        <code>{info.seed}</code>
-                    </Copyable>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Allocated Data Size</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">{info.space} byte(s)</BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Assigned Program Id</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.owner} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const AllocateWithSeedDetailsCard = defineInstructionCard<AllocateWithSeedInfo>({
+    fields: info => [
+        address('Account Address', info.account),
+        address('Base Address', info.base),
+        seed('Seed', info.seed),
+        bytes('Allocated Data Size', info.space),
+        address('Assigned Program Id', info.owner),
+    ],
+    title: 'System Program: Allocate Account w/ Seed',
+});

--- a/app/components/instruction/system/AssignDetailsCard.tsx
+++ b/app/components/instruction/system/AssignDetailsCard.tsx
@@ -1,51 +1,8 @@
-import { Address } from '@components/common/Address';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { AssignInfo } from './types';
 
-export function AssignDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: AssignInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Assign Account"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Account Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.account} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Assigned Program Id</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.owner} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const AssignDetailsCard = defineInstructionCard<AssignInfo>({
+    fields: info => [address('Account Address', info.account), address('Assigned Program Id', info.owner)],
+    title: 'System Program: Assign Account',
+});

--- a/app/components/instruction/system/AssignWithSeedDetailsCard.tsx
+++ b/app/components/instruction/system/AssignWithSeedDetailsCard.tsx
@@ -1,68 +1,13 @@
-import { Address } from '@components/common/Address';
-import { Copyable } from '@components/common/Copyable';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard, seed } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { AssignWithSeedInfo } from './types';
 
-export function AssignWithSeedDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: AssignWithSeedInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Assign Account w/ Seed"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Account Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.account} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Base Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.base} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Seed</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Copyable text={info.seed}>
-                        <code>{info.seed}</code>
-                    </Copyable>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Assigned Program Id</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.owner} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const AssignWithSeedDetailsCard = defineInstructionCard<AssignWithSeedInfo>({
+    fields: info => [
+        address('Account Address', info.account),
+        address('Base Address', info.base),
+        seed('Seed', info.seed),
+        address('Assigned Program Id', info.owner),
+    ],
+    title: 'System Program: Assign Account w/ Seed',
+});

--- a/app/components/instruction/system/CreateDetailsCard.tsx
+++ b/app/components/instruction/system/CreateDetailsCard.tsx
@@ -1,71 +1,14 @@
-import { Address } from '@components/common/Address';
-import { SolBalance } from '@components/common/SolBalance';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, bytes, defineInstructionCard, sol } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { CreateAccountInfo } from './types';
 
-export function CreateDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: CreateAccountInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Create Account"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>From Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.source} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>New Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.newAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Transfer Amount (SOL)</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <SolBalance lamports={info.lamports} />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Allocated Data Size</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">{info.space} byte(s)</BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Assigned Program Id</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.owner} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const CreateDetailsCard = defineInstructionCard<CreateAccountInfo>({
+    fields: info => [
+        address('From Address', info.source),
+        address('New Address', info.newAccount),
+        sol('Transfer Amount (SOL)', info.lamports),
+        bytes('Allocated Data Size', info.space),
+        address('Assigned Program Id', info.owner),
+    ],
+    title: 'System Program: Create Account',
+});

--- a/app/components/instruction/system/CreateWithSeedDetailsCard.tsx
+++ b/app/components/instruction/system/CreateWithSeedDetailsCard.tsx
@@ -1,91 +1,16 @@
-import { Address } from '@components/common/Address';
-import { Copyable } from '@components/common/Copyable';
-import { SolBalance } from '@components/common/SolBalance';
-import { ParsedInstruction, SignatureResult, SystemProgram, TransactionInstruction } from '@solana/web3.js';
-import React from 'react';
+import { address, bytes, defineInstructionCard, seed, sol } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { CreateAccountWithSeedInfo } from './types';
 
-export function CreateWithSeedDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: CreateAccountWithSeedInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-    // Raw instruction for displaying accounts and hex data in raw mode (used by inspector)
-    raw?: TransactionInstruction;
-}) {
-    const { ix, index, result, info, innerCards, childIndex, raw } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Create Account w/ Seed"
-            innerCards={innerCards}
-            childIndex={childIndex}
-            raw={raw}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>From Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.source} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>New Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.newAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Base Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.base} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Seed</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Copyable text={info.seed}>
-                        <code>{info.seed}</code>
-                    </Copyable>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Transfer Amount (SOL)</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <SolBalance lamports={info.lamports} />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Allocated Data Size</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">{info.space} byte(s)</BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Assigned Program Id</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.owner} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const CreateWithSeedDetailsCard = defineInstructionCard<CreateAccountWithSeedInfo>({
+    fields: info => [
+        address('From Address', info.source),
+        address('New Address', info.newAccount),
+        address('Base Address', info.base),
+        seed('Seed', info.seed),
+        sol('Transfer Amount (SOL)', info.lamports),
+        bytes('Allocated Data Size', info.space),
+        address('Assigned Program Id', info.owner),
+    ],
+    title: 'System Program: Create Account w/ Seed',
+});

--- a/app/components/instruction/system/NonceAdvanceDetailsCard.tsx
+++ b/app/components/instruction/system/NonceAdvanceDetailsCard.tsx
@@ -1,51 +1,11 @@
-import { Address } from '@components/common/Address';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { AdvanceNonceInfo } from './types';
 
-export function NonceAdvanceDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: AdvanceNonceInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Advance Nonce"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Nonce Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Authority Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const NonceAdvanceDetailsCard = defineInstructionCard<AdvanceNonceInfo>({
+    fields: info => [
+        address('Nonce Address', info.nonceAccount),
+        address('Authority Address', info.nonceAuthority),
+    ],
+    title: 'System Program: Advance Nonce',
+});

--- a/app/components/instruction/system/NonceAuthorizeDetailsCard.tsx
+++ b/app/components/instruction/system/NonceAuthorizeDetailsCard.tsx
@@ -1,58 +1,12 @@
-import { Address } from '@components/common/Address';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { AuthorizeNonceInfo } from './types';
 
-export function NonceAuthorizeDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: AuthorizeNonceInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Authorize Nonce"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Nonce Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Old Authority Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>New Authority Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.newAuthorized} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const NonceAuthorizeDetailsCard = defineInstructionCard<AuthorizeNonceInfo>({
+    fields: info => [
+        address('Nonce Address', info.nonceAccount),
+        address('Old Authority Address', info.nonceAuthority),
+        address('New Authority Address', info.newAuthorized),
+    ],
+    title: 'System Program: Authorize Nonce',
+});

--- a/app/components/instruction/system/NonceInitializeDetailsCard.tsx
+++ b/app/components/instruction/system/NonceInitializeDetailsCard.tsx
@@ -1,51 +1,11 @@
-import { Address } from '@components/common/Address';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { InitializeNonceInfo } from './types';
 
-export function NonceInitializeDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: InitializeNonceInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Initialize Nonce"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Nonce Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Authority Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const NonceInitializeDetailsCard = defineInstructionCard<InitializeNonceInfo>({
+    fields: info => [
+        address('Nonce Address', info.nonceAccount),
+        address('Authority Address', info.nonceAuthority),
+    ],
+    title: 'System Program: Initialize Nonce',
+});

--- a/app/components/instruction/system/NonceWithdrawDetailsCard.tsx
+++ b/app/components/instruction/system/NonceWithdrawDetailsCard.tsx
@@ -1,66 +1,13 @@
-import { Address } from '@components/common/Address';
-import { SolBalance } from '@components/common/SolBalance';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard, sol } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { WithdrawNonceInfo } from './types';
 
-export function NonceWithdrawDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: WithdrawNonceInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Withdraw Nonce"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Nonce Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Authority Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>To Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.destination} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Withdraw Amount (SOL)</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <SolBalance lamports={info.lamports} />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const NonceWithdrawDetailsCard = defineInstructionCard<WithdrawNonceInfo>({
+    fields: info => [
+        address('Nonce Address', info.nonceAccount),
+        address('Authority Address', info.nonceAuthority),
+        address('To Address', info.destination),
+        sol('Withdraw Amount (SOL)', info.lamports),
+    ],
+    title: 'System Program: Withdraw Nonce',
+});

--- a/app/components/instruction/system/SystemDetailsCard.tsx
+++ b/app/components/instruction/system/SystemDetailsCard.tsx
@@ -1,3 +1,4 @@
+import type { InstructionNode } from '@entities/instruction-card';
 import { ParsedInstruction, ParsedTransaction, SignatureResult, TransactionInstruction } from '@solana/web3.js';
 import { ParsedInfo } from '@validators/index';
 import React from 'react';
@@ -47,60 +48,71 @@ type DetailsProps = {
 };
 
 export function SystemDetailsCard(props: DetailsProps) {
+    // Transitional. Every System card now takes a single `node`, but the two
+    // `InstructionsSection`s still hand this component the old prop spread. This
+    // shim disappears once they build the node tree themselves.
+    const node: InstructionNode = {
+        childIndex: props.childIndex,
+        index: props.index,
+        innerCards: props.innerCards,
+        ix: props.ix,
+        raw: props.raw,
+    };
+
     try {
         const parsed = create(props.ix.parsed, ParsedInfo);
         switch (parsed.type) {
             case 'createAccount': {
                 const info = create(parsed.info, CreateAccountInfo);
-                return <CreateDetailsCard info={info} {...props} />;
+                return <CreateDetailsCard info={info} node={node} />;
             }
             case 'createAccountWithSeed': {
                 const info = create(parsed.info, CreateAccountWithSeedInfo);
-                return <CreateWithSeedDetailsCard info={info} {...props} />;
+                return <CreateWithSeedDetailsCard info={info} node={node} />;
             }
             case 'allocate': {
                 const info = create(parsed.info, AllocateInfo);
-                return <AllocateDetailsCard info={info} {...props} />;
+                return <AllocateDetailsCard info={info} node={node} />;
             }
             case 'allocateWithSeed': {
                 const info = create(parsed.info, AllocateWithSeedInfo);
-                return <AllocateWithSeedDetailsCard info={info} {...props} />;
+                return <AllocateWithSeedDetailsCard info={info} node={node} />;
             }
             case 'assign': {
                 const info = create(parsed.info, AssignInfo);
-                return <AssignDetailsCard info={info} {...props} />;
+                return <AssignDetailsCard info={info} node={node} />;
             }
             case 'assignWithSeed': {
                 const info = create(parsed.info, AssignWithSeedInfo);
-                return <AssignWithSeedDetailsCard info={info} {...props} />;
+                return <AssignWithSeedDetailsCard info={info} node={node} />;
             }
             case 'transfer': {
                 const info = create(parsed.info, TransferInfo);
-                return <TransferDetailsCard info={info} {...props} />;
+                return <TransferDetailsCard info={info} node={node} />;
             }
             case 'advanceNonce': {
                 const info = create(parsed.info, AdvanceNonceInfo);
-                return <NonceAdvanceDetailsCard info={info} {...props} />;
+                return <NonceAdvanceDetailsCard info={info} node={node} />;
             }
             case 'withdrawNonce': {
                 const info = create(parsed.info, WithdrawNonceInfo);
-                return <NonceWithdrawDetailsCard info={info} {...props} />;
+                return <NonceWithdrawDetailsCard info={info} node={node} />;
             }
             case 'authorizeNonce': {
                 const info = create(parsed.info, AuthorizeNonceInfo);
-                return <NonceAuthorizeDetailsCard info={info} {...props} />;
+                return <NonceAuthorizeDetailsCard info={info} node={node} />;
             }
             case 'initializeNonce': {
                 const info = create(parsed.info, InitializeNonceInfo);
-                return <NonceInitializeDetailsCard info={info} {...props} />;
+                return <NonceInitializeDetailsCard info={info} node={node} />;
             }
             case 'transferWithSeed': {
                 const info = create(parsed.info, TransferWithSeedInfo);
-                return <TransferWithSeedDetailsCard info={info} {...props} />;
+                return <TransferWithSeedDetailsCard info={info} node={node} />;
             }
             case 'upgradeNonce': {
                 const info = create(parsed.info, UpgradeNonceInfo);
-                return <UpgradeNonceDetailsCard info={info} {...props} />;
+                return <UpgradeNonceDetailsCard info={info} node={node} />;
             }
             default:
                 return <UnknownDetailsCard {...props} />;

--- a/app/components/instruction/system/TransferDetailsCard.tsx
+++ b/app/components/instruction/system/TransferDetailsCard.tsx
@@ -1,59 +1,12 @@
-import { Address } from '@components/common/Address';
-import { SolBalance } from '@components/common/SolBalance';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard, sol } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { TransferInfo } from './types';
 
-export function TransferDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: TransferInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Transfer"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>From Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.source} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>To Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.destination} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Transfer Amount (SOL)</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <SolBalance lamports={info.lamports} />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const TransferDetailsCard = defineInstructionCard<TransferInfo>({
+    fields: info => [
+        address('From Address', info.source),
+        address('To Address', info.destination),
+        sol('Transfer Amount (SOL)', info.lamports),
+    ],
+    title: 'System Program: Transfer',
+});

--- a/app/components/instruction/system/TransferWithSeedDetailsCard.tsx
+++ b/app/components/instruction/system/TransferWithSeedDetailsCard.tsx
@@ -1,83 +1,15 @@
-import { Address } from '@components/common/Address';
-import { Copyable } from '@components/common/Copyable';
-import { SolBalance } from '@components/common/SolBalance';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard, seed, sol } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { TransferWithSeedInfo } from './types';
 
-export function TransferWithSeedDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: TransferWithSeedInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Transfer w/ Seed"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>From Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.source} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Destination Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.destination} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Base Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.sourceBase} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Transfer Amount (SOL)</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <SolBalance lamports={info.lamports} />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Seed</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Copyable text={info.sourceSeed}>
-                        <code>{info.sourceSeed}</code>
-                    </Copyable>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Source Owner</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.sourceOwner} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const TransferWithSeedDetailsCard = defineInstructionCard<TransferWithSeedInfo>({
+    fields: info => [
+        address('From Address', info.source),
+        address('Destination Address', info.destination),
+        address('Base Address', info.sourceBase),
+        sol('Transfer Amount (SOL)', info.lamports),
+        seed('Seed', info.sourceSeed),
+        address('Source Owner', info.sourceOwner),
+    ],
+    title: 'System Program: Transfer w/ Seed',
+});

--- a/app/components/instruction/system/UpgradeNonceDetailsCard.tsx
+++ b/app/components/instruction/system/UpgradeNonceDetailsCard.tsx
@@ -1,44 +1,8 @@
-import { Address } from '@components/common/Address';
-import { ParsedInstruction, SignatureResult, SystemProgram } from '@solana/web3.js';
-import React from 'react';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import { InstructionCard } from '../InstructionCard';
 import { UpgradeNonceInfo } from './types';
 
-export function UpgradeNonceDetailsCard(props: {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    info: UpgradeNonceInfo;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-}) {
-    const { ix, index, result, info, innerCards, childIndex } = props;
-
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="System Program: Upgrade Nonce"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={SystemProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-
-            <BaseTable.Row>
-                <BaseTable.Cell>Nonce Address</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.nonceAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const UpgradeNonceDetailsCard = defineInstructionCard<UpgradeNonceInfo>({
+    fields: info => [address('Nonce Address', info.nonceAccount)],
+    title: 'System Program: Upgrade Nonce',
+});

--- a/app/entities/instruction-card/index.ts
+++ b/app/entities/instruction-card/index.ts
@@ -1,1 +1,11 @@
+export { defineInstructionCard } from './model/define-instruction-card';
+export type { InstructionCardProps, InstructionCardSpec } from './model/define-instruction-card';
+export { address, bytes, compactFields, custom, seed, sol, text } from './model/fields';
+export type { InstructionField, InstructionFieldList } from './model/fields';
+export type { InstructionNode } from './model/node';
+export { InstructionSurfaceProvider, useInstructionSurface } from './model/surface';
+export type { InstructionAddressProps, InstructionShellProps, InstructionSurface } from './model/surface';
+export { InstructionCardView } from './ui/InstructionCardView';
+export { InstructionFields } from './ui/InstructionFields';
 export { ProgramField } from './ui/ProgramField';
+export { TxInstructionSurface } from './ui/TxInstructionSurface';

--- a/app/entities/instruction-card/model/define-instruction-card.tsx
+++ b/app/entities/instruction-card/model/define-instruction-card.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { InstructionCardView } from '../ui/InstructionCardView';
+import { InstructionFields } from '../ui/InstructionFields';
+import type { InstructionFieldList } from './fields';
+import type { InstructionNode } from './node';
+
+export type InstructionCardProps<I> = { node: InstructionNode; info: I };
+
+export type InstructionCardSpec<I> = {
+    /** A function when the title depends on the decoded payload. */
+    title: string | ((info: I) => string);
+    fields: (info: I) => InstructionFieldList;
+    /** Open the card in raw mode, as `UnknownDetailsCard` does. */
+    defaultRaw?: boolean;
+};
+
+/**
+ * Builds a card from a declaration of what it shows.
+ *
+ * A card that needs real markup skips this and renders `InstructionCardView`
+ * directly with its own children — the factory is a shorthand for the common
+ * label/value shape, not a required abstraction.
+ */
+export function defineInstructionCard<I>(spec: InstructionCardSpec<I>): React.FC<InstructionCardProps<I>> {
+    function Card({ node, info }: InstructionCardProps<I>) {
+        const title = typeof spec.title === 'function' ? spec.title(info) : spec.title;
+
+        return (
+            <InstructionCardView node={node} title={title} defaultRaw={spec.defaultRaw}>
+                <InstructionFields fields={spec.fields(info)} programId={node.ix.programId} />
+            </InstructionCardView>
+        );
+    }
+
+    Card.displayName = `InstructionCard(${typeof spec.title === 'string' ? spec.title : 'dynamic'})`;
+    return Card;
+}

--- a/app/entities/instruction-card/model/fields.ts
+++ b/app/entities/instruction-card/model/fields.ts
@@ -1,0 +1,58 @@
+import type { PublicKey } from '@solana/web3.js';
+import type { ReactNode } from 'react';
+
+/**
+ * A row in an instruction card, described as data.
+ *
+ * Cards declare *what* a field means; `InstructionFields` decides how to draw
+ * it. That split is what lets the inspector swap the address renderer without
+ * every card taking an `AddressComponent` prop.
+ */
+export type InstructionField =
+    | { kind: 'address'; label: string; pubkey: PublicKey }
+    | { kind: 'sol'; label: string; lamports: number | bigint }
+    | { kind: 'bytes'; label: string; size: number }
+    | { kind: 'seed'; label: string; seed: string }
+    | { kind: 'text'; label: string; value: string | number }
+    | { kind: 'custom'; label: string; value: ReactNode };
+
+/** Falsy entries are dropped, so optional fields read as `cond && address(...)`. */
+export type InstructionFieldList = ReadonlyArray<InstructionField | false | undefined | null>;
+
+/** An account address. Links out on the tx page, resolves in-transaction in the inspector. */
+export function address(label: string, pubkey: PublicKey): InstructionField {
+    return { kind: 'address', label, pubkey };
+}
+
+/** A lamport amount, rendered as SOL. */
+export function sol(label: string, lamports: number | bigint): InstructionField {
+    return { kind: 'sol', label, lamports };
+}
+
+/** An account data size, rendered as `N byte(s)`. */
+export function bytes(label: string, size: number): InstructionField {
+    return { kind: 'bytes', label, size };
+}
+
+/** A PDA derivation seed, rendered as copyable code. */
+export function seed(label: string, value: string): InstructionField {
+    return { kind: 'seed', label, seed: value };
+}
+
+/** Plain text or a number. Deliberately not `ReactNode` — use `custom` for markup. */
+export function text(label: string, value: string | number): InstructionField {
+    return { kind: 'text', label, value };
+}
+
+/**
+ * Escape hatch for fields the vocabulary above does not cover — token amounts
+ * needing mint decimals, nested structs, bespoke widgets. Prefer a new `kind`
+ * once a shape repeats across programs.
+ */
+export function custom(label: string, value: ReactNode): InstructionField {
+    return { kind: 'custom', label, value };
+}
+
+export function compactFields(fields: InstructionFieldList): InstructionField[] {
+    return fields.filter((field): field is InstructionField => Boolean(field));
+}

--- a/app/entities/instruction-card/model/node.ts
+++ b/app/entities/instruction-card/model/node.ts
@@ -1,0 +1,30 @@
+import type { ParsedInstruction, TransactionInstruction } from '@solana/web3.js';
+
+/**
+ * Everything a card needs to know about *which* instruction it renders.
+ *
+ * Cards take a single `node` instead of the previous prop spread
+ * (`ix` + `index` + `childIndex` + `raw` + `innerCards`). Surface-level
+ * concerns — `result`, `signature`, the shell, the address renderer — live in
+ * `InstructionSurface` and never travel as props.
+ */
+export type InstructionNode = {
+    ix: ParsedInstruction | TransactionInstruction;
+    index: number;
+    childIndex?: number;
+    /** Raw form, when the card was reached through the RPC-parsed path. */
+    raw?: TransactionInstruction;
+    /**
+     * CPI children. Not yet populated — `InstructionsSection` still builds
+     * inner cards eagerly and hands them over as `innerCards` below. Once tree
+     * construction moves out of the render pass, the view walks this and
+     * `innerCards` goes away.
+     */
+    children?: InstructionNode[];
+    /**
+     * @deprecated Transitional. Pre-rendered inner cards from the legacy
+     * pipeline. The card never reads this — only the view passes it to the
+     * shell. Delete together with the eager building in `InstructionsSection`.
+     */
+    innerCards?: JSX.Element[];
+};

--- a/app/entities/instruction-card/model/surface.tsx
+++ b/app/entities/instruction-card/model/surface.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { ParsedInstruction, PublicKey, SignatureResult, TransactionInstruction } from '@solana/web3.js';
+import React, { createContext, useContext } from 'react';
+
+/** The subset of shell props every instruction shell accepts. */
+export type InstructionShellProps = {
+    title: string;
+    children?: React.ReactNode;
+    result: SignatureResult;
+    index: number;
+    ix: TransactionInstruction | ParsedInstruction;
+    defaultRaw?: boolean;
+    innerCards?: JSX.Element[];
+    childIndex?: number;
+    raw?: TransactionInstruction;
+};
+
+export type InstructionAddressProps = { pubkey: PublicKey };
+
+/**
+ * Where the cards are being rendered. There are two surfaces — the transaction
+ * page and the inspector — and they differ only in chrome, not in meaning.
+ *
+ * This replaces the per-card injection props (`InstructionCardComponent`,
+ * `AddressComponent`, `showProgramField`) and the `INSPECTOR_RESULT` placeholder
+ * the inspector passed to satisfy card signatures.
+ */
+export type InstructionSurface = {
+    /** Card frame: index badge, Raw toggle, scroll anchor, nesting slot. */
+    Shell: React.ComponentType<InstructionShellProps>;
+    /** How an account address renders on this surface. */
+    Address: React.ComponentType<InstructionAddressProps>;
+    /**
+     * Whether the field renderer emits the leading `Program` row.
+     * False in the inspector, whose shell already renders one itself.
+     */
+    showProgramField: boolean;
+    /** Per-transaction, so it belongs here rather than on every card. */
+    result: SignatureResult;
+};
+
+const InstructionSurfaceContext = createContext<InstructionSurface | undefined>(undefined);
+
+export function InstructionSurfaceProvider({
+    surface,
+    children,
+}: {
+    surface: InstructionSurface;
+    children: React.ReactNode;
+}) {
+    return <InstructionSurfaceContext.Provider value={surface}>{children}</InstructionSurfaceContext.Provider>;
+}
+
+export function useInstructionSurface(): InstructionSurface {
+    const surface = useContext(InstructionSurfaceContext);
+    if (!surface) {
+        throw new Error('useInstructionSurface must be used inside an <InstructionSurfaceProvider>');
+    }
+    return surface;
+}

--- a/app/entities/instruction-card/ui/InstructionCardView.tsx
+++ b/app/entities/instruction-card/ui/InstructionCardView.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import type { InstructionNode } from '../model/node';
+import { useInstructionSurface } from '../model/surface';
+
+/**
+ * Draws one instruction card on whatever surface it finds itself on.
+ *
+ * Cards below this point never see the shell, the signature result, or the
+ * nested cards — they only describe their own content.
+ */
+export function InstructionCardView({
+    node,
+    title,
+    defaultRaw,
+    children,
+}: {
+    node: InstructionNode;
+    title: string;
+    defaultRaw?: boolean;
+    children: React.ReactNode;
+}) {
+    const { Shell, result } = useInstructionSurface();
+
+    return (
+        <Shell
+            title={title}
+            ix={node.ix}
+            index={node.index}
+            childIndex={node.childIndex}
+            raw={node.raw}
+            result={result}
+            defaultRaw={defaultRaw}
+            innerCards={node.innerCards}
+        >
+            {children}
+        </Shell>
+    );
+}

--- a/app/entities/instruction-card/ui/InstructionFields.tsx
+++ b/app/entities/instruction-card/ui/InstructionFields.tsx
@@ -1,0 +1,50 @@
+import { Copyable } from '@components/common/Copyable';
+import { SolBalance } from '@components/common/SolBalance';
+import type { PublicKey } from '@solana/web3.js';
+import React from 'react';
+
+import { BaseTable } from '@/app/shared/ui/Table';
+
+import { compactFields, type InstructionField, type InstructionFieldList } from '../model/fields';
+import { useInstructionSurface } from '../model/surface';
+import { ProgramField } from './ProgramField';
+
+/**
+ * Renders field descriptors as card rows. This is the only place that knows the
+ * row markup, the right-alignment, and which address renderer the current
+ * surface uses.
+ */
+export function InstructionFields({ fields, programId }: { fields: InstructionFieldList; programId: PublicKey }) {
+    const { showProgramField } = useInstructionSurface();
+
+    return (
+        <>
+            {showProgramField && <ProgramField programId={programId} />}
+            {compactFields(fields).map((field, i) => (
+                <FieldRow key={`${field.label}-${i}`} field={field} />
+            ))}
+        </>
+    );
+}
+
+function FieldRow({ field }: { field: InstructionField }) {
+    const { Address } = useInstructionSurface();
+
+    return (
+        <BaseTable.Row>
+            <BaseTable.Cell>{field.label}</BaseTable.Cell>
+            <BaseTable.Cell className="text-right">
+                {field.kind === 'address' && <Address pubkey={field.pubkey} />}
+                {field.kind === 'sol' && <SolBalance lamports={field.lamports} />}
+                {field.kind === 'bytes' && `${field.size} byte(s)`}
+                {field.kind === 'seed' && (
+                    <Copyable text={field.seed}>
+                        <code>{field.seed}</code>
+                    </Copyable>
+                )}
+                {field.kind === 'text' && field.value}
+                {field.kind === 'custom' && field.value}
+            </BaseTable.Cell>
+        </BaseTable.Row>
+    );
+}

--- a/app/entities/instruction-card/ui/TxInstructionSurface.tsx
+++ b/app/entities/instruction-card/ui/TxInstructionSurface.tsx
@@ -1,0 +1,40 @@
+import { Address } from '@components/common/Address';
+import { InstructionCard } from '@components/instruction/InstructionCard';
+import type { SignatureResult } from '@solana/web3.js';
+import React from 'react';
+
+import type { InstructionAddressProps, InstructionSurface } from '../model/surface';
+import { InstructionSurfaceProvider } from '../model/surface';
+
+/** On the transaction page an address links out to its own account page. */
+const TxAddress = ({ pubkey }: InstructionAddressProps) => <Address pubkey={pubkey} alignRight link />;
+
+/**
+ * Declares how instruction cards render on the transaction page.
+ *
+ * Lives here rather than in the transaction feature so tests that render a card
+ * in isolation can pick a surface without reaching across layers. The inspector
+ * declares its own surface next to its `InstructionsSection`, because
+ * `InspectorInstructionCard` imports this entity's barrel and moving it here
+ * would close an import cycle.
+ */
+export function TxInstructionSurface({
+    result,
+    children,
+}: {
+    result: SignatureResult;
+    children: React.ReactNode;
+}) {
+    const surface = React.useMemo<InstructionSurface>(
+        () => ({
+            Address: TxAddress,
+            Shell: InstructionCard,
+            result,
+            // The tx-page shell renders no Program row of its own, so the fields do.
+            showProgramField: true,
+        }),
+        [result],
+    );
+
+    return <InstructionSurfaceProvider surface={surface}>{children}</InstructionSurfaceProvider>;
+}

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -23,6 +23,7 @@ import { UnknownDetailsCard } from '@components/instruction/UnknownDetailsCard';
 import { isWormholeInstruction } from '@components/instruction/wormhole/types';
 import { WormholeDetailsCard } from '@components/instruction/WormholeDetailsCard';
 import { ZkElGamalProofDetailsCard } from '@components/instruction/ZkElGamalProofDetailsCard';
+import { TxInstructionSurface } from '@entities/instruction-card';
 import { isParsedInstruction, useInstructionParser } from '@entities/instruction-parser';
 import { isZkElGamalProofInstruction } from '@entities/zk-elgamal-proof';
 import { getMangoInstructionLabel, isMangoInstruction } from '@explorer/decoder-mango/detection';
@@ -119,40 +120,42 @@ export function InstructionsSection({ signature }: SignatureProps) {
 
     return (
         <CollapsibleSection id="programs" title="Programs" className="">
-            <React.Suspense fallback={<LoadingCard message="Loading Instructions" />}>
-                {transaction.message.instructions.map((instruction, index) => {
-                    const innerCards: JSX.Element[] = [];
+            <TxInstructionSurface result={result}>
+                <React.Suspense fallback={<LoadingCard message="Loading Instructions" />}>
+                    {transaction.message.instructions.map((instruction, index) => {
+                        const innerCards: JSX.Element[] = [];
 
-                    if (index in innerInstructions) {
-                        innerInstructions[index].forEach((ix, childIndex) => {
-                            const res = (
-                                <InstructionCard
-                                    key={`${index}-${childIndex}`}
-                                    index={index}
-                                    ix={ix}
-                                    result={result}
-                                    signature={signature}
-                                    tx={transaction}
-                                    childIndex={childIndex}
-                                />
-                            );
-                            innerCards.push(res);
-                        });
-                    }
+                        if (index in innerInstructions) {
+                            innerInstructions[index].forEach((ix, childIndex) => {
+                                const res = (
+                                    <InstructionCard
+                                        key={`${index}-${childIndex}`}
+                                        index={index}
+                                        ix={ix}
+                                        result={result}
+                                        signature={signature}
+                                        tx={transaction}
+                                        childIndex={childIndex}
+                                    />
+                                );
+                                innerCards.push(res);
+                            });
+                        }
 
-                    return (
-                        <InstructionCard
-                            key={`${index}`}
-                            index={index}
-                            ix={instruction}
-                            result={result}
-                            signature={signature}
-                            tx={transaction}
-                            innerCards={innerCards}
-                        />
-                    );
-                })}
-            </React.Suspense>
+                        return (
+                            <InstructionCard
+                                key={`${index}`}
+                                index={index}
+                                ix={instruction}
+                                result={result}
+                                signature={signature}
+                                tx={transaction}
+                                innerCards={innerCards}
+                            />
+                        );
+                    })}
+                </React.Suspense>
+            </TxInstructionSurface>
         </CollapsibleSection>
     );
 }

--- a/openspec/changes/unify-instruction-card-rendering/proposal.md
+++ b/openspec/changes/unify-instruction-card-rendering/proposal.md
@@ -1,0 +1,53 @@
+# Proposal: Unify instruction card rendering across the tx page and inspector
+
+## Context
+
+- About 78 `*DetailsCard` components render instructions on two surfaces: `/tx/[signature]` and the inspector. 71 of them draw a card frame.
+- Surface chrome leaks into the cards as props. `InstructionCardComponent` swaps the frame in 7 files. `AssociatedTokenDetailsCard` also takes `AddressComponent` and `showProgramField`. `innerCards: JSX.Element[]` is built eagerly in `InstructionsSection` and threaded through four layers to reach `BaseInstructionCard`, so every card in between declares a prop it never reads. The inspector invents `INSPECTOR_RESULT` and `INSPECTOR_SIGNATURE` purely to satisfy card signatures.
+- Row markup is copied per field. The 13 System cards were 815 lines, almost all of it `<BaseTable.Row><Cell>label</Cell><Cell className="text-right">…</Cell></BaseTable.Row>` repeated.
+- `unify-instruction-parsing` named this work as an explicit out-of-scope follow-up: "collapsing the two per-surface card switches into one render pipeline."
+- That change is also what makes the leak observable for System. The inspector reaches System cards only because it landed the System slice and the shared dispatcher — `inspector/InstructionsSection.tsx:130` calls `dispatcher.fromTransactionInstruction(ix)` and `:213` routes `program === 'system'` to `SystemDetailsCard`. Before it, the inspector's own `into-parsed-data.ts` fed a separate path. System is therefore a program where one card component must already satisfy two surfaces, while still hardcoding the tx-page frame for both.
+
+## Why
+
+A card should describe what an instruction means. It should not know which page it is on. Today those two responsibilities share one prop bag, so every new surface concern becomes a new prop on every card, and every field becomes eight lines of table markup.
+
+Making chrome ambient (React Context) and fields declarative (data) separates them. Cards shrink to their actual content, and the surfaces stop needing to agree by convention.
+
+### Alternatives considered
+
+- **One `InstructionCard` with a `mode` flag.** Rejected — merges both surfaces' chrome into a conditional. Same coupling, different shape.
+- **Keep component injection, just formalise the prop names.** Rejected — the prop count grows with every surface concern, and it is already three (`InstructionCardComponent`, `AddressComponent`, `showProgramField`) for one card.
+- **Migrate all 71 cards in this change.** Rejected as unreviewable. 15 are inspector-reachable and carry real chrome deltas that need eyes; the other 56 are mechanical.
+- **Start with a tx-page-only program (Stake or Vote, 14 cards each).** Rejected. Zero behaviour risk, but it never exercises the second surface, so the design would land unproven on the only axis that motivates it. System is the one program that is large, inspector-reachable, *and* hardcodes its frame — and it already has field-by-field tests on both surfaces (`SystemDetailsCard.spec.tsx`, `InspectorPage-SystemProgram.spec.tsx`) that pin the migration.
+- **Make the field DSL mandatory.** Rejected — token amounts need mint decimals from a hook, and Pyth and Anchor cards need real markup. Cards opt out by rendering `InstructionCardView` with their own children, or by using `custom()` for one field.
+- **Build the instruction node tree in this change.** Deferred. It is independent of the surface split and would roughly double the diff.
+- **Put both surfaces in the entity.** Rejected for the inspector only — `InspectorInstructionCard` imports this entity's barrel, so moving its surface there closes an import cycle. The tx surface has no such edge and lives in the entity, which also lets card tests pick a surface without reaching across layers.
+
+## What Changes
+
+- Add to `app/entities/instruction-card/`:
+  - `model/surface.tsx` — `InstructionSurface` (frame, address renderer, `showProgramField`, `result`) delivered by Context. `useInstructionSurface` throws outside a provider, matching `useInstructionParser`.
+  - `model/node.ts` — `InstructionNode`, one object replacing the `ix` + `index` + `childIndex` + `raw` + `innerCards` spread.
+  - `model/fields.ts` — `address`, `sol`, `bytes`, `seed`, `text`, `custom`. `text` takes `string | number`; `custom` is the only `ReactNode` door, so the descriptors stay data.
+  - `ui/InstructionFields.tsx` — the only place that knows row markup, alignment, and which address renderer the surface uses.
+  - `ui/InstructionCardView.tsx` — resolves the frame from the surface. The escape hatch for cards that need their own markup.
+  - `model/define-instruction-card.tsx` — shorthand factory for the common label/value shape.
+  - `ui/TxInstructionSurface.tsx` — the transaction page surface.
+- The inspector declares `INSPECTOR_SURFACE` beside its own `InstructionsSection`, and `INSPECTOR_SIGNATURE` is deleted.
+- Migrate all 13 System cards to `defineInstructionCard`. No file under `app/components/instruction/system/` imports `Address`, `BaseTable`, or `InstructionCard` any more.
+- `SystemDetailsCard` builds the node from the props the two `InstructionsSection`s still pass.
+
+**Out of scope**, tracked as follow-ups: populating `InstructionNode.children` and deleting the eager `innerCards` build; replacing the two per-surface routing switches with a `programId`-keyed registry; migrating the remaining 58 cards.
+
+## Impact
+
+- **Transaction page: no change.** Verified empirically — the rendered cell text, button set, wrapper elements, and `<code>` counts are identical to `HEAD` for the Transfer and TransferWithSeed fixtures. Every piece is the same component with the same props.
+- **Inspector: four chrome deltas on System cards**, because they previously used the *tx-page* frame on both surfaces. A collapse chevron now appears (`InspectorInstructionCard` does not pass `collapsible`, and `CollapsibleCard` defaults it to `true`); address rows gain `AddressWithContext`'s wrapper div (with `hideInfo`, so no extra content or account fetch); Raw mode gains the hex and accounts block, because `raw` is now forwarded; the Raw-mode Program row uses `AddressWithContext` with `programValidator`. Row labels, order, count, and the single Program row are unchanged. All four align System with what Token, Token-2022, and ATA already do in the inspector.
+- **Accepted debt.** `InstructionNode.innerCards` still carries pre-rendered elements and is marked deprecated; cards never read it, only the view passes it to the frame. `InstructionNode.children` exists as the documented target and is unpopulated. Both disappear with the tree follow-up.
+- **`InstructionNode.ix` is provisional.** It is typed `ParsedInstruction | TransactionInstruction` because the *frame* — not the card — branches on `'parsed' in ix` to choose `BaseRawParsedDetails` over `BaseRawDetails` for the Raw view, and reads `ix.programId`. When `unify-instruction-parsing`'s follow-up stops producing `ParsedInstruction`, this field has to split into roughly `programId` + `raw` + an optional RPC-parsed payload. That revision is confined to `InstructionNode` and `InstructionCardView`; no card is affected, because no card reads `node.ix`.
+- **Interaction with `unify-instruction-parsing`: this change shrinks its remaining work.** The System slice's canonical `SystemParsed` is built from the same superstruct types the cards take — `system-parser.ts` imports `TransferInfo`, `CreateAccountInfo`, and the rest from `@components/instruction/system/types`, and those resolve to web3.js `PublicKey` via `PublicKeyFromString`. So `defineInstructionCard<TransferInfo>` already consumes the slice's shape, and the `address(label, pubkey: PublicKey)` descriptor is correct after the compat wrap is deleted. Migrating System off the wrap therefore touches **one** file — `SystemDetailsCard` drops its two `create(...)` passes and switches on `sliceParsed.type` instead — rather than re-editing 815 lines of card JSX. Note this alignment exists because `system-parser.ts` imports a web3.js type, which the parser proposal's own rule forbids for slice internals; that pre-existing tension is what makes the two shapes identical today.
+- **Migration guidance for the remaining 58 cards.** 49 are tx-page-only and behaviour-neutral, because the tx surface's frame *is* `InstructionCard`. 7 already parameterise their frame, so migrating them only deletes a prop. 2 are inspector-reachable and hardcode the frame — BPF Upgradeable Loader and Lighthouse — and need the same chrome review as System. Migrate one whole program per PR: a partial program leaves two different frames side by side in the inspector.
+- **Line count.** System leaf cards 815 → 155.
+- **Verification.** `tsc --noEmit` clean; eslint clean including `boundaries/dependencies`; 304 spec files and 3342 tests pass unchanged; `next build` compiles. Parity was probed by rendering both surfaces against a `HEAD` worktree and diffing the resulting DOM structure.
+- **Spec delta** ships at `specs/instruction-card/spec.md`. It pins the four rules a future card migration must not break: chrome comes from the surface, fields are data, a card takes one node, and a program migrates whole.

--- a/openspec/changes/unify-instruction-card-rendering/specs/instruction-card/spec.md
+++ b/openspec/changes/unify-instruction-card-rendering/specs/instruction-card/spec.md
@@ -1,0 +1,78 @@
+# instruction-card
+
+## Purpose
+
+One rendering layer for instruction cards, shared by `/tx/[signature]` and `/tx/(inspector)/inspector`. A card declares what an instruction means; the surface it renders on owns the chrome. Adding a field is one descriptor; adding a surface is one Context value.
+
+## ADDED Requirements
+
+### Requirement: Surface-owned chrome
+
+Instruction cards MUST NOT receive surface chrome as props. The card frame, the address renderer, whether the leading `Program` row is emitted, and the transaction's `SignatureResult` SHALL be supplied by an `InstructionSurface` value through React Context.
+
+This replaces the `InstructionCardComponent`, `AddressComponent`, and `showProgramField` injection props, and the inspector's `INSPECTOR_RESULT` / `INSPECTOR_SIGNATURE` placeholder constants. `useInstructionSurface` fails loudly rather than falling back to a default, matching `useInstructionParser`.
+
+#### Scenario: Same card on both surfaces
+
+- **WHEN** the same instruction renders on the tx page and in the inspector
+- **THEN** the card component MUST be the same component in both cases
+- **AND** only the surface value MUST differ
+
+#### Scenario: Program row is claimed exactly once
+
+- **WHEN** a surface's frame already renders a `Program` row of its own
+- **THEN** that surface MUST set `showProgramField: false`
+- **AND** exactly one `Program` row MUST appear in the rendered card
+
+#### Scenario: Missing provider
+
+- **WHEN** a card renders outside an `InstructionSurfaceProvider`
+- **THEN** `useInstructionSurface` MUST throw
+
+### Requirement: Fields declared as data
+
+A card's rows SHALL be declared as `InstructionField` descriptors rather than as table markup. `InstructionFields` MUST be the only component that knows row markup, cell alignment, and which address renderer the current surface uses.
+
+The union is closed: `address`, `sol`, `bytes`, `seed`, `text`, `custom`. `text` MUST accept only `string | number`, and `custom` MUST be the sole `ReactNode` door, so descriptors stay inspectable data instead of becoming opaque markup.
+
+#### Scenario: Repeated shape earns its own kind
+
+- **WHEN** the same value rendering repeats across cards
+- **THEN** it MUST be added as an `InstructionField` kind
+- **AND** those cards MUST NOT each re-implement it through `custom`
+
+#### Scenario: Card needing real markup
+
+- **WHEN** a card's content does not fit the descriptor vocabulary
+- **THEN** it MAY render `InstructionCardView` with its own children instead
+- **AND** it MUST still take its chrome from the surface
+
+### Requirement: Single node prop
+
+A card SHALL receive the instruction it renders as one `InstructionNode`, not as a spread of `ix`, `index`, `childIndex`, `raw`, and `innerCards`. Nested cards MUST NOT travel through cards as props — only the view hands `InstructionNode.innerCards` to the frame, and no card reads it.
+
+`InstructionNode.children` is the target representation for CPI children and stays unpopulated until tree construction moves out of the render pass. `innerCards` is marked deprecated and is deleted in that same follow-up.
+
+`InstructionNode.ix` is provisional: it exists for the frame, which needs `programId` and branches on `'parsed' in ix` for the Raw view. Cards MUST NOT read `node.ix`, so the field can be reshaped when the instruction-parser compat wrap is deleted without touching any card.
+
+#### Scenario: Card is unaware of nesting
+
+- **WHEN** an instruction has inner instructions
+- **THEN** the card MUST NOT declare or read any nested-card prop
+- **AND** the nested cards MUST reach the frame through the view
+
+#### Scenario: Card reads only its decoded payload
+
+- **WHEN** a card needs the instruction's program or raw bytes
+- **THEN** it MUST obtain them from the frame or the surface, not from `node.ix`
+- **AND** the card's own inputs MUST be limited to its decoded `info`
+
+### Requirement: Whole-program migration
+
+A program's cards SHALL migrate to the surface together in one change, never partially. A partially migrated program renders two different frames side by side in the inspector, because unmigrated cards hardcode the tx-page frame regardless of surface.
+
+#### Scenario: Program with a hardcoded frame reaches the inspector
+
+- **WHEN** a program's cards hardcode `InstructionCard` and the inspector routes to that program
+- **THEN** all of that program's cards MUST migrate in the same change
+- **AND** the resulting inspector chrome deltas MUST be reviewed before merge


### PR DESCRIPTION
Follow-up to `unify-instruction-parsing`, which named this explicitly as out of scope: *"collapsing the two per-surface card switches into one render pipeline."*

## Problem

Instruction cards took their surface chrome as props:

- `InstructionCardComponent` swaps the card frame in 7 files
- `AssociatedTokenDetailsCard` also takes `AddressComponent` and `showProgramField`
- `innerCards: JSX.Element[]` is built eagerly in `InstructionsSection` and threaded through four layers to reach `BaseInstructionCard`, so every card in between declares a prop it never reads
- the inspector invents `INSPECTOR_RESULT` and `INSPECTOR_SIGNATURE` purely to satisfy card signatures

And row markup is copied per field — the 13 System cards were 815 lines, almost all of it repeated `<BaseTable.Row><Cell>label</Cell><Cell className="text-right">…</Cell></BaseTable.Row>`.

## Change

A new `instruction-card` entity supplies chrome ambiently and lets cards declare rows as data.

```tsx
export const TransferDetailsCard = defineInstructionCard<TransferInfo>({
    fields: info => [
        address('From Address', info.source),
        address('To Address', info.destination),
        sol('Transfer Amount (SOL)', info.lamports),
    ],
    title: 'System Program: Transfer',
});
```

- **`InstructionSurface`** via Context — frame, address renderer, `showProgramField`, `result`. Throws outside a provider, matching `useInstructionParser`.
- **`InstructionNode`** — one prop replacing the `ix`/`index`/`childIndex`/`raw`/`innerCards` spread. Cards no longer see nested cards at all.
- **Field descriptors** — `address`, `sol`, `bytes`, `seed`, `text`, `custom`. `text` is `string | number`; `custom` is the only `ReactNode` door. `InstructionFields` is the only place that knows row markup.
- **`InstructionCardView`** — escape hatch for cards needing real markup. The DSL is never mandatory.

All 13 System cards migrated: **815 → 155 lines**. No file under `app/components/instruction/system/` imports `Address`, `BaseTable`, or `InstructionCard` any more.

## Behaviour

**Transaction page: byte-identical.** Verified by rendering both fixtures against a `HEAD` worktree and diffing the resulting DOM — cell text, button set, wrapper elements, and `<code>` counts all match.

**Inspector: four chrome deltas on System cards**, which previously used the *tx-page* frame on both surfaces:

| | Before | After |
|---|---|---|
| Row labels, order, count | — | identical |
| Program rows | 1 | 1 (no duplicate) |
| Collapse chevron | absent | present |
| Address wrapper div | — | `AddressWithContext`'s flex div (`hideInfo`, so no extra content or fetch) |
| Raw mode | parsed JSON only | + hex/accounts block; Program row uses `AddressWithContext` |

All four align System with what Token, Token-2022, and ATA already do in the inspector.

## Review focus

**Please click Raw on a System instruction in the inspector.** Every existing assertion runs in normal mode, so the Raw-mode deltas are the one thing the suite cannot confirm.

## Out of scope

Populating `InstructionNode.children` and deleting the eager `innerCards` build; replacing the two per-surface routing switches with a `programId`-keyed registry; the remaining 58 cards.

Migration guidance is in the proposal: of those 58, **49 are tx-page-only and behaviour-neutral**, 7 already parameterise their frame, and 2 are inspector-reachable with a hardcoded frame (BPF Upgradeable Loader, Lighthouse) and need the same chrome review. **Migrate one whole program per PR** — a partial program leaves two different frames side by side in the inspector.

Also documented: `InstructionNode.ix` is provisional, and this change shrinks the eventual `SliceParsed` migration for System to a single file, because `SystemParsed` is already built from the same superstruct types the cards take.

## Verification

- `tsc --noEmit` clean
- eslint clean, including `boundaries/dependencies`
- 304 spec files / 3342 tests pass, unchanged from baseline
- `next build` compiles
- `pnpm openspec:validate` → 10 passed

Rationale and spec delta: `openspec/changes/unify-instruction-card-rendering/`.
