### PR TITLE
feat: pmp decode data from args functionality [p1]

### DIFF
--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -2,6 +2,7 @@ import { BaseInstructionCard } from '@components/common/BaseInstructionCard';
 import { isParsedInstruction, toParsedTransaction, useInstructionParser } from '@entities/instruction-parser';
 import { AssociatedTokenDetailsCard } from '@features/decode-instruction-associated-token';
 import { LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
+import { isProgramMetadataInstruction, PmpDetailsCard } from '@features/decode-instruction-pmp';
 import { IdlInstructionCard, useIdlInstructionDecode } from '@features/decode-instruction-with-idl';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { useCluster } from '@providers/cluster';
@@ -124,6 +125,36 @@ function InspectorInstructionCard({
 
     // Dynamic IDL tier — shared with the tx page. See app/features/transaction/ui/InstructionsSection.tsx.
     const idlDecode = useIdlInstructionDecode({ programId: programId.toString(), raw: ix });
+
+    // PMP owns every instruction on its program id: `setData`/`initialize`/`write` render decoded content from
+    // the bundled typed decoders (no IDL needed), and the housekeeping instructions delegate to the IDL tier
+    // from inside the card. Must sit before the generic idlDecode tier so it wins for the content instructions.
+    if (isProgramMetadataInstruction(ix)) {
+        return (
+            <PmpDetailsCard
+                ix={ix}
+                index={index}
+                result={INSPECTOR_RESULT}
+                InstructionCardComponent={BaseInstructionCard}
+                // The card cannot import the IDL feature (boundaries/dependencies), so this surface decides what
+                // a non-content PMP instruction falls back to. Same two outcomes as before the branch existed.
+                fallback={
+                    idlDecode ? (
+                        <IdlInstructionCard
+                            decoded={idlDecode}
+                            ix={ix}
+                            index={index}
+                            result={INSPECTOR_RESULT}
+                            signature={INSPECTOR_SIGNATURE}
+                        />
+                    ) : (
+                        <UnknownDetailsCard index={index} ix={ix} programName={programName} />
+                    )
+                }
+            />
+        );
+    }
+
     if (idlDecode) {
         return (
             <IdlInstructionCard

--- a/app/components/inspector/__tests__/InstructionsSection-Pmp.spec.tsx
+++ b/app/components/inspector/__tests__/InstructionsSection-Pmp.spec.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { PMP_ADDRESS } from '@features/decode-instruction-pmp';
+import { Keypair, type MessageV0, PublicKey, TransactionInstruction, TransactionMessage } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getAllocateInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { InstructionParserProvider } from '@/app/entities/instruction-parser';
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { TransactionsProvider } from '@/app/providers/transactions';
+import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
+
+import { InstructionsSection } from '../InstructionsSection';
+
+// The IDL tiers (`useAnchorProgram`, `useProgramMetadataIdl`) read through SWR. Stub it to "no IDL" so the PMP
+// branch is exercised without a network-resolved IDL - which is exactly the case the p1 spec cares about.
+vi.mock('swr', () => ({
+    __esModule: true,
+    default: vi.fn(() => ({
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+    })),
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/'),
+    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('next/link', () => ({
+    __esModule: true,
+    default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+// The decoded-JSON viewer is a next/dynamic ssr:false import, so it resolves asynchronously and would make this
+// spec's assertions racy. Stub it, as MetadataCard.spec.tsx does. The decode path itself is still real.
+vi.mock('@/app/components/common/JsonViewer', () => ({
+    SolarizedJsonViewer: ({ src }: { src: unknown }) => (
+        <div data-testid="json-viewer">{JSON.stringify(src, null, 2)}</div>
+    ),
+}));
+
+function renderMessage(message: MessageV0) {
+    return render(
+        <ScrollAnchorProvider>
+            <ClusterProvider>
+                <TransactionsProvider>
+                    <AccountsProvider>
+                        <InstructionParserProvider dispatcher={instructionParserDispatcher}>
+                            <InstructionsSection message={message} />
+                        </InstructionParserProvider>
+                    </AccountsProvider>
+                </TransactionsProvider>
+            </ClusterProvider>
+        </ScrollAnchorProvider>,
+    );
+}
+
+function buildMessage(data: Uint8Array): MessageV0 {
+    const ix = new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: [
+            { isSigner: false, isWritable: true, pubkey: Keypair.generate().publicKey },
+            { isSigner: false, isWritable: false, pubkey: Keypair.generate().publicKey },
+        ],
+        programId: new PublicKey(PMP_ADDRESS),
+    });
+    return new TransactionMessage({
+        instructions: [ix],
+        payerKey: Keypair.generate().publicKey,
+        recentBlockhash: PublicKey.default.toBase58(),
+    }).compileToV0Message();
+}
+
+describe('Inspector InstructionsSection with a Program Metadata instruction', () => {
+    test('should decode and render an inline setData payload with no IDL resolved', async () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            data: new TextEncoder().encode('{"name":"company","version":"1.0.0"}'),
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        renderMessage(buildMessage(data));
+
+        expect(await screen.findByText(/ProgramMetadata: SetData/i)).toBeInTheDocument();
+
+        // The section opens on the Raw tab and Radix unmounts the inactive panel, so the decoded document is only
+        // in the DOM once the reader switches.
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(screen.getByTestId('json-viewer')).toHaveTextContent('company');
+    });
+
+    test('should leave a housekeeping instruction to the existing tiers', async () => {
+        const data = getAllocateInstructionDataEncoder().encode({ seed: 'idl' }) as Uint8Array;
+
+        renderMessage(buildMessage(data));
+
+        expect(await screen.findAllByText(/Program Metadata Program/i)).not.toHaveLength(0);
+        expect(screen.queryByTestId('pmp-payload-section')).not.toBeInTheDocument();
+    });
+});

--- a/app/components/instruction/codama/CodamaInstructionBody.tsx
+++ b/app/components/instruction/codama/CodamaInstructionBody.tsx
@@ -22,12 +22,19 @@ export function CodamaInstructionBody({
     programName,
     accounts,
     namedAccounts,
+    accountNames,
     data,
 }: {
     programId: PublicKey;
     programName: string;
     accounts: readonly AccountLike[];
     namedAccounts?: Record<string, AccountMeta<string>>;
+    /**
+     * FINAL positional row labels, rendered verbatim, for callers with no Codama parse to read names from (the
+     * PMP card decodes IDL-free). Takes precedence over `namedAccounts`, whose camelCase keys still go through
+     * `camelToTitleCase`. Verbatim rather than title-cased so a caller can match Codama's own capitalisation.
+     */
+    accountNames?: readonly string[];
     data?: Record<string, unknown>;
 }) {
     // Codama emits `namedAccounts` in instruction-account order, so the Nth
@@ -35,7 +42,9 @@ export function CodamaInstructionBody({
     // name-by-address map: two accounts can share the same address (e.g.
     // MemoryWrite's payer and sourceAccount), which would collapse in a map and
     // mislabel one of the rows.
-    const namedAccountNames = namedAccounts ? Object.keys(namedAccounts) : [];
+    const namedAccountNames = namedAccounts ? Object.keys(namedAccounts) : undefined;
+    // `accountNames` arrives pre-formatted, `namedAccounts` keys do not, so the two differ only in formatting.
+    const names = accountNames ?? namedAccountNames?.map(camelToTitleCase);
 
     return (
         <>
@@ -56,10 +65,10 @@ export function CodamaInstructionBody({
                     <BaseTable.Row key={keyIndex} data-testid={`account-row-${keyIndex}`}>
                         <BaseTable.Cell>
                             <div className="mr-1.5 md:inline">
-                                {namedAccounts
-                                    ? keyIndex < namedAccountNames.length
-                                        ? camelToTitleCase(namedAccountNames[keyIndex])
-                                        : `Remaining Account #${keyIndex + 1 - namedAccountNames.length}`
+                                {names
+                                    ? keyIndex < names.length
+                                        ? names[keyIndex]
+                                        : `Remaining Account #${keyIndex + 1 - names.length}`
                                     : `Account #${keyIndex + 1}`}
                             </div>
                             {isWritableRole(role) && (

--- a/app/features/decode-instruction-pmp/index.ts
+++ b/app/features/decode-instruction-pmp/index.ts
@@ -1,6 +1,13 @@
 export { PMP_ADDRESS } from './lib/constants';
+export { decodePmpBufferAccount } from './lib/decode-pmp-buffer-account';
 export { decodePmpContentInstruction } from './lib/decode-pmp-instruction';
 export { decodePmpPayload } from './lib/decode-pmp-payload';
 export { isProgramMetadataInstruction } from './lib/is-program-metadata-instruction';
-export type { PmpContentInstruction, PmpDecodeConfig, PmpDecodedPayload } from './lib/types';
+export type {
+    PmpAccountContent,
+    PmpAccountSnapshot,
+    PmpContentInstruction,
+    PmpDecodeConfig,
+    PmpDecodedPayload,
+} from './lib/types';
 export { PmpDetailsCard } from './ui/PmpDetailsCard';

--- a/app/features/decode-instruction-pmp/index.ts
+++ b/app/features/decode-instruction-pmp/index.ts
@@ -1,0 +1,6 @@
+export { PMP_ADDRESS } from './lib/constants';
+export { decodePmpContentInstruction } from './lib/decode-pmp-instruction';
+export { decodePmpPayload } from './lib/decode-pmp-payload';
+export { isProgramMetadataInstruction } from './lib/is-program-metadata-instruction';
+export type { PmpContentInstruction, PmpDecodeConfig, PmpDecodedPayload } from './lib/types';
+export { PmpDetailsCard } from './ui/PmpDetailsCard';

--- a/app/features/decode-instruction-pmp/lib/__tests__/analytics.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/analytics.spec.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { trackEvent } from '@/app/shared/lib/analytics';
+
+import { pmpAnalytics } from '../analytics';
+
+vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+describe('pmpAnalytics', () => {
+    beforeEach(() => {
+        vi.mocked(trackEvent).mockClear();
+    });
+
+    it('should emit pmp_data_tab_opened when the decoded tab is opened', () => {
+        pmpAnalytics.trackTabOpened({
+            dataSource: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            tab: 'decoded',
+        });
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', {
+            data_source: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            tab: 'decoded',
+        });
+    });
+
+    it('should emit pmp_data_tab_opened for a non-Direct data source', () => {
+        pmpAnalytics.trackTabOpened({ dataSource: 'url', format: 'json', instruction: 'initialize', tab: 'raw' });
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', {
+            data_source: 'url',
+            format: 'json',
+            instruction: 'initialize',
+            tab: 'raw',
+        });
+    });
+
+    it('should expose no decode-outcome event', () => {
+        // Pins the deliberate removal: whether a payload decodes is a property of the instruction's bytes, not of
+        // anything the reader did, so it is not tracked. Guards against the old event being reinstated by habit.
+        expect('trackDecodeCompleted' in pmpAnalytics).toBe(false);
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-buffer-account.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-buffer-account.spec.ts
@@ -1,0 +1,177 @@
+import type { Address } from '@solana/kit';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getBufferEncoder,
+    getMetadataEncoder,
+    packDirectData,
+} from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { concat } from '@/app/shared/lib/bytes';
+
+import { PMP_ADDRESS } from '../constants';
+import { decodePmpBufferAccount } from '../decode-pmp-buffer-account';
+import type { PmpDecodeConfig } from '../types';
+
+const PROGRAM = '4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw' as Address;
+const AUTHORITY = '2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8' as Address;
+
+const DOC = '{"name":"company","version":"1.0.0"}';
+const DOC_VALUE = { name: 'company', version: '1.0.0' };
+
+/** The instruction's hints. A Buffer account is decoded with these, a Metadata account with its own. */
+const IX_CONFIG: PmpDecodeConfig = { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json };
+
+/** The library's own producer, so every body below is a byte-exact round trip of what the client puts on chain. */
+function pack(content: string, compression: Compression): Uint8Array {
+    return packDirectData({ compression, content, encoding: Encoding.Utf8 }).data as Uint8Array;
+}
+
+/** Both encoders inject their own discriminator, so these fixtures carry the real 96-byte header. */
+function bufferAccount(body: Uint8Array): Uint8Array {
+    return getBufferEncoder().encode({
+        authority: AUTHORITY,
+        canonical: true,
+        data: body,
+        program: PROGRAM,
+        seed: 'idl',
+    }) as Uint8Array;
+}
+
+function metadataAccount({
+    body,
+    config = IX_CONFIG,
+    dataLength,
+}: {
+    body: Uint8Array;
+    config?: PmpDecodeConfig;
+    dataLength?: number;
+}): Uint8Array {
+    return getMetadataEncoder().encode({
+        authority: AUTHORITY,
+        canonical: true,
+        compression: config.compression,
+        data: body,
+        dataLength: dataLength ?? body.length,
+        dataSource: DataSource.Direct,
+        encoding: config.encoding,
+        format: config.format,
+        mutable: true,
+        program: PROGRAM,
+        seed: 'idl',
+    }) as Uint8Array;
+}
+
+function read(data: Uint8Array | undefined, overrides: { lamports?: number; owner?: string } = {}) {
+    return decodePmpBufferAccount({
+        account: { data, lamports: overrides.lamports ?? 1_000_000, owner: overrides.owner ?? PMP_ADDRESS },
+        config: IX_CONFIG,
+    });
+}
+
+describe('decodePmpBufferAccount', () => {
+    it('should decode a Buffer account body with the instruction hints', () => {
+        const result = read(bufferAccount(pack(DOC, Compression.None)));
+
+        expect(result).toEqual({
+            account: 'buffer',
+            body: expect.any(Uint8Array),
+            config: IX_CONFIG,
+            kind: 'payload',
+            payload: expect.objectContaining({ document: { kind: 'json', value: DOC_VALUE }, kind: 'decoded' }),
+        });
+    });
+
+    it('should decompress a Buffer account body when the instruction says it is compressed', () => {
+        const result = decodePmpBufferAccount({
+            account: { data: bufferAccount(pack(DOC, Compression.Zlib)), lamports: 1, owner: PMP_ADDRESS },
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+        });
+
+        expect(result.kind === 'payload' && result.payload).toMatchObject({
+            document: { kind: 'json', value: DOC_VALUE },
+            kind: 'decoded',
+        });
+    });
+
+    it('should decode a Metadata account with the account hints rather than the instruction hints', () => {
+        // The account is Zlib, the instruction claims None. Decoding with the instruction's hints would hand raw
+        // deflate bytes to the UTF-8 step, so a correct document proves the account's own header won.
+        const accountConfig = { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json };
+        const result = read(metadataAccount({ body: pack(DOC, Compression.Zlib), config: accountConfig }));
+
+        expect(result).toMatchObject({
+            account: 'metadata',
+            config: accountConfig,
+            kind: 'payload',
+            payload: { document: { kind: 'json', value: DOC_VALUE }, kind: 'decoded' },
+        });
+    });
+
+    it('should ignore the slack an untrimmed extend leaves past dataLength', () => {
+        const body = pack(DOC, Compression.None);
+        // `data` is a remainder field, so an account grown by `extend` and never trimmed hands back the padding
+        // too. Only `dataLength` bytes are the payload.
+        const result = read(metadataAccount({ body: concat([body, new Uint8Array(512)]), dataLength: body.length }));
+
+        expect(result.kind === 'payload' && result.body).toEqual(body);
+        expect(result.kind === 'payload' && result.payload).toMatchObject({
+            document: { kind: 'json', value: DOC_VALUE },
+            kind: 'decoded',
+        });
+    });
+
+    it('should report absent for the closed-account shape the provider hands back', () => {
+        expect(read(new Uint8Array(0), { lamports: 0 })).toEqual({ kind: 'absent' });
+        expect(read(undefined, { lamports: 0 })).toEqual({ kind: 'absent' });
+    });
+
+    it('should report unreadable when the account is not owned by the Program Metadata Program', () => {
+        const result = read(bufferAccount(pack(DOC, Compression.None)), { owner: PROGRAM });
+
+        expect(result).toEqual({ kind: 'unreadable', reason: expect.stringContaining(PROGRAM) });
+    });
+
+    it('should report unreadable when the account is shorter than the header', () => {
+        expect(read(new Uint8Array(95))).toEqual({ kind: 'unreadable', reason: expect.stringContaining('96-byte') });
+    });
+
+    it('should report unreadable for a discriminator that carries no payload', () => {
+        const empty = bufferAccount(pack(DOC, Compression.None));
+        empty[0] = 0; // AccountDiscriminator.Empty
+
+        expect(read(empty)).toEqual({ kind: 'unreadable', reason: expect.stringContaining('discriminator 0') });
+    });
+
+    it('should report unreadable when a Metadata header carries an out-of-range hint', () => {
+        const account = metadataAccount({ body: pack(DOC, Compression.None) });
+        account[83] = 9; // the `encoding` byte, past every variant the enum defines
+
+        expect(read(account)).toEqual({ kind: 'unreadable', reason: expect.any(String) });
+    });
+
+    it('should surface a body that does not decode as a payload failure, not an unreadable account', () => {
+        // The account itself parses fine - it is the CONTENT that is not the zlib stream the hints promise. That
+        // distinction is what the UI renders differently, so it must survive here.
+        const result = decodePmpBufferAccount({
+            account: { data: bufferAccount(new Uint8Array([1, 2, 3, 4])), lamports: 1, owner: PMP_ADDRESS },
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+        });
+
+        expect(result).toMatchObject({ kind: 'payload', payload: { kind: 'failed' } });
+    });
+
+    it('should report the payload oversized above the render cap without decoding it', () => {
+        const body = pack('a'.repeat(4096), Compression.None);
+        const result = decodePmpBufferAccount({
+            account: { data: bufferAccount(body), lamports: 1, owner: PMP_ADDRESS },
+            cap: 1024,
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.None },
+        });
+
+        expect(result).toMatchObject({ kind: 'payload', payload: { kind: 'oversized' } });
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-instruction.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-instruction.spec.ts
@@ -1,0 +1,244 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getAllocateInstructionDataEncoder,
+    getInitializeInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+    getWriteInstructionDataEncoder,
+} from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { PMP_ADDRESS } from '../constants';
+import { decodePmpContentInstruction } from '../decode-pmp-instruction';
+import { isProgramMetadataInstruction } from '../is-program-metadata-instruction';
+
+const PMP = new PublicKey(PMP_ADDRESS);
+const FOREIGN_BUFFER = new PublicKey('4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw');
+const METADATA_PDA = new PublicKey('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8');
+// `Uint8Array.from` is load-bearing, not redundant: under jsdom `TextEncoder` returns a Uint8Array built with a
+// DIFFERENT realm's constructor, and Vitest's `toEqual` compares prototypes, so a bare `encode()` result never
+// deep-equals a same-realm Uint8Array ("Compared values have no visual difference"). Re-wrap to this realm.
+const DOC_BYTES = Uint8Array.from(new TextEncoder().encode('{"name":"company"}'));
+
+function makeIx(data: Uint8Array, accounts: PublicKey[] = []): TransactionInstruction {
+    return new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: accounts.map(pubkey => ({ isSigner: false, isWritable: false, pubkey })),
+        programId: PMP,
+    });
+}
+
+describe('isProgramMetadataInstruction', () => {
+    it('should accept an instruction targeting the PMP program', () => {
+        expect(isProgramMetadataInstruction(makeIx(new Uint8Array([3, 1, 0, 1])))).toBe(true);
+    });
+
+    it('should reject an instruction targeting another program', () => {
+        const ix = new TransactionInstruction({
+            data: Buffer.from([0]),
+            keys: [],
+            programId: new PublicKey('11111111111111111111111111111111'),
+        });
+
+        expect(isProgramMetadataInstruction(ix)).toBe(false);
+    });
+});
+
+describe('decodePmpContentInstruction', () => {
+    it('should decode a setData carrying an inline Direct payload', () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.Zlib,
+            data: DOC_BYTES,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: DOC_BYTES,
+        });
+    });
+
+    it('should decode a 4-byte header-only setData without a dataSource and without throwing', () => {
+        // The generated decoder throws on this shape ("Codec [u8] cannot decode empty byte arrays") and the
+        // generated ENCODER cannot build it, so it has to be a literal. It is on-chain valid: the Rust CLI emits
+        // it to change `format` without touching the stored bytes.
+        const result = decodePmpContentInstruction(makeIx(new Uint8Array([3, 1, 0, 1]), [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            kind: 'setData',
+        });
+    });
+
+    it('should reject a header-only setData whose hint byte is out of range instead of casting it', () => {
+        // The header-only shape is the only path that reads hint bytes raw, so `PmpDecodeConfigStruct` is what
+        // stops an out-of-range byte reaching the card as a number no label map can resolve. `format = 7` here.
+        expect(
+            decodePmpContentInstruction(makeIx(new Uint8Array([3, 1, 0, 7]), [METADATA_PDA, PMP, PMP])),
+        ).toBeUndefined();
+    });
+
+    it('should reject a header-only setData whose encoding and compression bytes are out of range', () => {
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([3, 9, 0, 1])))).toBeUndefined();
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([3, 1, 9, 1])))).toBeUndefined();
+    });
+
+    it('should accept every in-range hint combination on the header-only shape', () => {
+        // Guards against the struct being too strict - e.g. listing the enum variants wrongly, or `Object.values`
+        // on a numeric enum admitting its reverse-mapping label strings.
+        for (const encoding of [0, 1, 2, 3]) {
+            for (const compression of [0, 1, 2]) {
+                for (const format of [0, 1, 2, 3]) {
+                    const result = decodePmpContentInstruction(
+                        makeIx(new Uint8Array([3, encoding, compression, format])),
+                    );
+                    expect(result).toEqual({ config: { compression, encoding, format }, kind: 'setData' });
+                }
+            }
+        }
+    });
+
+    it('should report the foreign buffer when setData carries no inline payload', () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, FOREIGN_BUFFER]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            sourceBuffer: FOREIGN_BUFFER.toBase58(),
+        });
+    });
+
+    it('should not report a source buffer when account index 2 holds the program id', () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+        });
+    });
+
+    it('should decode an initialize carrying an inline payload with its seed', () => {
+        const data = getInitializeInstructionDataEncoder().encode({
+            compression: Compression.None,
+            data: DOC_BYTES,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+            seed: 'idl',
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'initialize',
+            metadataAccount: METADATA_PDA.toBase58(),
+            payload: DOC_BYTES,
+            seed: 'idl',
+        });
+    });
+
+    it('should report the metadata account when initialize is the in-place shape', () => {
+        const data = getInitializeInstructionDataEncoder().encode({
+            compression: Compression.None,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+            seed: 'idl',
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'initialize',
+            metadataAccount: METADATA_PDA.toBase58(),
+            seed: 'idl',
+        });
+    });
+
+    it('should decode a write carrying an inline chunk at its logical offset', () => {
+        const data = getWriteInstructionDataEncoder().encode({
+            data: new Uint8Array([1, 2, 3]),
+            offset: 7,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({ chunk: new Uint8Array([1, 2, 3]), kind: 'write', offset: 7 });
+    });
+
+    it('should report the source buffer for a write whose chunk is not in the transaction', () => {
+        const data = getWriteInstructionDataEncoder().encode({ offset: 7 }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, FOREIGN_BUFFER]));
+
+        expect(result).toEqual({ kind: 'write', offset: 7, sourceBuffer: FOREIGN_BUFFER.toBase58() });
+    });
+
+    it('should return undefined for a housekeeping instruction so the caller falls through to the IDL tier', () => {
+        const data = getAllocateInstructionDataEncoder().encode({ seed: 'idl' }) as Uint8Array;
+
+        expect(decodePmpContentInstruction(makeIx(data, [METADATA_PDA]))).toBeUndefined();
+    });
+
+    it('should return undefined for an unrecognised discriminator instead of throwing', () => {
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([99])))).toBeUndefined();
+    });
+
+    it('should return undefined for empty instruction data instead of throwing', () => {
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([])))).toBeUndefined();
+    });
+
+    it('should return undefined for a truncated setData instead of throwing', () => {
+        // Discriminator 3 with only one hint byte: identify succeeds, the typed decoder then fails.
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([3, 1])))).toBeUndefined();
+    });
+
+    it('should return undefined for a setData whose enum byte is out of range', () => {
+        // Pins an ACCEPTED limitation rather than desired behaviour. `format = 7` makes the typed decoder throw
+        // ("Enum discriminator out of range. Expected a number in [0-3], got 7"), so the instruction falls
+        // through to the IDL tier and then to Unknown, and the reader loses accounts and hints that were
+        // themselves decodable. The `Unknown (n)` label fallbacks in the card's ConfigRows do NOT cover this
+        // path - they only ever fire for the 4-byte header-only shape, which reads its hint bytes raw. Handling
+        // it would mean hand-decoding the header on a decoder failure, which is out of scope for P1.
+        const valid = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            data: DOC_BYTES,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+        const corrupt = Uint8Array.from(valid);
+        corrupt[3] = 7; // the `format` byte
+
+        expect(decodePmpContentInstruction(makeIx(corrupt, [METADATA_PDA, PMP, PMP]))).toBeUndefined();
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-payload.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-payload.spec.ts
@@ -1,0 +1,121 @@
+import { Compression, Encoding, Format, packDirectData } from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { PMP_DECODED_RENDER_CAP_BYTES } from '../constants';
+import { decodePmpPayload } from '../decode-pmp-payload';
+
+const DOC = '{"name":"company","version":"1.0.0"}';
+const DOC_VALUE = { name: 'company', version: '1.0.0' };
+
+// `packDirectData` is the library's own producer, so every fixture below is a byte-exact round trip of what the
+// canonical client puts on chain. Its `encoding` argument INTERPRETS the content string, so Utf8 is the only
+// realistic choice for a JSON document (with Base64 the content would have to be base64 text already).
+function pack(content: string, compression: Compression): Uint8Array {
+    return packDirectData({ compression, content, encoding: Encoding.Utf8 }).data as Uint8Array;
+}
+
+describe('decodePmpPayload', () => {
+    it('should decode an uncompressed UTF-8 JSON payload into a parsed document', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            data: pack(DOC, Compression.None),
+        });
+
+        expect(result).toEqual({
+            bytes: expect.any(Uint8Array),
+            document: { kind: 'json', value: DOC_VALUE },
+            kind: 'decoded',
+        });
+    });
+
+    it('should decompress a Zlib payload before decoding', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            data: pack(DOC, Compression.Zlib),
+        });
+
+        expect(result.kind === 'decoded' && result.document).toEqual({ kind: 'json', value: DOC_VALUE });
+    });
+
+    it('should decompress a Gzip payload before decoding', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Yaml },
+            data: pack('name: company\n', Compression.Gzip),
+        });
+
+        expect(result.kind === 'decoded' && result.document).toEqual({ kind: 'text', text: 'name: company\n' });
+    });
+
+    it('should render Encoding None as hex rather than as text', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        });
+
+        expect(result.kind === 'decoded' && result.document).toEqual({ kind: 'text', text: 'deadbeef' });
+    });
+
+    it('should report oversized with the full decompressed bytes when the payload exceeds the cap', () => {
+        const result = decodePmpPayload({
+            cap: 4,
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3, 4, 5, 6, 7]),
+        });
+
+        expect(result.kind).toBe('oversized');
+        expect(result.kind === 'oversized' && result.bytes.length).toBe(7);
+    });
+
+    it('should not report oversized when the payload is exactly at the cap', () => {
+        const result = decodePmpPayload({
+            cap: 4,
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            data: new Uint8Array([1, 2, 3, 4]),
+        });
+
+        expect(result.kind).toBe('decoded');
+    });
+
+    it('should default the cap to PMP_DECODED_RENDER_CAP_BYTES', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            data: new Uint8Array(PMP_DECODED_RENDER_CAP_BYTES + 1),
+        });
+
+        expect(result.kind).toBe('oversized');
+    });
+
+    it('should report failed with a reason when the compressed stream is corrupt', () => {
+        // `uncompressData` surfaces pako's failure by throwing a bare STRING, not an Error, so the reason
+        // extraction has to handle a non-Error throw. This test is the guard for that.
+        const result = decodePmpPayload({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3, 4]),
+        });
+
+        expect(result).toEqual({ kind: 'failed', reason: 'incorrect header check' });
+    });
+
+    it('should report failed rather than throwing when the compression value is out of range', () => {
+        // `uncompressData`'s switch has no default arm, so an out-of-range value returns undefined and the
+        // length check then throws a TypeError. The catch has to swallow that too.
+        const result = decodePmpPayload({
+            config: { compression: 99 as Compression, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3]),
+        });
+
+        expect(result.kind).toBe('failed');
+    });
+
+    it('should report failed rather than an empty document when the encoding value is out of range', () => {
+        // `decodeData(_, 99)` returns undefined for the same missing-default-arm reason. Without the explicit
+        // guard this comes back as `{ kind: 'decoded' }` carrying an empty document, which would render as a
+        // blank successful decode. P2 reads the config from an account header, so it can reach this.
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: 99 as Encoding, format: Format.None },
+            data: new Uint8Array([1, 2, 3]),
+        });
+
+        expect(result).toEqual({ kind: 'failed', reason: 'unsupported encoding (99)' });
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/to-decoded-document.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/to-decoded-document.spec.ts
@@ -1,0 +1,39 @@
+import { Format } from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { toDecodedDocument } from '../to-decoded-document';
+
+describe('toDecodedDocument', () => {
+    it('should parse a JSON document so the viewer can render it as a tree', () => {
+        expect(toDecodedDocument('{"name":"company","version":"1.0.0"}', Format.Json)).toEqual({
+            kind: 'json',
+            value: { name: 'company', version: '1.0.0' },
+        });
+    });
+
+    it('should parse a JSON array document', () => {
+        expect(toDecodedDocument('[1,2]', Format.Json)).toEqual({ kind: 'json', value: [1, 2] });
+    });
+
+    it('should fall back to verbatim text when Format is Json but the text does not parse', () => {
+        expect(toDecodedDocument('{not json', Format.Json)).toEqual({ kind: 'text', text: '{not json' });
+    });
+
+    it('should fall back to verbatim text when a Json payload parses to a scalar', () => {
+        // react-json-view requires an object or array root, and a bare scalar reads fine as text anyway.
+        expect(toDecodedDocument('42', Format.Json)).toEqual({ kind: 'text', text: '42' });
+        expect(toDecodedDocument('null', Format.Json)).toEqual({ kind: 'text', text: 'null' });
+    });
+
+    it('should render Yaml and Toml verbatim without pulling in a parser', () => {
+        expect(toDecodedDocument('name: company\n', Format.Yaml)).toEqual({ kind: 'text', text: 'name: company\n' });
+        expect(toDecodedDocument('name = "company"', Format.Toml)).toEqual({
+            kind: 'text',
+            text: 'name = "company"',
+        });
+    });
+
+    it('should render Format None verbatim', () => {
+        expect(toDecodedDocument('deadbeef', Format.None)).toEqual({ kind: 'text', text: 'deadbeef' });
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/analytics.ts
+++ b/app/features/decode-instruction-pmp/lib/analytics.ts
@@ -1,0 +1,32 @@
+import { type GA4EventName, trackEvent } from '@/app/shared/lib/analytics';
+
+/** Which panel of the Decoded Content section the reader switched to. */
+type PmpTab = 'decoded' | 'raw';
+
+const PMP_TAB_OPENED = 'pmp_data_tab_opened';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compile error if the name exceeds GA4's 40-char cap
+const _assertGA4Length: typeof PMP_TAB_OPENED extends GA4EventName<typeof PMP_TAB_OPENED> ? true : never = true;
+
+export const pmpAnalytics = {
+    /**
+     * Fires on a reader-initiated tab switch only. Radix's `onValueChange` does not fire for the tab that is
+     * selected on mount, so the default panel never produces an event and the counts stay comparable.
+     *
+     * `dataSource` is carried because the tabs now render for `Url` and `External` too, where the decoded panel
+     * shows the on-chain pointer rather than a document - without it those clicks are indistinguishable.
+     */
+    trackTabOpened({
+        dataSource,
+        format,
+        instruction,
+        tab,
+    }: {
+        dataSource: string;
+        format: string;
+        instruction: string;
+        tab: PmpTab;
+    }): void {
+        trackEvent(PMP_TAB_OPENED, { data_source: dataSource, format, instruction, tab });
+    },
+};

--- a/app/features/decode-instruction-pmp/lib/analytics.ts
+++ b/app/features/decode-instruction-pmp/lib/analytics.ts
@@ -3,6 +3,9 @@ import { type GA4EventName, trackEvent } from '@/app/shared/lib/analytics';
 /** Which panel of the Decoded Content section the reader switched to. */
 type PmpTab = 'decoded' | 'raw';
 
+/** Where the bytes in the section came from: the instruction itself, or the account it points at. */
+type PmpPayloadSource = 'account' | 'instruction';
+
 const PMP_TAB_OPENED = 'pmp_data_tab_opened';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- compile error if the name exceeds GA4's 40-char cap
@@ -15,18 +18,21 @@ export const pmpAnalytics = {
      *
      * `dataSource` is carried because the tabs now render for `Url` and `External` too, where the decoded panel
      * shows the on-chain pointer rather than a document - without it those clicks are indistinguishable.
+     * `source` separates the two panels that share these tabs, which open on different default tabs.
      */
     trackTabOpened({
         dataSource,
         format,
         instruction,
+        source,
         tab,
     }: {
         dataSource: string;
         format: string;
         instruction: string;
+        source: PmpPayloadSource;
         tab: PmpTab;
     }): void {
-        trackEvent(PMP_TAB_OPENED, { data_source: dataSource, format, instruction, tab });
+        trackEvent(PMP_TAB_OPENED, { data_source: dataSource, format, instruction, source, tab });
     },
 };

--- a/app/features/decode-instruction-pmp/lib/constants.ts
+++ b/app/features/decode-instruction-pmp/lib/constants.ts
@@ -1,0 +1,109 @@
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    PROGRAM_METADATA_PROGRAM_ADDRESS,
+} from '@solana-program/program-metadata';
+
+/** The PMP program id, re-exported from the library so the guard cannot drift from the decoders. */
+export const PMP_ADDRESS: string = PROGRAM_METADATA_PROGRAM_ADDRESS;
+
+/**
+ * Program label for the card title and the Program row, matching what `CodamaInstructionCard` derives from the
+ * IDL for the six housekeeping instructions: the rootNode program name `programMetadata` with its first letter
+ * upper-cased. Deliberately NOT the registry name `PROGRAM_NAMES.PROGRAM_METADATA` ('Program Metadata Program'),
+ * so a transaction carrying both a `setData` and an `allocate` labels both cards identically.
+ */
+export const PMP_CODAMA_PROGRAM_NAME = 'ProgramMetadata';
+
+/**
+ * Render cap for decoded content, per the p1 spec. Above it the card renders a bounded raw view plus a
+ * download affordance instead of the full document. Measured on the DECOMPRESSED payload bytes, so an
+ * oversized payload is never handed to `decodeData` or `JSON.parse` at all.
+ */
+export const PMP_DECODED_RENDER_CAP_BYTES = 256 * 1024;
+
+/**
+ * Depth at which the decoded JSON tree starts collapsed. `@microlink/react-json-view` is not virtualized and the
+ * common payload is a program IDL, so an expanded root would render thousands of nodes. The IDL page collapses
+ * for the same reason.
+ */
+export const PMP_JSON_COLLAPSE_DEPTH = 1;
+
+/** Download base names. `DownloadDropdown` appends `_<encoding>.txt`, so no extension belongs here. */
+export const PMP_RAW_DOWNLOAD_FILENAME = 'pmp-payload-raw';
+export const PMP_DECODED_DOWNLOAD_FILENAME = 'pmp-payload-decoded';
+export const PMP_WRITE_CHUNK_DOWNLOAD_FILENAME = 'pmp-write-chunk';
+
+/** setData carries `dataSource` as an optional trailing byte, so 4 bytes is the header-only hint-update shape. */
+export const HEADER_ONLY_SET_DATA_LEN = 4;
+
+/** setData's optional `buffer` and write's optional `sourceBuffer` both sit at account index 2. */
+export const PMP_OPTIONAL_BUFFER_ACCOUNT_INDEX = 2;
+
+// Explicit label maps rather than the numeric enums' reverse mapping: a new library variant then breaks the
+// build here instead of rendering `undefined` in the card.
+export const PMP_ENCODING_LABELS: Record<Encoding, string> = {
+    [Encoding.Base58]: 'Base58',
+    [Encoding.Base64]: 'Base64',
+    [Encoding.None]: 'None (hex)',
+    [Encoding.Utf8]: 'UTF-8',
+};
+
+export const PMP_COMPRESSION_LABELS: Record<Compression, string> = {
+    [Compression.Gzip]: 'Gzip',
+    [Compression.None]: 'None',
+    [Compression.Zlib]: 'Zlib',
+};
+
+export const PMP_FORMAT_LABELS: Record<Format, string> = {
+    [Format.Json]: 'JSON',
+    [Format.None]: 'None',
+    [Format.Toml]: 'TOML',
+    [Format.Yaml]: 'YAML',
+};
+
+export const PMP_DATA_SOURCE_LABELS: Record<DataSource, string> = {
+    [DataSource.Direct]: 'Direct',
+    [DataSource.External]: 'External',
+    [DataSource.Url]: 'Url',
+};
+
+/** Lowercase GA param values, so the event vocabulary stays stable if the display labels change. */
+export const PMP_FORMAT_ANALYTICS_NAMES: Record<Format, string> = {
+    [Format.Json]: 'json',
+    [Format.None]: 'none',
+    [Format.Toml]: 'toml',
+    [Format.Yaml]: 'yaml',
+};
+
+export const PMP_DATA_SOURCE_ANALYTICS_NAMES: Record<DataSource, string> = {
+    [DataSource.Direct]: 'direct',
+    [DataSource.External]: 'external',
+    [DataSource.Url]: 'url',
+};
+
+export const PMP_ANALYTICS_IX_NAMES = {
+    initialize: 'initialize',
+    setData: 'set_data',
+} as const;
+
+/**
+ * Instruction account order, verified against the generated client's `getXInstruction` builders (design 1).
+ * These are FINAL row labels, rendered verbatim. They carry Codama's own capitalisation (first letter upper,
+ * no word split) so a `setData` card labels its accounts exactly like the `allocate` card next to it, which
+ * `CodamaInstructionCard` builds with `charAt(0).toUpperCase() + slice(1)`.
+ */
+export const PMP_ACCOUNT_NAMES = {
+    initialize: ['Metadata', 'Authority', 'Program', 'ProgramData', 'System'],
+    setData: ['Metadata', 'Authority', 'Buffer', 'Program', 'ProgramData'],
+    write: ['Buffer', 'Authority', 'SourceBuffer'],
+} as const;
+
+/** Instruction labels in Codama's style (the IDL name with its first letter upper-cased), for the same reason. */
+export const PMP_IX_TITLES = {
+    initialize: 'Initialize',
+    setData: 'SetData',
+    write: 'Write',
+} as const;

--- a/app/features/decode-instruction-pmp/lib/constants.ts
+++ b/app/features/decode-instruction-pmp/lib/constants.ts
@@ -1,4 +1,5 @@
 import {
+    ACCOUNT_HEADER_LENGTH,
     Compression,
     DataSource,
     Encoding,
@@ -35,6 +36,16 @@ export const PMP_JSON_COLLAPSE_DEPTH = 1;
 export const PMP_RAW_DOWNLOAD_FILENAME = 'pmp-payload-raw';
 export const PMP_DECODED_DOWNLOAD_FILENAME = 'pmp-payload-decoded';
 export const PMP_WRITE_CHUNK_DOWNLOAD_FILENAME = 'pmp-write-chunk';
+export const PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME = 'pmp-account-raw';
+
+/**
+ * Both PMP account layouts put the payload body at byte 96, so anything shorter cannot carry one.
+ *
+ * Buffer:   disc [0,1) program [1,33) authority [33,65) canonical [65,66) seed [66,82) padding [82,96)
+ * Metadata: disc [0,1) program [1,33) authority [33,65) mutable [65,66) canonical [66,67) seed [67,83)
+ *           encoding [83,84) compression [84,85) format [85,86) dataSource [86,87) dataLength [87,91) padding [91,96)
+ */
+export const PMP_ACCOUNT_HEADER_LEN: number = ACCOUNT_HEADER_LENGTH;
 
 /** setData carries `dataSource` as an optional trailing byte, so 4 bytes is the header-only hint-update shape. */
 export const HEADER_ONLY_SET_DATA_LEN = 4;

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-buffer-account.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-buffer-account.ts
@@ -1,0 +1,95 @@
+import type { ReadonlyUint8Array } from '@solana/kit';
+import { AccountDiscriminator, getBufferDecoder, getMetadataDecoder } from '@solana-program/program-metadata';
+
+import { bytes } from '@/app/shared/lib/bytes';
+
+import { PMP_ACCOUNT_HEADER_LEN, PMP_ADDRESS } from './constants';
+import { decodePmpPayload } from './decode-pmp-payload';
+import type { PmpAccountContent, PmpAccountKind, PmpAccountSnapshot, PmpDecodeConfig } from './types';
+
+/**
+ * Decodes the payload a PMP account currently holds, for the instructions that carry no inline bytes: a `setData`
+ * whose payload came from a foreign buffer, and an `initialize` that finalized bytes pre-written to its metadata
+ * PDA. Pure - the caller supplies the already-fetched account.
+ *
+ * This reads CURRENT state. It is not a reconstruction of what the viewed transaction wrote, and it makes no
+ * attempt to be: no write history, no execution-position bound, no length derivation. The UI says so.
+ *
+ * `config` is used only for a Buffer account, whose header carries no encoding/compression/format of its own. A
+ * Metadata account carries its own hints, and those are the ones that match the bytes it currently holds.
+ */
+export function decodePmpBufferAccount({
+    account,
+    config,
+    cap,
+}: {
+    account: PmpAccountSnapshot;
+    config: PmpDecodeConfig;
+    cap?: number;
+}): PmpAccountContent {
+    const { data, lamports, owner } = account;
+
+    // The accounts provider models "no such account" as zero lamports plus an empty raw buffer, which is exactly
+    // what a closed PMP buffer leaves behind. No account can hold data at zero lamports, so this is unambiguous.
+    if (lamports === 0 && (data === undefined || data.length === 0)) return { kind: 'absent' };
+
+    if (owner !== PMP_ADDRESS) {
+        return {
+            kind: 'unreadable', reason: `the account is owned by ${owner}, not the Program Metadata Program`
+        };
+    }
+    if (data === undefined || data.length < PMP_ACCOUNT_HEADER_LEN) {
+        return {
+            kind: 'unreadable', reason: `the account is shorter than the ${PMP_ACCOUNT_HEADER_LEN}-byte header`
+        };
+    }
+
+    try {
+        switch (data[0]) {
+            case AccountDiscriminator.Buffer:
+                // A buffer has no length field: its body runs to the end of the account, which is what the
+                // remainder decoder hands back.
+                return toContent('buffer', config, getBufferDecoder().decode(data).data, cap);
+            case AccountDiscriminator.Metadata: {
+                const metadata = getMetadataDecoder().decode(data);
+                // The `data` field is a REMAINDER, so an account grown by `extend` and never trimmed carries
+                // slack past the payload. `dataLength` is what the program itself treats as the payload.
+                const body = metadata.data.subarray(0, metadata.dataLength);
+                const accountConfig = {
+                    compression: metadata.compression,
+                    encoding: metadata.encoding,
+                    format: metadata.format,
+                };
+                return toContent('metadata', accountConfig, body, cap);
+            }
+            default:
+                // AccountDiscriminator.Empty, or a byte the enum does not cover at all. Reading either as a
+                // payload would decode padding as content.
+                return { kind: 'unreadable', reason: `the account holds no PMP payload (discriminator ${data[0]})` };
+        }
+    } catch (error) {
+        return { kind: 'unreadable', reason: toReason(error) };
+    }
+}
+
+/**
+ * The body is copied out rather than kept as a view. The provider hands back web3.js's Node `Buffer`, so every
+ * slice of it is a `Buffer` sitting at an offset into Node's shared allocation pool - which would leak that
+ * pool's lifetime and `Buffer`'s own `toJSON` into everything downstream, exactly as the inline path avoids.
+ */
+function toContent(
+    account: PmpAccountKind,
+    config: PmpDecodeConfig,
+    body: ReadonlyUint8Array,
+    cap: number | undefined,
+): PmpAccountContent {
+    const data = bytes(body);
+    return { account, body: data, config, kind: 'payload', payload: decodePmpPayload({ cap, config, data }) };
+}
+
+/** The generated decoders throw plain Errors, but pako (reached via `decodePmpPayload`) throws bare strings. */
+function toReason(error: unknown): string {
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    return 'unknown account decode error';
+}

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-instruction.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-instruction.ts
@@ -1,0 +1,117 @@
+import { unwrapOption } from '@solana/kit';
+import type { TransactionInstruction } from '@solana/web3.js';
+import {
+    getInitializeInstructionDataDecoder,
+    getSetDataInstructionDataDecoder,
+    getWriteInstructionDataDecoder,
+    identifyProgramMetadataInstruction,
+    ProgramMetadataInstruction,
+} from '@solana-program/program-metadata';
+import { is } from 'superstruct';
+
+import { HEADER_ONLY_SET_DATA_LEN, PMP_ADDRESS, PMP_OPTIONAL_BUFFER_ACCOUNT_INDEX } from './constants';
+import type { PmpContentInstruction } from './types';
+import { PmpDecodeConfigStruct } from './validators';
+
+/**
+ * Decodes the config and payload of a content-carrying PMP instruction from its RAW bytes, using the library's
+ * typed decoders. Needs no IDL, because those decoders ship with the installed package.
+ *
+ * Returns undefined for the six housekeeping instructions and for any shape the decoders reject, so the caller
+ * falls through to its remaining tiers (the dynamic IDL card, then Unknown) exactly as it does today.
+ */
+export function decodePmpContentInstruction(ix: TransactionInstruction): PmpContentInstruction | undefined {
+    try {
+        switch (identifyProgramMetadataInstruction(ix.data)) {
+            case ProgramMetadataInstruction.SetData:
+                return decodeSetData(ix);
+            case ProgramMetadataInstruction.Initialize:
+                return decodeInitialize(ix);
+            case ProgramMetadataInstruction.Write:
+                return decodeWrite(ix);
+            default:
+                // allocate, setAuthority, setImmutable, trim, extend, close carry no payload.
+                return undefined;
+        }
+    } catch {
+        // Three shapes land here:
+        // - an unknown or empty discriminator (identify throws)
+        // - a truncated body,
+        // - an out-of-range enum byte ("Enum discriminator out of range").
+        // All fall through to the IDL tier and then to Unknown.
+        return undefined;
+    }
+}
+
+function decodeSetData(ix: TransactionInstruction): PmpContentInstruction | undefined {
+    // setData carries `dataSource` as an OPTIONAL trailing byte, so a 4-byte instruction is the header-only hint
+    // update and `getSetDataInstructionDataDecoder()` throws on it. Branch on the length before decoding.
+    if (ix.data.length === HEADER_ONLY_SET_DATA_LEN) {
+        const [, encoding, compression, format] = ix.data;
+        const config = { compression, encoding, format };
+        // These are the slice's only unvalidated bytes, so superstruct narrows them to the library enums rather
+        // than an `as` cast asserting a range nothing checked. An out-of-range hint then falls through like every
+        // other malformed shape, instead of reaching the card as a number no label map can resolve.
+        return is(config, PmpDecodeConfigStruct) ? { config, kind: 'setData' } : undefined;
+    }
+
+    const decoded = getSetDataInstructionDataDecoder().decode(ix.data);
+    const payload = toPayload(unwrapOption(decoded.data));
+    return {
+        config: { compression: decoded.compression, encoding: decoded.encoding, format: decoded.format },
+        dataSource: decoded.dataSource,
+        kind: 'setData',
+        payload,
+        // A 5-byte setData with `buffer == programId` is InvalidInstructionData on chain, so "no payload plus a
+        // foreign buffer at index 2" is the only reachable buffer-sourced shape.
+        sourceBuffer: payload ? undefined : sourceBufferAt(ix),
+    };
+}
+
+function decodeInitialize(ix: TransactionInstruction): PmpContentInstruction {
+    // `initialize`'s `dataSource` is a fixed struct field, so its decoder always applies - no length branch.
+    const decoded = getInitializeInstructionDataDecoder().decode(ix.data);
+    return {
+        config: { compression: decoded.compression, encoding: decoded.encoding, format: decoded.format },
+        dataSource: decoded.dataSource,
+        kind: 'initialize',
+        // The in-place path finalises bytes already written to the metadata PDA at account index 0.
+        metadataAccount: ix.keys[0]?.pubkey.toBase58(),
+        payload: toPayload(unwrapOption(decoded.data)),
+        seed: decoded.seed,
+    };
+}
+
+function decodeWrite(ix: TransactionInstruction): PmpContentInstruction {
+    const { data, offset } = getWriteInstructionDataDecoder().decode(ix.data);
+    const chunk = toPayload(unwrapOption(data));
+    return {
+        chunk,
+        kind: 'write',
+        offset,
+        sourceBuffer: chunk ? undefined : sourceBufferAt(ix),
+    };
+}
+
+/**
+ * `unwrapOption` returns null for None, and the `data` field is a REMAINDER option, so none() and some(empty)
+ * encode to the same bytes. Both collapse to "no payload here" - account index 2 is what tells a source-buffer
+ * copy apart from a zero-length inline write.
+ *
+ * `TransactionInstruction.data` is a Node `Buffer`, so the remainder slice the decoder hands back is a Buffer
+ * VIEW, not a plain `Uint8Array`. Copy it into one: the declared type says `Uint8Array`, the repo is migrating
+ * off `Buffer`, and `Buffer` carries its own `toJSON`, which would change how a payload serialises downstream.
+ * Copied rather than re-viewed because a Buffer view sits at a non-zero offset into Node's shared allocation
+ * pool, which leaks that offset (and the whole pool's lifetime) into everything downstream. Inline payloads are
+ * transaction-size bounded, so the copy is at most ~1 KB.
+ */
+function toPayload(value: unknown): Uint8Array | undefined {
+    if (!(value instanceof Uint8Array) || value.length === 0) return undefined;
+    return new Uint8Array(value);
+}
+
+/** The optional buffer/sourceBuffer slot. Codama's "programId" strategy fills an omitted optional with the id. */
+function sourceBufferAt(ix: TransactionInstruction): string | undefined {
+    const account = ix.keys[PMP_OPTIONAL_BUFFER_ACCOUNT_INDEX]?.pubkey.toBase58();
+    return account && account !== PMP_ADDRESS ? account : undefined;
+}

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-payload.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-payload.ts
@@ -1,0 +1,52 @@
+import { decodeData, uncompressData } from '@solana-program/program-metadata';
+
+import { PMP_DECODED_RENDER_CAP_BYTES } from './constants';
+import { toDecodedDocument } from './to-decoded-document';
+import type { PmpDecodeConfig, PmpDecodedPayload } from './types';
+
+/**
+ * Decodes an inline PMP payload: decompress, enforce the render cap, then decode per `encoding` and present per
+ * `format`. Never throws - every failure comes back as `{ kind: 'failed' }` so the card can degrade locally
+ * without losing its accounts and config tables.
+ *
+ * The cap is measured on the DECOMPRESSED bytes and checked BEFORE the encoding step, so an oversized payload is
+ * never handed to `decodeData` or `JSON.parse`. That is the cost the cap exists to avoid.
+ *
+ * TODO: scope is inline bytes only, which are transaction-size bounded, so the library's unbounded pako inflate is safe here. Buffer-sourced (milestone P2) and fetched (milestone P3) bytes are NOT bounded and need the output-bounded inflate.
+ */
+export function decodePmpPayload({
+    config,
+    data,
+    cap = PMP_DECODED_RENDER_CAP_BYTES,
+}: {
+    config: PmpDecodeConfig;
+    data: Uint8Array;
+    cap?: number;
+}): PmpDecodedPayload {
+    try {
+        // `uncompressData` is typed ReadonlyUint8Array but returns the input by reference for Compression.None
+        // and a real Uint8Array from pako otherwise, so this is a view cast rather than a copy.
+        const bytes = uncompressData(data, config.compression);
+        if (bytes.length > cap) {
+            return { bytes: bytes.subarray(), kind: 'oversized' };
+        }
+        const text = decodeData(bytes, config.encoding);
+        // `decodeData`'s switch has no default arm, so an out-of-range `encoding` returns undefined instead of
+        // throwing, and `toDecodedDocument(undefined, ...)` would then report a successful decode of an empty
+        // document. Unreachable in P1, because the typed instruction decoder rejects a bad enum byte first
+        // ("Enum discriminator out of range"), but P2 reads the config from an account header where it is not.
+        if (typeof text !== 'string') {
+            return { kind: 'failed', reason: `unsupported encoding (${config.encoding})` };
+        }
+        return { bytes: bytes.subarray(), document: toDecodedDocument(text, config.format), kind: 'decoded' };
+    } catch (error) {
+        return { kind: 'failed', reason: toDecodeFailureReason(error) };
+    }
+}
+
+/** pako's inflate/ungzip throw a bare string, so `error instanceof Error` is not enough on this path. */
+function toDecodeFailureReason(error: unknown): string {
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    return 'unknown decode error';
+}

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-payload.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-payload.ts
@@ -11,8 +11,6 @@ import type { PmpDecodeConfig, PmpDecodedPayload } from './types';
  *
  * The cap is measured on the DECOMPRESSED bytes and checked BEFORE the encoding step, so an oversized payload is
  * never handed to `decodeData` or `JSON.parse`. That is the cost the cap exists to avoid.
- *
- * TODO: scope is inline bytes only, which are transaction-size bounded, so the library's unbounded pako inflate is safe here. Buffer-sourced (milestone P2) and fetched (milestone P3) bytes are NOT bounded and need the output-bounded inflate.
  */
 export function decodePmpPayload({
     config,
@@ -30,14 +28,12 @@ export function decodePmpPayload({
         if (bytes.length > cap) {
             return { bytes: bytes.subarray(), kind: 'oversized' };
         }
+
         const text = decodeData(bytes, config.encoding);
-        // `decodeData`'s switch has no default arm, so an out-of-range `encoding` returns undefined instead of
-        // throwing, and `toDecodedDocument(undefined, ...)` would then report a successful decode of an empty
-        // document. Unreachable in P1, because the typed instruction decoder rejects a bad enum byte first
-        // ("Enum discriminator out of range"), but P2 reads the config from an account header where it is not.
         if (typeof text !== 'string') {
             return { kind: 'failed', reason: `unsupported encoding (${config.encoding})` };
         }
+
         return { bytes: bytes.subarray(), document: toDecodedDocument(text, config.format), kind: 'decoded' };
     } catch (error) {
         return { kind: 'failed', reason: toDecodeFailureReason(error) };

--- a/app/features/decode-instruction-pmp/lib/is-program-metadata-instruction.ts
+++ b/app/features/decode-instruction-pmp/lib/is-program-metadata-instruction.ts
@@ -1,0 +1,11 @@
+import type { TransactionInstruction } from '@solana/web3.js';
+
+import { PMP_ADDRESS } from './constants';
+
+/**
+ * Whether an instruction targets the Program Metadata Program. Mirrors the per-program guards it sits alongside
+ * (`isLighthouseInstruction`, `isPythInstruction`, ...) and is used by both the tx page and the inspector.
+ */
+export function isProgramMetadataInstruction(ix: TransactionInstruction): boolean {
+    return ix.programId.toBase58() === PMP_ADDRESS;
+}

--- a/app/features/decode-instruction-pmp/lib/to-decoded-document.ts
+++ b/app/features/decode-instruction-pmp/lib/to-decoded-document.ts
@@ -1,0 +1,26 @@
+import { Format } from '@solana-program/program-metadata';
+
+import type { PmpDecodedDocument } from './types';
+
+/**
+ * Decides how an already-decoded payload string should be presented. Only `Json` gets parsed, and only after the
+ * caller has enforced the render cap, so `JSON.parse` never sees an unbounded document. Yaml/Toml/None stay
+ * verbatim text - no parser library is pulled in, so no new attack surface.
+ */
+export function toDecodedDocument(text: string, format: Format): PmpDecodedDocument {
+    if (format !== Format.Json) {
+        return { kind: 'text', text };
+    }
+    try {
+        const value: unknown = JSON.parse(text);
+        // `SolarizedJsonViewer` wraps react-json-view, whose `src` must be an object or array. A scalar document
+        // is valid JSON but has no tree to show, so it degrades to text rather than crashing the viewer.
+        if (typeof value !== 'object' || value === null) {
+            return { kind: 'text', text };
+        }
+        return { kind: 'json', value };
+    } catch {
+        // The on-chain `format` hint is attacker-controlled, so a Json hint over non-JSON bytes is expected.
+        return { kind: 'text', text };
+    }
+}

--- a/app/features/decode-instruction-pmp/lib/types.ts
+++ b/app/features/decode-instruction-pmp/lib/types.ts
@@ -1,0 +1,61 @@
+import type { Compression, DataSource, Encoding, Format } from '@solana-program/program-metadata';
+/** The three decode hints `setData` and `initialize` carry on the wire. `format` classifies, it does not decode. */
+export type PmpDecodeConfig = {
+    encoding: Encoding;
+    compression: Compression;
+    format: Format;
+};
+
+/**
+ * The content-carrying PMP instructions. The six housekeeping instructions (allocate, setAuthority,
+ * setImmutable, trim, extend, close) never produce one of these - they fall through to the IDL card.
+ */
+export type PmpContentInstruction =
+    | {
+          kind: 'setData';
+          config: PmpDecodeConfig;
+          /** Absent on the 4-byte header-only shape, which carries no `dataSource` byte and no payload. */
+          dataSource?: DataSource;
+          /** Absent on the header-only shape and when the bytes live in `sourceBuffer` (reconstruction is milestone P2). */
+          payload?: Uint8Array;
+          /** Account index 2 when it is not the program id, meaning the bytes come from a foreign buffer. */
+          sourceBuffer?: string;
+      }
+    | {
+          kind: 'initialize';
+          config: PmpDecodeConfig;
+          dataSource: DataSource;
+          seed: string;
+          /** Absent on the in-place path, where the bytes were pre-written to the metadata PDA (P2). */
+          payload?: Uint8Array;
+          /** Account index 0, the metadata PDA that the in-place path pre-wrote. */
+          metadataAccount?: string;
+      }
+    | {
+          kind: 'write';
+          offset: number;
+          /** Absent when the chunk was copied from `sourceBuffer`, whose bytes are not in this transaction. */
+          chunk?: Uint8Array;
+          sourceBuffer?: string;
+      };
+
+/** The two instructions that carry decode hints, so the only two that can produce a decoded document. */
+export type PmpPayloadInstruction = Extract<PmpContentInstruction, { kind: 'setData' | 'initialize' }>;
+
+/**
+ * How the decoded payload should be presented. `json` carries the PARSED value for `SolarizedJsonViewer`, which
+ * needs an object rather than a string. Everything else is verbatim text in a `<pre>`, including a `Format.Json`
+ * payload whose bytes do not actually parse, and a `Format.Json` payload that parses to a scalar (the viewer
+ * requires an object or array root).
+ */
+export type PmpDecodedDocument = { kind: 'json'; value: object } | { kind: 'text'; text: string };
+
+/**
+ * Result of decoding an inline payload. `oversized` and `failed` are the two guard states the p1 spec requires:
+ * neither may throw out to the card, and neither may render as a successful document. `oversized` carries the
+ * full decompressed bytes and no document, because nothing above the cap is decoded at all.
+ */
+export type PmpDecodedPayload =
+    | { kind: 'decoded'; document: PmpDecodedDocument; bytes: Uint8Array }
+    | { kind: 'oversized'; bytes: Uint8Array }
+    | { kind: 'failed'; reason: string };

--- a/app/features/decode-instruction-pmp/lib/types.ts
+++ b/app/features/decode-instruction-pmp/lib/types.ts
@@ -16,7 +16,7 @@ export type PmpContentInstruction =
           config: PmpDecodeConfig;
           /** Absent on the 4-byte header-only shape, which carries no `dataSource` byte and no payload. */
           dataSource?: DataSource;
-          /** Absent on the header-only shape and when the bytes live in `sourceBuffer` (reconstruction is milestone P2). */
+          /** Absent on the header-only shape and when the bytes live in `sourceBuffer`, which is read on demand. */
           payload?: Uint8Array;
           /** Account index 2 when it is not the program id, meaning the bytes come from a foreign buffer. */
           sourceBuffer?: string;
@@ -26,7 +26,7 @@ export type PmpContentInstruction =
           config: PmpDecodeConfig;
           dataSource: DataSource;
           seed: string;
-          /** Absent on the in-place path, where the bytes were pre-written to the metadata PDA (P2). */
+          /** Absent on the in-place path, where the bytes were pre-written to the metadata PDA and are read there. */
           payload?: Uint8Array;
           /** Account index 0, the metadata PDA that the in-place path pre-wrote. */
           metadataAccount?: string;
@@ -59,3 +59,35 @@ export type PmpDecodedPayload =
     | { kind: 'decoded'; document: PmpDecodedDocument; bytes: Uint8Array }
     | { kind: 'oversized'; bytes: Uint8Array }
     | { kind: 'failed'; reason: string };
+
+/** Which PMP account layout the body was read from. A Buffer carries no hints of its own, a Metadata does. */
+export type PmpAccountKind = 'buffer' | 'metadata';
+
+/**
+ * The minimal account shape the pure account decoder needs, so `lib/` stays free of the accounts provider.
+ * `owner` is base58 and `data` is the account's RAW bytes, header included.
+ */
+export type PmpAccountSnapshot = {
+    owner: string;
+    lamports: number;
+    data: Uint8Array | undefined;
+};
+
+/**
+ * Result of reading a payload from the account the instruction points at, rather than from the instruction.
+ *
+ * `absent` is an ordinary outcome, not an error: the canonical client closes a `setData` source buffer right
+ * after the instruction to reclaim its rent, so a historical transaction's buffer is normally gone.
+ */
+export type PmpAccountContent =
+    | { kind: 'absent' }
+    | { kind: 'unreadable'; reason: string }
+    | {
+          kind: 'payload';
+          account: PmpAccountKind;
+          /** The hints the body was decoded with: a Metadata account's own, or the instruction's for a Buffer. */
+          config: PmpDecodeConfig;
+          /** The account body as stored, before decompression - what the Raw tab shows. */
+          body: Uint8Array;
+          payload: PmpDecodedPayload;
+      };

--- a/app/features/decode-instruction-pmp/lib/validators.ts
+++ b/app/features/decode-instruction-pmp/lib/validators.ts
@@ -1,0 +1,17 @@
+import { Compression, Encoding, Format } from '@solana-program/program-metadata';
+import { enums, object } from 'superstruct';
+
+/**
+ * Runtime shape of the three decode hints, for the one path that reads them as raw bytes: the 4-byte header-only
+ * `setData`. Every other shape goes through a generated decoder that already rejects an out-of-range enum byte,
+ * so this is the only place unvalidated chain data enters the slice.
+ *
+ * The variants are listed explicitly rather than derived with `Object.values`, because a numeric TypeScript enum's
+ * runtime object also carries its reverse mapping (`{ 0: 'None', None: 0, ... }`), which would admit the label
+ * strings as valid values. Listing them also means a new library variant is a compile error here.
+ */
+export const PmpDecodeConfigStruct = object({
+    compression: enums([Compression.None, Compression.Gzip, Compression.Zlib]),
+    encoding: enums([Encoding.None, Encoding.Utf8, Encoding.Base58, Encoding.Base64]),
+    format: enums([Format.None, Format.Json, Format.Yaml, Format.Toml]),
+});

--- a/app/features/decode-instruction-pmp/model/use-pmp-account-payload.ts
+++ b/app/features/decode-instruction-pmp/model/use-pmp-account-payload.ts
@@ -1,0 +1,50 @@
+import { useAccountInfo, useFetchAccountInfo } from '@providers/accounts';
+import { FetchStatus } from '@providers/cache';
+import { PublicKey } from '@solana/web3.js';
+import React from 'react';
+
+import { decodePmpBufferAccount } from '../lib/decode-pmp-buffer-account';
+import type { PmpAccountContent, PmpDecodeConfig } from '../lib/types';
+
+export type PmpAccountPayloadState =
+    | { status: 'loading' }
+    | { status: 'failed' }
+    | { status: 'ready'; content: PmpAccountContent };
+
+/**
+ * Reads the payload a PMP account currently holds.
+ *
+ * `config` must be referentially stable (pass the memoised instruction's own `config`), because it keys the
+ * decode memo and a fresh object per render would re-decompress the payload on every render.
+ */
+export function usePmpAccountPayload({
+    address,
+    config,
+}: {
+    address: string;
+    config: PmpDecodeConfig;
+}): PmpAccountPayloadState {
+    const fetchAccountInfo = useFetchAccountInfo();
+    const entry = useAccountInfo(address);
+
+    React.useEffect(() => {
+        // `entry` guards the re-request: the provider keeps a Fetching entry from the first call onwards, so this
+        // fires once per address rather than on every render until the response lands.
+        if (entry !== undefined) return;
+        fetchAccountInfo(new PublicKey(address), 'raw');
+    }, [address, entry, fetchAccountInfo]);
+
+    return React.useMemo(() => {
+        if (entry === undefined || entry.status === FetchStatus.Fetching) return { status: 'loading' };
+        if (entry.status === FetchStatus.FetchFailed || entry.data === undefined) return { status: 'failed' };
+
+        const { data, lamports, owner } = entry.data;
+        return {
+            content: decodePmpBufferAccount({
+                account: { data: data.raw, lamports, owner: owner.toBase58() },
+                config,
+            }),
+            status: 'ready',
+        };
+    }, [config, entry]);
+}

--- a/app/features/decode-instruction-pmp/ui/PmpDetailsCard.tsx
+++ b/app/features/decode-instruction-pmp/ui/PmpDetailsCard.tsx
@@ -1,0 +1,201 @@
+import { RawDataField } from '@components/shared/RawDataField';
+import { PublicKey, type SignatureResult, type TransactionInstruction } from '@solana/web3.js';
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { Address } from '@/app/components/common/Address';
+import { CodamaInstructionBody } from '@/app/components/instruction/codama/CodamaInstructionBody';
+import { InstructionCard } from '@/app/components/instruction/InstructionCard';
+import { toKitInstruction } from '@/app/shared/lib/web3js-compat';
+import { BaseTable } from '@/app/shared/ui/Table';
+
+import {
+    PMP_ACCOUNT_NAMES,
+    PMP_CODAMA_PROGRAM_NAME,
+    PMP_COMPRESSION_LABELS,
+    PMP_DATA_SOURCE_LABELS,
+    PMP_ENCODING_LABELS,
+    PMP_FORMAT_LABELS,
+    PMP_IX_TITLES,
+    PMP_WRITE_CHUNK_DOWNLOAD_FILENAME,
+} from '../lib/constants';
+import { decodePmpContentInstruction } from '../lib/decode-pmp-instruction';
+import type { PmpContentInstruction, PmpPayloadInstruction } from '../lib/types';
+import { PmpPayloadSection } from './PmpPayloadSection';
+
+/** The card table has three columns, matching PmpPayloadSection's own constant. */
+const CARD_TABLE_COLUMNS = 3;
+
+type PmpDetailsCardProps = {
+    ix: TransactionInstruction;
+    index: number;
+    result: SignatureResult;
+    innerCards?: JSX.Element[];
+    childIndex?: number;
+    InstructionCardComponent?: React.FC<Parameters<typeof InstructionCard>[0]>;
+    /**
+     * What to render when this instruction carries no decodable content, and the ErrorBoundary fallback. Each
+     * surface builds it: the IDL card when an IDL resolved, its own Unknown card otherwise. Injected rather than
+     * built here because `boundaries/dependencies` forbids this feature from importing
+     * `@features/decode-instruction-with-idl`, and because it keeps the card free of IDL concepts entirely.
+     */
+    fallback: React.ReactNode;
+};
+
+/**
+ * The single entry point for every Program Metadata Program instruction on both the tx page and the inspector.
+ *
+ * It is keyed on the program id rather than hung off `CodamaInstructionCard` for two reasons: a 4-byte
+ * header-only `setData` never produces a Codama decode at all, and the whole Codama path is gated on runtime
+ * PMP IDL resolution while the typed decoders this card uses ship with the installed library.
+ *
+ * `setData`, `initialize` and `write` get the custom render below. Everything else, including the six
+ * housekeeping instructions, renders `fallback`, which is what those instructions got before this card existed.
+ */
+export function PmpDetailsCard({ fallback, ...props }: PmpDetailsCardProps) {
+    // The payload decode already degrades locally rather than throwing, so this boundary only ever catches an
+    // unexpected failure in the tables above it. It must never be the path a decode failure takes.
+    return (
+        <ErrorBoundary fallback={<>{fallback}</>}>
+            <PmpDetailsCardBody {...props} fallback={fallback} />
+        </ErrorBoundary>
+    );
+}
+
+function PmpDetailsCardBody({
+    ix,
+    index,
+    result,
+    innerCards,
+    childIndex,
+    InstructionCardComponent = InstructionCard,
+    fallback,
+}: PmpDetailsCardProps) {
+    const content = React.useMemo(() => decodePmpContentInstruction(ix), [ix]);
+
+    if (!content) {
+        return <>{fallback}</>;
+    }
+
+    // `toKitInstruction` always returns an array, so no `?? []` is needed here.
+    const kitIx = toKitInstruction(ix);
+
+    return (
+        <InstructionCardComponent
+            title={`${PMP_CODAMA_PROGRAM_NAME}: ${PMP_IX_TITLES[content.kind]}`}
+            ix={ix}
+            index={index}
+            result={result}
+            innerCards={innerCards}
+            childIndex={childIndex}
+        >
+            <CodamaInstructionBody
+                programId={ix.programId}
+                programName={PMP_CODAMA_PROGRAM_NAME}
+                accounts={kitIx.accounts}
+                accountNames={PMP_ACCOUNT_NAMES[content.kind]}
+            />
+            {content.kind === 'write' ? (
+                <WriteRows content={content} />
+            ) : (
+                <>
+                    <ConfigRows content={content} />
+                    <PmpPayloadSection content={content} />
+                </>
+            )}
+        </InstructionCardComponent>
+    );
+}
+
+/**
+ * The decode hints, rendered from their library enums rather than as raw numbers.
+ *
+ * Every label lookup below is total, with no `Unknown (n)` fallback, because no unvalidated hint ever reaches
+ * here: the 5+ byte shapes come through a generated decoder that rejects an out-of-range enum byte, and the
+ * 4-byte header-only shape is narrowed by `PmpDecodeConfigStruct`. Both reject by falling through to the card's
+ * `fallback` instead. Adding a library variant breaks the build at the label maps, which is the intent.
+ */
+function ConfigRows({ content }: { content: PmpPayloadInstruction }) {
+    return (
+        <>
+            <ArgumentHeaderRow />
+            {content.kind === 'initialize' && <ValueRow testId="pmp-config-seed" label="Seed" value={content.seed} />}
+            <ValueRow
+                testId="pmp-config-encoding"
+                label="Encoding"
+                value={PMP_ENCODING_LABELS[content.config.encoding]}
+            />
+            <ValueRow
+                testId="pmp-config-compression"
+                label="Compression"
+                value={PMP_COMPRESSION_LABELS[content.config.compression]}
+            />
+            <ValueRow testId="pmp-config-format" label="Format" value={PMP_FORMAT_LABELS[content.config.format]} />
+            {content.dataSource !== undefined && (
+                <ValueRow
+                    testId="pmp-config-data-source"
+                    label="Data Source"
+                    value={PMP_DATA_SOURCE_LABELS[content.dataSource]}
+                />
+            )}
+        </>
+    );
+}
+
+/** `write` is a fragment with no hints, so it can never be decoded to a document on its own. */
+function WriteRows({ content }: { content: Extract<PmpContentInstruction, { kind: 'write' }> }) {
+    return (
+        <>
+            <ArgumentHeaderRow />
+            {/* The wire `offset` is LOGICAL, 0-based inside the payload. The 96-byte header offset is a raw
+                account-slicing detail and must not be added here. */}
+            <ValueRow testId="pmp-write-offset" label="Offset" value={String(content.offset)} />
+            {/* `&&` guards rather than a ternary chain: `unicorn/no-null` forbids a `null` tail in production. */}
+            {content.chunk !== undefined && (
+                <BaseTable.Row data-testid="pmp-write-chunk">
+                    <BaseTable.Cell colSpan={CARD_TABLE_COLUMNS}>
+                        <div className="mb-1.5">Chunk</div>
+                        {/* A chunk runs to ~1 KB, so it gets the same field the raw payload does: hex/base64
+                            tabs, byte count, copy, download and show-more, rather than a bare HexData grid. */}
+                        <RawDataField data={content.chunk} filename={PMP_WRITE_CHUNK_DOWNLOAD_FILENAME} />
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            )}
+            {content.chunk === undefined && content.sourceBuffer !== undefined && (
+                <BaseTable.Row data-testid="pmp-write-source-buffer">
+                    <BaseTable.Cell>Source Buffer</BaseTable.Cell>
+                    <BaseTable.Cell colSpan={2} className="text-right">
+                        <div className="flex flex-col items-end gap-1.5">
+                            <Address pubkey={new PublicKey(content.sourceBuffer)} alignRight link />
+                            <span className="text-xs text-neutral-500">
+                                The chunk was copied from this buffer, so it is not in this instruction.
+                            </span>
+                        </div>
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            )}
+        </>
+    );
+}
+
+function ArgumentHeaderRow() {
+    return (
+        <BaseTable.Row className="bg-dark-background text-dk-xs font-semibold uppercase tracking-[0.08em] text-dark-muted-foreground">
+            <BaseTable.Cell>Argument Name</BaseTable.Cell>
+            <BaseTable.Cell className="text-right" colSpan={2}>
+                Value
+            </BaseTable.Cell>
+        </BaseTable.Row>
+    );
+}
+
+function ValueRow({ label, testId, value }: { label: string; testId: string; value: string }) {
+    return (
+        <BaseTable.Row data-testid={testId}>
+            <BaseTable.Cell>{label}</BaseTable.Cell>
+            <BaseTable.Cell colSpan={2} className="text-right font-mono text-xs">
+                {value}
+            </BaseTable.Cell>
+        </BaseTable.Row>
+    );
+}

--- a/app/features/decode-instruction-pmp/ui/PmpDetailsCard.tsx
+++ b/app/features/decode-instruction-pmp/ui/PmpDetailsCard.tsx
@@ -21,9 +21,9 @@ import {
 } from '../lib/constants';
 import { decodePmpContentInstruction } from '../lib/decode-pmp-instruction';
 import type { PmpContentInstruction, PmpPayloadInstruction } from '../lib/types';
-import { PmpPayloadSection } from './PmpPayloadSection';
+import { DataPayloadSection } from './PmpPayloadSection';
 
-/** The card table has three columns, matching PmpPayloadSection's own constant. */
+/** The card table has three columns, matching DataPayloadSection's own constant. */
 const CARD_TABLE_COLUMNS = 3;
 
 type PmpDetailsCardProps = {
@@ -100,7 +100,7 @@ function PmpDetailsCardBody({
             ) : (
                 <>
                     <ConfigRows content={content} />
-                    <PmpPayloadSection content={content} />
+                    <DataPayloadSection content={content} />
                 </>
             )}
         </InstructionCardComponent>

--- a/app/features/decode-instruction-pmp/ui/PmpPayloadSection.tsx
+++ b/app/features/decode-instruction-pmp/ui/PmpPayloadSection.tsx
@@ -1,0 +1,215 @@
+import { RawDataField } from '@components/shared/RawDataField';
+import { PublicKey } from '@solana/web3.js';
+import { DataSource } from '@solana-program/program-metadata';
+import React from 'react';
+
+import { Address } from '@/app/components/common/Address';
+import { SolarizedJsonViewer } from '@/app/components/common/JsonViewer';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
+import { Alert } from '@/app/shared/ui/Alert';
+import { BaseTable } from '@/app/shared/ui/Table';
+
+import { pmpAnalytics } from '../lib/analytics';
+import {
+    PMP_ANALYTICS_IX_NAMES,
+    PMP_DATA_SOURCE_ANALYTICS_NAMES,
+    PMP_DECODED_DOWNLOAD_FILENAME,
+    PMP_DECODED_RENDER_CAP_BYTES,
+    PMP_FORMAT_ANALYTICS_NAMES,
+    PMP_JSON_COLLAPSE_DEPTH,
+    PMP_RAW_DOWNLOAD_FILENAME,
+} from '../lib/constants';
+import { decodePmpPayload } from '../lib/decode-pmp-payload';
+import type { PmpDecodedPayload, PmpPayloadInstruction } from '../lib/types';
+
+/** The card table has three columns, so every row in this section spans all of them. */
+const CARD_TABLE_COLUMNS = 3;
+
+/**
+ * The Decoded Content section of the PMP card. Owns every payload state.
+ * A decode failure degrades to the raw view plus an inline note INSIDE this section (it never throws
+ * out to the card's error boundary, which would discard the accounts and config tables), and an oversized
+ * payload renders a bounded view plus a download rather than the full document.
+ *
+ * Raw bytes always go through `RawDataField`, which owns the hex/base64 tabs, the byte count, copy, download,
+ * show-more and its own too-large guard. Nothing here reimplements those.
+ */
+export function PmpPayloadSection({
+    content,
+    cap = PMP_DECODED_RENDER_CAP_BYTES,
+}: {
+    content: PmpPayloadInstruction;
+    cap?: number;
+}) {
+    const { config, payload } = content;
+
+    // Decoded for every payload, not just `Direct`: `Url` and `External` also get the Decoded/Raw tabs, where the
+    // decoded panel applies the instruction's own encoding/compression hints to the POINTER bytes. That is a local
+    // decode, not pointer resolution - nothing is fetched and no account is read, which stays P3/P4 work.
+    const decoded = React.useMemo(
+        () => (payload ? decodePmpPayload({ cap, config, data: payload }) : undefined),
+        [cap, config, payload],
+    );
+
+    return (
+        <>
+            <BaseTable.Row>
+                <BaseTable.Cell colSpan={CARD_TABLE_COLUMNS} data-testid="pmp-payload-section">
+                    <PayloadBody content={content} decoded={decoded} />
+                </BaseTable.Cell>
+            </BaseTable.Row>
+        </>
+    );
+}
+
+function PayloadBody({ content, decoded }: { content: PmpPayloadInstruction; decoded: PmpDecodedPayload | undefined }) {
+    const { dataSource } = content;
+
+    // A 4-byte header-only setData updates the hints and leaves the stored bytes alone - not "no data", and not a decode failure.
+    // Only `setData` reaches here:
+    // `initialize` carries `dataSource` as a fixed struct field, so its decode always produces one.
+    if (dataSource === undefined) {
+        return (
+            <Alert variant="default" data-testid="pmp-header-only-note" className="mb-0">
+                This instruction updates the encoding, compression and format hints only. It carries no new payload.
+            </Alert>
+        );
+    }
+
+    if (content.payload === undefined) {
+        return <DeferredSourceNote content={content} />;
+    }
+
+    // A payload is present, which is exactly what the memo in the parent decodes on, so `decoded` is always set
+    // here. TypeScript cannot relate the two, so narrow once and keep `decoded` NON-optional in everything below -
+    // the impossible state must not cross a component boundary.
+    if (!decoded) return <></>;
+
+    return <DecodedTabs content={content} dataSource={dataSource} decoded={decoded} payload={content.payload} />;
+}
+
+/** setData from a foreign buffer, or initialize in-place: the bytes are not in this transaction (P2 territory). */
+function DeferredSourceNote({ content }: { content: PmpPayloadInstruction }) {
+    const account = content.kind === 'setData' ? content.sourceBuffer : content.metadataAccount;
+    const label = content.kind === 'setData' ? 'Source buffer' : 'Metadata account';
+
+    if (!account) {
+        return (
+            <Alert variant="default" data-testid="pmp-deferred-source-note" className="mb-0">
+                This instruction carries no payload bytes.
+            </Alert>
+        );
+    }
+
+    return (
+        <Alert variant="default" data-testid="pmp-deferred-source-note" className="mb-0">
+            <div className="flex w-full flex-row items-center gap-1.5">
+                <span>The payload was written to the {label} account</span>
+                <Address noNicknameEditing pubkey={new PublicKey(account)} link raw />
+            </div>
+        </Alert>
+    );
+}
+
+function DecodedTabs({
+    content,
+    dataSource,
+    decoded,
+    payload,
+}: {
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+    decoded: PmpDecodedPayload;
+    payload: Uint8Array;
+}) {
+    // `onValueChange` fires only on a reader-initiated switch, never for the tab selected on mount, so the
+    // default panel produces no event. Radix hands back a plain string, so narrow it to the tracked union.
+    const handleTabChange = (value: string) => {
+        if (value !== 'decoded' && value !== 'raw') return;
+        pmpAnalytics.trackTabOpened({
+            dataSource: PMP_DATA_SOURCE_ANALYTICS_NAMES[dataSource],
+            format: PMP_FORMAT_ANALYTICS_NAMES[content.config.format],
+            instruction: PMP_ANALYTICS_IX_NAMES[content.kind],
+            tab: value,
+        });
+    };
+
+    return (
+        <Tabs defaultValue="raw" onValueChange={handleTabChange}>
+            <TabsList>
+                <TabsTrigger value="raw">Raw</TabsTrigger>
+                <TabsTrigger value="decoded">Decoded</TabsTrigger>
+            </TabsList>
+            <TabsContent value="raw" className="pt-3">
+                <RawBytes payload={payload} />
+            </TabsContent>
+            <TabsContent value="decoded" className="pt-3">
+                <DecodedBody decoded={decoded} />
+            </TabsContent>
+        </Tabs>
+    );
+}
+
+function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
+    if (decoded.kind === 'failed') {
+        return (
+            <div className="flex flex-col gap-3">
+                <Alert variant="warning" data-testid="pmp-decode-error" className="mb-0">
+                    Could not decode this payload: {decoded.reason}
+                </Alert>
+            </div>
+        );
+    }
+
+    if (decoded.kind === 'oversized') {
+        return (
+            <div className="flex flex-col gap-3" data-testid="pmp-payload-oversized">
+                <Alert variant="warning" className="mb-0">
+                    Payload too large to render ({decoded.bytes.length} bytes). Copy or download it instead.
+                </Alert>
+                {/* The DECOMPRESSED bytes, which the sibling Raw tab cannot give you: that tab shows the on-chain
+                    payload, so for a compressed document it hands back the compressed bytes. This is the only
+                    route to the actual document once it is over the cap, which is what makes the copy/download
+                    the Alert promises real. RawDataField's own 1 KB guard means nothing this big is inlined. */}
+                <RawDataField data={decoded.bytes} filename={PMP_DECODED_DOWNLOAD_FILENAME} />
+            </div>
+        );
+    }
+
+    if (decoded.document.kind === 'json') {
+        return (
+            // `.string-value` is emitted by react-json-view - the arbitrary variant scopes break-all to its
+            // descendants only, matching how MetadataCard and AttestationDataCard wrap the same viewer.
+            <div data-testid="pmp-decoded-json" className="[&_.string-value]:break-all">
+                <SolarizedJsonViewer
+                    src={decoded.document.value}
+                    collapsed={PMP_JSON_COLLAPSE_DEPTH}
+                    name={false}
+                    enableClipboard={true}
+                    displayObjectSize={false}
+                    displayDataTypes={false}
+                />
+            </div>
+        );
+    }
+
+    // TODO: resolving DataSource.URL and DataSource.Externals lands in a later milestone.
+    // Currently text url gets rendered.
+    return (
+        <pre
+            data-testid="pmp-decoded-text"
+            className="mb-0 max-h-80 overflow-auto whitespace-pre-wrap break-words bg-heavy-metal-900 p-3 text-left text-xs"
+        >
+            {decoded.document.text}
+        </pre>
+    );
+}
+
+/** Thin wrapper so the section's own test id sits on a stable node around the shared field. */
+function RawBytes({ payload }: { payload: Uint8Array }) {
+    return (
+        <div data-testid="pmp-payload-raw">
+            <RawDataField data={payload} filename={PMP_RAW_DOWNLOAD_FILENAME} />
+        </div>
+    );
+}

--- a/app/features/decode-instruction-pmp/ui/PmpPayloadSection.tsx
+++ b/app/features/decode-instruction-pmp/ui/PmpPayloadSection.tsx
@@ -11,6 +11,7 @@ import { BaseTable } from '@/app/shared/ui/Table';
 
 import { pmpAnalytics } from '../lib/analytics';
 import {
+    PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME,
     PMP_ANALYTICS_IX_NAMES,
     PMP_DATA_SOURCE_ANALYTICS_NAMES,
     PMP_DECODED_DOWNLOAD_FILENAME,
@@ -20,7 +21,8 @@ import {
     PMP_RAW_DOWNLOAD_FILENAME,
 } from '../lib/constants';
 import { decodePmpPayload } from '../lib/decode-pmp-payload';
-import type { PmpDecodedPayload, PmpPayloadInstruction } from '../lib/types';
+import type { PmpAccountContent, PmpDecodedPayload, PmpPayloadInstruction } from '../lib/types';
+import { usePmpAccountPayload } from '../model/use-pmp-account-payload';
 
 /** The card table has three columns, so every row in this section spans all of them. */
 const CARD_TABLE_COLUMNS = 3;
@@ -34,7 +36,7 @@ const CARD_TABLE_COLUMNS = 3;
  * Raw bytes always go through `RawDataField`, which owns the hex/base64 tabs, the byte count, copy, download,
  * show-more and its own too-large guard. Nothing here reimplements those.
  */
-export function PmpPayloadSection({
+export function DataPayloadSection({
     content,
     cap = PMP_DECODED_RENDER_CAP_BYTES,
 }: {
@@ -70,14 +72,14 @@ function PayloadBody({ content, decoded }: { content: PmpPayloadInstruction; dec
     // `initialize` carries `dataSource` as a fixed struct field, so its decode always produces one.
     if (dataSource === undefined) {
         return (
-            <Alert variant="default" data-testid="pmp-header-only-note" className="mb-0">
+            <Alert variant="default" data-testid="pmp-header-only-note" className="!mb-0">
                 This instruction updates the encoding, compression and format hints only. It carries no new payload.
             </Alert>
         );
     }
 
     if (content.payload === undefined) {
-        return <DeferredSourceNote content={content} />;
+        return <AccountSourceSection content={content} dataSource={dataSource} />;
     }
 
     // A payload is present, which is exactly what the memo in the parent decodes on, so `decoded` is always set
@@ -85,42 +87,138 @@ function PayloadBody({ content, decoded }: { content: PmpPayloadInstruction; dec
     // the impossible state must not cross a component boundary.
     if (!decoded) return <></>;
 
-    return <DecodedTabs content={content} dataSource={dataSource} decoded={decoded} payload={content.payload} />;
+    return (
+        <DecodedTabs
+            content={content}
+            dataSource={dataSource}
+            decoded={decoded}
+            payload={content.payload}
+            source="instruction"
+        />
+    );
 }
 
-/** setData from a foreign buffer, or initialize in-place: the bytes are not in this transaction (P2 territory). */
-function DeferredSourceNote({ content }: { content: PmpPayloadInstruction }) {
+/**
+ * setData from a foreign buffer, or initialize in-place: the bytes are not in this transaction, they are in the
+ * account this instruction points at. That account can be read, so the section names it and reads it.
+ */
+function AccountSourceSection({ content, dataSource }: { content: PmpPayloadInstruction; dataSource: DataSource }) {
     const account = content.kind === 'setData' ? content.sourceBuffer : content.metadataAccount;
     const label = content.kind === 'setData' ? 'Source buffer' : 'Metadata account';
 
     if (!account) {
         return (
-            <Alert variant="default" data-testid="pmp-deferred-source-note" className="mb-0">
+            <Alert variant="default" data-testid="pmp-deferred-source-note" className="!mb-0">
                 This instruction carries no payload bytes.
             </Alert>
         );
     }
 
     return (
-        <Alert variant="default" data-testid="pmp-deferred-source-note" className="mb-0">
-            <div className="flex w-full flex-row items-center gap-1.5">
-                <span>The payload was written to the {label} account</span>
-                <Address noNicknameEditing pubkey={new PublicKey(account)} link raw />
-            </div>
-        </Alert>
+        <div className="flex flex-col gap-0">
+            <Alert variant="default" data-testid="pmp-deferred-source-note" className="!mb-0">
+                <div className="flex w-full flex-row items-center gap-2">
+                    <span>The payload was written to the {label} account</span>
+                    <Address noNicknameEditing pubkey={new PublicKey(account)} link raw />
+                </div>
+            </Alert>
+            <AccountPayload account={account} content={content} dataSource={dataSource} />
+        </div>
     );
 }
 
+/**
+ * Reads what the referenced account holds RIGHT NOW, on render.
+ * Deliberately not a reconstruction of what the viewed transaction wrote, no write-history replay.
+ */
+function AccountPayload({
+    account,
+    content,
+    dataSource,
+}: {
+    account: string;
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+}) {
+    // `content.config` comes from the card's own `decodePmpContentInstruction` memo, so it is referentially
+    // stable across renders, which is what keeps the hook from re-decoding the payload on every render.
+    const state = usePmpAccountPayload({ address: account, config: content.config });
+
+    if (state.status === 'loading') {
+        return (
+            <span data-testid="pmp-account-loading" className="text-xs text-neutral-500">
+                Reading account...
+            </span>
+        );
+    }
+
+    if (state.status === 'failed') {
+        return (
+            <Alert variant="warning" data-testid="pmp-account-failed" className="!mb-0">
+                Could not read this account. The RPC request failed.
+            </Alert>
+        );
+    }
+
+    return <AccountContentBody content={content} dataSource={dataSource} result={state.content} />;
+}
+
+function AccountContentBody({
+    content,
+    dataSource,
+    result,
+}: {
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+    result: PmpAccountContent;
+}) {
+    if (result.kind === 'absent') {
+        return (
+            <Alert variant="default" data-testid="pmp-account-absent" className="!mb-0">
+                Account does not exist on chain.
+            </Alert>
+        );
+    }
+
+    if (result.kind === 'unreadable') {
+        return (
+            <Alert variant="warning" data-testid="pmp-account-unreadable" className="!mb-0">
+                Could not read account content: {result.reason}.
+            </Alert>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-0">
+            <DecodedTabs
+                content={content}
+                dataSource={dataSource}
+                decoded={result.payload}
+                payload={result.body}
+                source="account"
+            />
+        </div>
+    );
+}
+
+/**
+ * `source` says where `payload` came from, and it settles which panel opens first: the instruction's own bytes
+ * are already on screen unasked, so they open Raw, while account content was fetched on an explicit request for
+ * the decoded document and opens Decoded. It also rides along on the tab event, so the two panels' switch counts
+ * stay separable despite their different starting tabs.
+ */
 function DecodedTabs({
     content,
     dataSource,
     decoded,
     payload,
+    source,
 }: {
     content: PmpPayloadInstruction;
     dataSource: DataSource;
     decoded: PmpDecodedPayload;
     payload: Uint8Array;
+    source: 'account' | 'instruction';
 }) {
     // `onValueChange` fires only on a reader-initiated switch, never for the tab selected on mount, so the
     // default panel produces no event. Radix hands back a plain string, so narrow it to the tracked union.
@@ -130,18 +228,19 @@ function DecodedTabs({
             dataSource: PMP_DATA_SOURCE_ANALYTICS_NAMES[dataSource],
             format: PMP_FORMAT_ANALYTICS_NAMES[content.config.format],
             instruction: PMP_ANALYTICS_IX_NAMES[content.kind],
+            source,
             tab: value,
         });
     };
 
     return (
-        <Tabs defaultValue="raw" onValueChange={handleTabChange}>
+        <Tabs defaultValue={source === 'account' ? 'decoded' : 'raw'} onValueChange={handleTabChange}>
             <TabsList>
                 <TabsTrigger value="raw">Raw</TabsTrigger>
                 <TabsTrigger value="decoded">Decoded</TabsTrigger>
             </TabsList>
             <TabsContent value="raw" className="pt-3">
-                <RawBytes payload={payload} />
+                <RawBytes payload={payload} source={source} />
             </TabsContent>
             <TabsContent value="decoded" className="pt-3">
                 <DecodedBody decoded={decoded} />
@@ -153,8 +252,8 @@ function DecodedTabs({
 function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
     if (decoded.kind === 'failed') {
         return (
-            <div className="flex flex-col gap-3">
-                <Alert variant="warning" data-testid="pmp-decode-error" className="mb-0">
+            <div className="flex flex-col gap-0">
+                <Alert variant="warning" data-testid="pmp-decode-error" className="!mb-0">
                     Could not decode this payload: {decoded.reason}
                 </Alert>
             </div>
@@ -163,8 +262,8 @@ function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
 
     if (decoded.kind === 'oversized') {
         return (
-            <div className="flex flex-col gap-3" data-testid="pmp-payload-oversized">
-                <Alert variant="warning" className="mb-0">
+            <div className="flex flex-col gap-0" data-testid="pmp-payload-oversized">
+                <Alert variant="warning" className="!mb-0">
                     Payload too large to render ({decoded.bytes.length} bytes). Copy or download it instead.
                 </Alert>
                 {/* The DECOMPRESSED bytes, which the sibling Raw tab cannot give you: that tab shows the on-chain
@@ -193,8 +292,7 @@ function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
         );
     }
 
-    // TODO: resolving DataSource.URL and DataSource.Externals lands in a later milestone.
-    // Currently text url gets rendered.
+    // TODO: resolve DataSource.URL and DataSource.Externals lands in a later milestone. Currently only text url gets rendered.
     return (
         <pre
             data-testid="pmp-decoded-text"
@@ -206,10 +304,14 @@ function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
 }
 
 /** Thin wrapper so the section's own test id sits on a stable node around the shared field. */
-function RawBytes({ payload }: { payload: Uint8Array }) {
+function RawBytes({ payload, source }: { payload: Uint8Array; source: 'account' | 'instruction' }) {
+    const isAccount = source === 'account';
     return (
-        <div data-testid="pmp-payload-raw">
-            <RawDataField data={payload} filename={PMP_RAW_DOWNLOAD_FILENAME} />
+        <div data-testid={isAccount ? 'pmp-account-raw' : 'pmp-payload-raw'}>
+            <RawDataField
+                data={payload}
+                filename={isAccount ? PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME : PMP_RAW_DOWNLOAD_FILENAME}
+            />
         </div>
     );
 }

--- a/app/features/decode-instruction-pmp/ui/__stories__/PmpDetailsCard.stories.tsx
+++ b/app/features/decode-instruction-pmp/ui/__stories__/PmpDetailsCard.stories.tsx
@@ -1,0 +1,185 @@
+import { PmpDetailsCard } from '@features/decode-instruction-pmp';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getInitializeInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+    getWriteInstructionDataEncoder,
+    packDirectData,
+    PROGRAM_METADATA_PROGRAM_ADDRESS,
+} from '@solana-program/program-metadata';
+import {
+    nextjsParameters,
+    withCluster,
+    withMockTransactions,
+    withScrollAnchor,
+    withTokenInfoBatch,
+} from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+const PROGRAM_ID = new PublicKey(PROGRAM_METADATA_PROGRAM_ADDRESS);
+
+const IDL_DOC = JSON.stringify({
+    instructions: [{ name: 'initialize' }],
+    name: 'company_program',
+    version: '1.0.0',
+});
+
+// Account addresses are labelled positionally from the card's static name table, so any keys work here.
+function makeIx(data: Uint8Array, accountCount: number): TransactionInstruction {
+    return new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: Array.from({ length: accountCount }, () => ({
+            isSigner: false,
+            isWritable: true,
+            pubkey: PublicKey.unique(),
+        })),
+        programId: PROGRAM_ID,
+    });
+}
+
+function setDataIx({
+    compression,
+    content,
+    dataSource = DataSource.Direct,
+    format,
+}: {
+    compression: Compression;
+    content: string;
+    dataSource?: DataSource;
+    format: Format;
+}) {
+    const packed = packDirectData({ compression, content, encoding: Encoding.Utf8 });
+    return makeIx(
+        getSetDataInstructionDataEncoder().encode({
+            compression: packed.compression,
+            data: packed.data,
+            dataSource,
+            encoding: packed.encoding,
+            format,
+        }) as Uint8Array,
+        5,
+    );
+}
+
+const meta = {
+    component: PmpDetailsCard,
+    decorators: [withCluster, withScrollAnchor, withTokenInfoBatch, withMockTransactions],
+    parameters: nextjsParameters,
+    tags: ['autodocs', 'test'],
+    title: 'Features/DecodeInstructionPmp/PmpDetailsCard',
+} satisfies Meta<typeof PmpDetailsCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// `fallback` is never exercised by these stories - every fixture below is a content instruction, so the card
+// always takes its custom-render path. `null` is fine here: stories are exempt from `unicorn/no-null`.
+const baseArgs = {
+    fallback: null,
+    index: 0,
+    result: { err: null },
+};
+
+export const SetDataInlineJson: Story = {
+    args: { ...baseArgs, ix: setDataIx({ compression: Compression.None, content: IDL_DOC, format: Format.Json }) },
+};
+
+export const SetDataZlibCompressedJson: Story = {
+    args: { ...baseArgs, ix: setDataIx({ compression: Compression.Zlib, content: IDL_DOC, format: Format.Json }) },
+};
+
+export const SetDataYamlVerbatim: Story = {
+    args: {
+        ...baseArgs,
+        ix: setDataIx({
+            compression: Compression.None,
+            content: 'name: company\nversion: 1.0.0\n',
+            format: Format.Yaml,
+        }),
+    },
+};
+
+export const SetDataEncodingNoneAsHex: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.None,
+                data: new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33]),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.None,
+                format: Format.None,
+            }) as Uint8Array,
+            5,
+        ),
+    },
+};
+
+// The 4-byte header-only shape. The generated encoder cannot build it, so the bytes are a literal:
+// discriminator 3, encoding Utf8, compression None, format Json.
+export const SetDataHeaderOnly: Story = {
+    args: { ...baseArgs, ix: makeIx(new Uint8Array([3, 1, 0, 1]), 5) },
+};
+
+// A Zlib stream that is not a Zlib stream, so the local decode fallback renders instead of the document.
+export const SetDataDecodeFailure: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.Zlib,
+                data: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+            }) as Uint8Array,
+            5,
+        ),
+    },
+};
+
+export const SetDataUrlSource: Story = {
+    args: {
+        ...baseArgs,
+        ix: setDataIx({
+            compression: Compression.None,
+            content: 'https://example.com/company-idl.json',
+            dataSource: DataSource.Url,
+            format: Format.Json,
+        }),
+    },
+};
+
+export const InitializeInlineJson: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getInitializeInstructionDataEncoder().encode({
+                compression: Compression.None,
+                data: new TextEncoder().encode(IDL_DOC),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+                seed: 'idl',
+            }) as Uint8Array,
+            5,
+        ),
+    },
+};
+
+export const WriteChunk: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getWriteInstructionDataEncoder().encode({
+                data: new TextEncoder().encode('{"instructions":['),
+                offset: 0,
+            }) as Uint8Array,
+            3,
+        ),
+    },
+};

--- a/app/features/decode-instruction-pmp/ui/__tests__/DataPayloadSection.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/DataPayloadSection.spec.tsx
@@ -1,15 +1,39 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
-import { Compression, DataSource, Encoding, Format, packDirectData } from '@solana-program/program-metadata';
+import type { Account } from '@providers/accounts';
+import { FetchStatus } from '@providers/cache';
+import type { Address } from '@solana/kit';
+import { PublicKey } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getBufferEncoder,
+    packDirectData,
+} from '@solana-program/program-metadata';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { trackEvent } from '@/app/shared/lib/analytics';
 
+import { PMP_ADDRESS } from '../../lib/constants';
 import type { PmpPayloadInstruction } from '../../lib/types';
-import { PmpPayloadSection } from '../PmpPayloadSection';
+import { DataPayloadSection } from '../DataPayloadSection';
 
 vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+// The on-demand account read goes through the shared accounts provider, so the section is exercised against a
+// controllable cache entry rather than a live RPC.
+const { mockFetchAccountInfo, mockUseAccountInfo } = vi.hoisted(() => ({
+    mockFetchAccountInfo: vi.fn(),
+    mockUseAccountInfo: vi.fn(),
+}));
+
+vi.mock('@providers/accounts', () => ({
+    useAccountInfo: mockUseAccountInfo,
+    useFetchAccountInfo: () => mockFetchAccountInfo,
+}));
 
 // The real viewer is a next/dynamic import with ssr: false, so it resolves asynchronously and would force every
 // assertion to be awaited. Stub it the way MetadataCard.spec.tsx does, which is the established pattern.
@@ -33,13 +57,45 @@ function renderSection(content: PmpPayloadInstruction, cap?: number) {
     return render(
         <table>
             <tbody>
-                <PmpPayloadSection content={content} cap={cap} />
+                <DataPayloadSection content={content} cap={cap} />
             </tbody>
         </table>,
     );
 }
 
 const JSON_CONFIG = { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json };
+
+const BUFFER_ADDRESS = '4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw';
+
+/** A `setData` whose bytes live in a foreign buffer, which is the shape that offers the account read. */
+const DEFERRED_SET_DATA: PmpPayloadInstruction = {
+    config: JSON_CONFIG,
+    dataSource: DataSource.Direct,
+    kind: 'setData',
+    sourceBuffer: BUFFER_ADDRESS,
+};
+
+/** The library's own encoder, so the fixture carries the real 96-byte Buffer header. */
+function bufferAccountData(body: Uint8Array): Uint8Array {
+    return getBufferEncoder().encode({
+        authority: BUFFER_ADDRESS as Address,
+        canonical: true,
+        data: body,
+        program: BUFFER_ADDRESS as Address,
+        seed: 'idl',
+    }) as Uint8Array;
+}
+
+function fetchedEntry(raw: Uint8Array | undefined, overrides: { lamports?: number; owner?: string } = {}) {
+    const data: Account = {
+        data: { raw },
+        executable: false,
+        lamports: overrides.lamports ?? 1_000_000,
+        owner: new PublicKey(overrides.owner ?? PMP_ADDRESS),
+        pubkey: new PublicKey(BUFFER_ADDRESS),
+    };
+    return { data, status: FetchStatus.Fetched };
+}
 
 /**
  * The section opens on the Raw tab and Radix unmounts the inactive panel, so nothing decoded is in the DOM until
@@ -49,9 +105,13 @@ async function openDecodedTab() {
     await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
 }
 
-describe('PmpPayloadSection', () => {
+describe('DataPayloadSection', () => {
     beforeEach(() => {
         vi.mocked(trackEvent).mockClear();
+        mockFetchAccountInfo.mockClear();
+        // Nothing in the cache, which is the state every test starts from - a test that needs a resolved read
+        // sets its own return value.
+        mockUseAccountInfo.mockReset().mockReturnValue(undefined);
     });
 
     it('should render an inline Direct JSON payload through the JSON viewer', async () => {
@@ -256,6 +316,7 @@ describe('PmpPayloadSection', () => {
             data_source: 'direct',
             format: 'json',
             instruction: 'set_data',
+            source: 'instruction',
             tab: 'decoded',
         });
     });
@@ -292,5 +353,68 @@ describe('PmpPayloadSection', () => {
         renderSection({ config: JSON_CONFIG, kind: 'setData' });
 
         expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('should read the referenced account on render, as raw bytes', () => {
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(mockFetchAccountInfo).toHaveBeenCalledTimes(1);
+        const [pubkey, dataMode] = mockFetchAccountInfo.mock.calls[0];
+        expect(pubkey.toBase58()).toBe(BUFFER_ADDRESS);
+        // `raw` and not `parsed`: the provider only keeps raw bytes for accounts it could not parse natively, and
+        // a PMP buffer has to arrive as bytes for the generated decoder to see its header at all.
+        expect(dataMode).toBe('raw');
+        expect(screen.getByTestId('pmp-account-loading')).toBeInTheDocument();
+    });
+
+    it('should decode the referenced buffer content once the read resolves', () => {
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(bufferAccountData(pack(DOC, Compression.None))));
+        renderSection(DEFERRED_SET_DATA);
+
+        // Account content opens on the DECODED panel, unlike an inline payload, which opens Raw.
+        expect(screen.getByTestId('pmp-decoded-json')).toHaveTextContent('"name": "company"');
+        expect(screen.getByTestId('pmp-account-current-state-note')).toHaveTextContent(/current on-chain content/i);
+        expect(screen.getByRole('tab', { name: 'Raw' })).toBeInTheDocument();
+    });
+
+    it('should say the account is gone rather than fail when the buffer was closed', () => {
+        // The provider's closed-account shape, and the common outcome on a historical setData: the client closes
+        // the source buffer in the same flow to reclaim its rent.
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(new Uint8Array(0), { lamports: 0 }));
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(screen.getByTestId('pmp-account-absent')).toHaveTextContent(/does not exist on chain/i);
+        expect(screen.queryByTestId('pmp-account-unreadable')).not.toBeInTheDocument();
+    });
+
+    it('should warn when the referenced account is not owned by the Program Metadata Program', () => {
+        mockUseAccountInfo.mockReturnValue(
+            fetchedEntry(bufferAccountData(pack(DOC, Compression.None)), { owner: BUFFER_ADDRESS }),
+        );
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(screen.getByTestId('pmp-account-unreadable')).toHaveTextContent(BUFFER_ADDRESS);
+        expect(screen.queryByTestId('pmp-decoded-json')).not.toBeInTheDocument();
+    });
+
+    it('should surface an RPC failure as its own state', () => {
+        mockUseAccountInfo.mockReturnValue({ status: FetchStatus.FetchFailed });
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(screen.getByTestId('pmp-account-failed')).toBeInTheDocument();
+    });
+
+    it('should mark a tab switch on account content as its own source', async () => {
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(bufferAccountData(pack(DOC, Compression.None))));
+        renderSection(DEFERRED_SET_DATA);
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+        // Without `source` the account panel's switches would be indistinguishable from the inline panel's, which
+        // matters because the two open on opposite default tabs.
+        expect(trackEvent).toHaveBeenCalledWith(
+            'pmp_data_tab_opened',
+            expect.objectContaining({ source: 'account', tab: 'raw' }),
+        );
     });
 });

--- a/app/features/decode-instruction-pmp/ui/__tests__/PmpDetailsCard.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/PmpDetailsCard.spec.tsx
@@ -19,7 +19,7 @@ import { PmpDetailsCard } from '../PmpDetailsCard';
 
 vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
 
-// See PmpPayloadSection.spec.tsx: the real viewer is a next/dynamic ssr:false import, so it resolves async.
+// See DataPayloadSection.spec.tsx: the real viewer is a next/dynamic ssr:false import, so it resolves async.
 vi.mock('@/app/components/common/JsonViewer', () => ({
     SolarizedJsonViewer: ({ src }: { src: unknown }) => (
         <div data-testid="json-viewer">{JSON.stringify(src, null, 2)}</div>
@@ -67,7 +67,7 @@ function renderCard(ix: TransactionInstruction) {
     );
 }
 
-/** The payload section opens on the Raw tab and Radix unmounts the inactive panel. See PmpPayloadSection.spec. */
+/** The payload section opens on the Raw tab and Radix unmounts the inactive panel. See DataPayloadSection.spec. */
 async function openDecodedTab() {
     await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
 }

--- a/app/features/decode-instruction-pmp/ui/__tests__/PmpDetailsCard.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/PmpDetailsCard.spec.tsx
@@ -1,0 +1,206 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getAllocateInstructionDataEncoder,
+    getInitializeInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+    getWriteInstructionDataEncoder,
+    packDirectData,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PMP_ADDRESS } from '../../lib/constants';
+import { PmpDetailsCard } from '../PmpDetailsCard';
+
+vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+// See PmpPayloadSection.spec.tsx: the real viewer is a next/dynamic ssr:false import, so it resolves async.
+vi.mock('@/app/components/common/JsonViewer', () => ({
+    SolarizedJsonViewer: ({ src }: { src: unknown }) => (
+        <div data-testid="json-viewer">{JSON.stringify(src, null, 2)}</div>
+    ),
+}));
+
+vi.mock('@/app/components/instruction/InstructionCard', () => ({
+    InstructionCard: ({ children, title }: { children: React.ReactNode; title: string }) => (
+        <div data-testid="instruction-card">
+            <div data-testid="instruction-card-title">{title}</div>
+            <table>
+                <tbody>{children}</tbody>
+            </table>
+        </div>
+    ),
+}));
+
+vi.mock('@/app/components/common/Address', () => ({
+    Address: ({ pubkey, overrideText }: { pubkey: PublicKey; overrideText?: string }) => (
+        <div data-testid="address">{overrideText ?? pubkey.toBase58()}</div>
+    ),
+}));
+
+vi.mock('@/app/components/common/Copyable', () => ({
+    Copyable: ({ children }: { children: React.ReactNode }) => <div data-testid="copyable">{children}</div>,
+}));
+
+const PMP = new PublicKey(PMP_ADDRESS);
+const AUTHORITY = new PublicKey('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u');
+const METADATA_PDA = new PublicKey('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8');
+const FOREIGN_BUFFER = new PublicKey('4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw');
+const DOC = '{"name":"company","version":"1.0.0"}';
+
+function makeIx(data: Uint8Array, accounts: PublicKey[]): TransactionInstruction {
+    return new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: accounts.map(pubkey => ({ isSigner: false, isWritable: true, pubkey })),
+        programId: PMP,
+    });
+}
+
+function renderCard(ix: TransactionInstruction) {
+    return render(
+        <PmpDetailsCard ix={ix} index={0} result={{ err: null }} fallback={<div data-testid="injected-fallback" />} />,
+    );
+}
+
+/** The payload section opens on the Raw tab and Radix unmounts the inactive panel. See PmpPayloadSection.spec. */
+async function openDecodedTab() {
+    await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+}
+
+describe('PmpDetailsCard', () => {
+    it('should render a titled Set Data card with named accounts, config rows and the decoded document', async () => {
+        const packed = packDirectData({ compression: Compression.Zlib, content: DOC, encoding: Encoding.Utf8 });
+        const ix = makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: packed.compression,
+                data: packed.data,
+                dataSource: DataSource.Direct,
+                encoding: packed.encoding,
+                format: Format.Json,
+            }) as Uint8Array,
+            [METADATA_PDA, AUTHORITY, PMP, PMP, PMP],
+        );
+
+        renderCard(ix);
+        await openDecodedTab();
+
+        // Labels mirror CodamaInstructionCard's style on purpose, so an `allocate` card in the same transaction
+        // reads identically. 'ProgramData' is not a typo for 'Program Data'.
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: SetData');
+        expect(screen.getByTestId('account-row-0')).toHaveTextContent('Metadata');
+        expect(screen.getByTestId('account-row-1')).toHaveTextContent('Authority');
+        expect(screen.getByTestId('account-row-4')).toHaveTextContent('ProgramData');
+        expect(screen.getByTestId('pmp-config-encoding')).toHaveTextContent('UTF-8');
+        expect(screen.getByTestId('pmp-config-compression')).toHaveTextContent('Zlib');
+        expect(screen.getByTestId('pmp-config-format')).toHaveTextContent('JSON');
+        expect(screen.getByTestId('pmp-config-data-source')).toHaveTextContent('Direct');
+        expect(screen.getByTestId('json-viewer')).toHaveTextContent('company');
+    });
+
+    it('should render the updated hints and the header-only note for a 4-byte setData', () => {
+        renderCard(makeIx(new Uint8Array([3, 1, 0, 1]), [METADATA_PDA, AUTHORITY, PMP]));
+
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: SetData');
+        expect(screen.getByTestId('pmp-config-format')).toHaveTextContent('JSON');
+        expect(screen.getByTestId('pmp-header-only-note')).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-config-data-source')).not.toBeInTheDocument();
+    });
+
+    it('should render an Initialize card with its seed and decoded document', async () => {
+        const ix = makeIx(
+            getInitializeInstructionDataEncoder().encode({
+                compression: Compression.None,
+                data: new TextEncoder().encode(DOC),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+                seed: 'idl',
+            }) as Uint8Array,
+            [METADATA_PDA, AUTHORITY, PMP, PMP, PMP],
+        );
+
+        renderCard(ix);
+        await openDecodedTab();
+
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: Initialize');
+        expect(screen.getByTestId('pmp-config-seed')).toHaveTextContent('idl');
+        expect(screen.getByTestId('account-row-4')).toHaveTextContent('System');
+        expect(screen.getByTestId('json-viewer')).toHaveTextContent('1.0.0');
+    });
+
+    it('should show a Write card with its offset and raw chunk and no decoded document', () => {
+        const ix = makeIx(
+            getWriteInstructionDataEncoder().encode({
+                data: new Uint8Array([0xde, 0xad]),
+                offset: 96,
+            }) as Uint8Array,
+            [FOREIGN_BUFFER, AUTHORITY, PMP],
+        );
+
+        renderCard(ix);
+
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: Write');
+        expect(screen.getByTestId('pmp-write-offset')).toHaveTextContent('96');
+        // RawDataField owns the hex grid and the byte count inside the Chunk row.
+        expect(screen.getByTestId('pmp-write-chunk')).toHaveTextContent('de ad');
+        expect(screen.getByTestId('pmp-write-chunk')).toHaveTextContent('2 bytes');
+        expect(screen.queryByTestId('json-viewer')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-payload-section')).not.toBeInTheDocument();
+    });
+
+    it('should show the source buffer note for a Write that copies from another buffer', () => {
+        const ix = makeIx(getWriteInstructionDataEncoder().encode({ offset: 0 }) as Uint8Array, [
+            METADATA_PDA,
+            AUTHORITY,
+            FOREIGN_BUFFER,
+        ]);
+
+        renderCard(ix);
+
+        expect(screen.getByTestId('pmp-write-source-buffer')).toHaveTextContent(FOREIGN_BUFFER.toBase58());
+        expect(screen.queryByTestId('pmp-write-chunk')).not.toBeInTheDocument();
+    });
+
+    it('should render the injected fallback for a housekeeping instruction', () => {
+        const ix = makeIx(getAllocateInstructionDataEncoder().encode({ seed: 'idl' }) as Uint8Array, [
+            METADATA_PDA,
+            AUTHORITY,
+        ]);
+
+        renderCard(ix);
+
+        expect(screen.getByTestId('injected-fallback')).toBeInTheDocument();
+        expect(screen.queryByTestId('instruction-card')).not.toBeInTheDocument();
+    });
+
+    // This is the card-level guarantee the p1 spec's decode-failure scenario is actually about: "the
+    // instruction's account table and argument table SHALL still render unchanged". Task 4 proves the fallback
+    // renders inside the section, and the first test here proves the tables render on the happy path, but only
+    // this case proves BOTH hold at once - that the failure never reaches the ErrorBoundary and swaps the card.
+    it('should keep the account and config tables when the payload fails to decode', async () => {
+        const ix = makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.Zlib, // a Zlib stream that is not one
+                data: new Uint8Array([1, 2, 3, 4]),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+            }) as Uint8Array,
+            [METADATA_PDA, AUTHORITY, PMP, PMP, PMP],
+        );
+
+        renderCard(ix);
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decode-error')).toBeInTheDocument();
+        expect(screen.getByTestId('account-row-0')).toHaveTextContent('Metadata');
+        expect(screen.getByTestId('pmp-config-encoding')).toHaveTextContent('UTF-8');
+        expect(screen.getByTestId('pmp-config-compression')).toHaveTextContent('Zlib');
+        expect(screen.queryByTestId('injected-fallback')).not.toBeInTheDocument();
+    });
+});

--- a/app/features/decode-instruction-pmp/ui/__tests__/PmpPayloadSection.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/PmpPayloadSection.spec.tsx
@@ -1,0 +1,296 @@
+/* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { Compression, DataSource, Encoding, Format, packDirectData } from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { trackEvent } from '@/app/shared/lib/analytics';
+
+import type { PmpPayloadInstruction } from '../../lib/types';
+import { PmpPayloadSection } from '../PmpPayloadSection';
+
+vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+// The real viewer is a next/dynamic import with ssr: false, so it resolves asynchronously and would force every
+// assertion to be awaited. Stub it the way MetadataCard.spec.tsx does, which is the established pattern.
+vi.mock('@/app/components/common/JsonViewer', () => ({
+    SolarizedJsonViewer: ({ src }: { src: unknown }) => (
+        <div data-testid="json-viewer">{JSON.stringify(src, null, 2)}</div>
+    ),
+}));
+
+vi.mock('@/app/components/common/Address', () => ({
+    Address: ({ pubkey }: { pubkey: { toBase58(): string } }) => <div data-testid="address">{pubkey.toBase58()}</div>,
+}));
+
+const DOC = '{"name":"company","version":"1.0.0"}';
+
+function pack(content: string, compression: Compression): Uint8Array {
+    return packDirectData({ compression, content, encoding: Encoding.Utf8 }).data as Uint8Array;
+}
+
+function renderSection(content: PmpPayloadInstruction, cap?: number) {
+    return render(
+        <table>
+            <tbody>
+                <PmpPayloadSection content={content} cap={cap} />
+            </tbody>
+        </table>,
+    );
+}
+
+const JSON_CONFIG = { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json };
+
+/**
+ * The section opens on the Raw tab and Radix unmounts the inactive panel, so nothing decoded is in the DOM until
+ * the reader switches. Every assertion about decoded content has to go through this first.
+ */
+async function openDecodedTab() {
+    await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+}
+
+describe('PmpPayloadSection', () => {
+    beforeEach(() => {
+        vi.mocked(trackEvent).mockClear();
+    });
+
+    it('should render an inline Direct JSON payload through the JSON viewer', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+        await openDecodedTab();
+
+        const viewer = screen.getByTestId('json-viewer');
+        expect(viewer).toHaveTextContent('company');
+        expect(viewer).toHaveTextContent('1.0.0');
+        expect(screen.getByTestId('pmp-decoded-json')).toBeInTheDocument();
+    });
+
+    it('should also offer the raw encoded bytes on a Raw tab', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+        // RawDataField owns the hex grid and the byte count, so asserting on them proves it is wired up.
+        const raw = screen.getByTestId('pmp-payload-raw');
+        expect(raw).toHaveTextContent('de ad be ef');
+        expect(raw).toHaveTextContent('4 bytes');
+        expect(screen.getByRole('tab', { name: 'Hex' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Base64' })).toBeInTheDocument();
+    });
+
+    it('should decompress a Zlib payload before rendering it', async () => {
+        renderSection({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.Zlib),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('json-viewer')).toHaveTextContent('1.0.0');
+    });
+
+    it('should render a Yaml payload as verbatim text rather than through the viewer', async () => {
+        renderSection({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Yaml },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack('name: company\n', Compression.None),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('name: company');
+        expect(screen.queryByTestId('json-viewer')).not.toBeInTheDocument();
+    });
+
+    it('should render an Encoding None payload as hex text rather than as characters', async () => {
+        renderSection({
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('deadbeef');
+    });
+
+    it('should render a Json-hinted payload that does not parse as verbatim text', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack('{not json', Compression.None),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('{not json');
+        expect(screen.queryByTestId('json-viewer')).not.toBeInTheDocument();
+    });
+
+    it('should state that a header-only setData carries no new payload without surfacing a decode failure', () => {
+        renderSection({ config: JSON_CONFIG, kind: 'setData' });
+
+        expect(screen.getByTestId('pmp-header-only-note')).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decode-error')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decoded-json')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+    });
+
+    it('should show the source buffer address when setData carries no inline payload', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            sourceBuffer: '4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw',
+        });
+
+        expect(screen.getByTestId('pmp-deferred-source-note')).toBeInTheDocument();
+        expect(screen.getByTestId('address')).toHaveTextContent('4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw');
+    });
+
+    it('should show the metadata account when initialize is the in-place shape', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'initialize',
+            metadataAccount: '2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8',
+            seed: 'idl',
+        });
+
+        expect(screen.getByTestId('pmp-deferred-source-note')).toBeInTheDocument();
+        expect(screen.getByTestId('address')).toHaveTextContent('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8');
+    });
+
+    it('should render an External payload through the same tabs, opening on the raw bytes', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.External,
+            kind: 'setData',
+            payload: new Uint8Array(40),
+        });
+
+        // A non-Direct source gets no special-cased note in this section: the card's `Data Source` config row
+        // already names it, so the section stays a plain bytes view rather than repeating the same fact.
+        expect(screen.getByTestId('pmp-payload-raw')).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Decoded' })).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decoded-json')).not.toBeInTheDocument();
+    });
+
+    it('should render a Url payload pointer as decoded text without resolving it', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Url,
+            kind: 'setData',
+            payload: new TextEncoder().encode('https://example.com/idl.json'),
+        });
+        await openDecodedTab();
+
+        // The decoded panel applies the instruction's own hints to the POINTER bytes - a local decode, not
+        // resolution. For a Url payload that is the URL text itself, and nothing is fetched or linked.
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('https://example.com/idl.json');
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should fall back to the raw view with an inline error note when the payload fails to decode', async () => {
+        renderSection({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: new Uint8Array([1, 2, 3, 4]),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decode-error')).toHaveTextContent('incorrect header check');
+        expect(screen.queryByTestId('pmp-decoded-json')).not.toBeInTheDocument();
+        // The failed panel no longer repeats a raw view of its own - Raw is a sibling tab, so the bytes stay one
+        // click away. Assert the escape hatch is still reachable rather than that it is mounted right now.
+        expect(screen.getByRole('tab', { name: 'Raw' })).toBeInTheDocument();
+    });
+
+    it('should render a bounded view with the byte count and a download when the payload exceeds the cap', async () => {
+        renderSection(
+            {
+                config: JSON_CONFIG,
+                dataSource: DataSource.Direct,
+                kind: 'setData',
+                payload: new Uint8Array(2048).fill(0x41),
+            },
+            8,
+        );
+        await openDecodedTab();
+
+        const oversized = screen.getByTestId('pmp-payload-oversized');
+        expect(oversized).toHaveTextContent(/too large/i);
+        // The DECOMPRESSED size, which is what the cap is measured on - the on-chain payload here is 2048 bytes
+        // uncompressed, so the two happen to match, but the number reported is the decoded one.
+        expect(oversized).toHaveTextContent('2048 bytes');
+        expect(screen.queryByTestId('pmp-decoded-json')).not.toBeInTheDocument();
+        // The panel carries its OWN copy/download over the decompressed bytes. The sibling Raw tab is not a
+        // substitute: that one serves the on-chain payload, so for a compressed document it would hand back the
+        // compressed bytes. Without this the Alert's "Copy or download it instead" would point at nothing.
+        expect(oversized).toHaveTextContent(/use download\/copy/i);
+        expect(screen.getByLabelText('Download')).toBeInTheDocument();
+    });
+
+    it('should emit a tab analytics event when the reader opens the decoded tab', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', {
+            data_source: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            tab: 'decoded',
+        });
+    });
+
+    it('should carry the data source when the tabs render for a non-Direct payload', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Url,
+            kind: 'setData',
+            payload: new TextEncoder().encode('https://example.com/idl.json'),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(trackEvent).toHaveBeenCalledWith(
+            'pmp_data_tab_opened',
+            expect.objectContaining({ data_source: 'url', tab: 'decoded' }),
+        );
+    });
+
+    it('should emit no analytics event on mount, before any tab is clicked', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+
+        // The default panel must not count as an interaction, or every rendered card inflates the tab counts.
+        expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('should emit no analytics event when there are no tabs to click', () => {
+        renderSection({ config: JSON_CONFIG, kind: 'setData' });
+
+        expect(trackEvent).not.toHaveBeenCalled();
+    });
+});

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -33,6 +33,7 @@ import {
 } from '@explorer/decoder-serum/detection';
 import { AssociatedTokenDetailsCard } from '@features/decode-instruction-associated-token';
 import { isLighthouseInstruction, LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
+import { isProgramMetadataInstruction, PmpDetailsCard } from '@features/decode-instruction-pmp';
 import { IdlInstructionCard, useIdlInstructionDecode } from '@features/decode-instruction-with-idl';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { isStakeInstruction, RawStakeDetailsCard, StakeDetailsCard } from '@features/stake';
@@ -354,6 +355,26 @@ function InstructionCard({
             <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>
                 <MetaplexTokenMetadataDetailsCard {...props} />
             </ErrorBoundary>
+        );
+    }
+    // PMP owns every instruction on its program id: `setData`/`initialize`/`write` render decoded content from
+    // the bundled typed decoders (no IDL needed), and the housekeeping instructions delegate to the IDL tier
+    // from inside the card. Must sit before the generic idlDecode tier so it wins for the content instructions.
+    if (isProgramMetadataInstruction(transactionIx)) {
+        return (
+            <PmpDetailsCard
+                key={key}
+                {...props}
+                // The card cannot import the IDL feature (boundaries/dependencies), so this surface decides what
+                // a non-content PMP instruction falls back to. Same two outcomes as before the branch existed.
+                fallback={
+                    idlDecode ? (
+                        <IdlInstructionCard decoded={idlDecode} {...props} />
+                    ) : (
+                        <UnknownDetailsCard {...props} />
+                    )
+                }
+            />
         );
     }
     if (idlDecode) {

--- a/app/features/transaction/ui/__tests__/InstructionsSection-Pmp.spec.tsx
+++ b/app/features/transaction/ui/__tests__/InstructionsSection-Pmp.spec.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { PMP_ADDRESS } from '@features/decode-instruction-pmp';
+import { Keypair, type ParsedTransaction, PublicKey } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getSetDataInstructionDataEncoder,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import bs58 from 'bs58';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { InstructionParserProvider } from '@/app/entities/instruction-parser';
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { TransactionsProvider } from '@/app/providers/transactions';
+import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
+
+import { InstructionsSection } from '../InstructionsSection';
+
+const SIGNATURE = '5dakXwp5QTySbvc6P1Wp9MLZubnnG4R1Dh6cWSgNv6w1xt2JMsTp7EZvWEUxk9YLbJZHG97TT3jMVJ4yMTXKjM2L';
+const METADATA = Keypair.generate().publicKey;
+const AUTHORITY = Keypair.generate().publicKey;
+
+const SET_DATA = getSetDataInstructionDataEncoder().encode({
+    compression: Compression.None,
+    data: new TextEncoder().encode('{"name":"company","version":"1.0.0"}'),
+    dataSource: DataSource.Direct,
+    encoding: Encoding.Utf8,
+    format: Format.Json,
+}) as Uint8Array;
+
+// A minimal ParsedTransaction with one PMP instruction. `intoTransactionInstruction` looks each ix account up in
+// `message.accountKeys` and base58-decodes `data`, so both have to line up for the raw path to produce an ix.
+// Built once at module scope for a stable identity across renders. Safe to reference from the vi.mock factory
+// below even though vi.mock is hoisted, because it is only ever READ inside the returned arrow, which runs at
+// render time. `as unknown as` because the fixture carries only the fields the section actually reads.
+const PARSED_TX = {
+    message: {
+        accountKeys: [
+            { pubkey: METADATA, signer: false, source: 'transaction', writable: true },
+            { pubkey: AUTHORITY, signer: true, source: 'transaction', writable: false },
+        ],
+        addressTableLookups: null,
+        instructions: [
+            {
+                accounts: [METADATA, AUTHORITY],
+                data: bs58.encode(SET_DATA),
+                programId: new PublicKey(PMP_ADDRESS),
+            },
+        ],
+        recentBlockhash: PublicKey.default.toBase58(),
+    },
+    signatures: [SIGNATURE],
+} as unknown as ParsedTransaction;
+
+vi.mock('swr', () => ({
+    __esModule: true,
+    default: vi.fn(() => ({
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+    })),
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/'),
+    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('next/link', () => ({
+    __esModule: true,
+    default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+// The decoded-JSON viewer is a next/dynamic ssr:false import, so it resolves asynchronously and would make this
+// spec's assertions racy. Stub it, as MetadataCard.spec.tsx does. The decode path itself is still real.
+vi.mock('@/app/components/common/JsonViewer', () => ({
+    SolarizedJsonViewer: ({ src }: { src: unknown }) => (
+        <div data-testid="json-viewer">{JSON.stringify(src, null, 2)}</div>
+    ),
+}));
+
+// Override only the two cache reads the section makes. `importOriginal` keeps `TransactionsProvider` real, so the
+// raw-details context the InstructionCard reads is still there.
+vi.mock('@providers/transactions', async importOriginal => ({
+    ...(await importOriginal<typeof import('@providers/transactions')>()),
+    useTransactionDetails: vi.fn(() => ({
+        data: { transactionWithMeta: { meta: null, slot: 1, transaction: PARSED_TX } },
+    })),
+    useTransactionStatus: vi.fn(() => ({ data: { info: { result: { err: null } } } })),
+}));
+
+describe('Transaction page InstructionsSection with a Program Metadata instruction', () => {
+    test('should decode and render an inline setData payload with no IDL resolved', async () => {
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <TransactionsProvider>
+                        <AccountsProvider>
+                            <InstructionParserProvider dispatcher={instructionParserDispatcher}>
+                                <InstructionsSection signature={SIGNATURE} />
+                            </InstructionParserProvider>
+                        </AccountsProvider>
+                    </TransactionsProvider>
+                </ClusterProvider>
+            </ScrollAnchorProvider>,
+        );
+
+        expect(await screen.findByText(/ProgramMetadata: SetData/i)).toBeInTheDocument();
+
+        // The section opens on the Raw tab and Radix unmounts the inactive panel, so the decoded document is only
+        // in the DOM once the reader switches.
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(screen.getByTestId('json-viewer')).toHaveTextContent('company');
+    });
+});


### PR DESCRIPTION
## Description

This is **P1 of a 4-phase plan**.

Decodes and renders the metadata data payload that a Program Metadata Program (PMP)
`setData` / `initialize` / `write` instruction carries **inline**, on both the transaction page and the inspector.


### Why a dedicated card rather than the existing IDL

PMP instructions previously fell through to the generic Codama/IDL `IdlInstructionCard`.
That card works, but it has two limits this feature can't live with:

- It's gated on resolving the PMP IDL at runtime over the network. (The typed decoders
ship inside the installed `@solana-program/program-metadata@0.7.0`, so decoding needs no fetch at all).
- The on-chain-valid 4-byte header-only `setData` (a hint-only update) yields `{kind:
'unknown'}` from the IDL path.

The new card is keyed on the program id and is the single entry point for **every** PMP instruction.

It custom-renders the three data-carrying instructions and delegates the six ones (`allocate`, `setAuthority`, `setImmutable`, `trim`, `extend`, `close`) to the the IDL card when an IDL resolved, the Unknown card when it didn't (**Behaviour for those six is unchanged.**).

**New feature slice** `app/features/decode-instruction-pmp`:

| Module | Responsibility |
|---|---|
| `lib/decode-pmp-instruction.ts` | raw ix bytes -> `PmpContentInstruction`, via the library's generated decoders |
| `lib/decode-pmp-payload.ts` | decompress -> enforce render cap -> decode. Never throws |
| `lib/to-decoded-document.ts` | JSON tree vs verbatim text. No YAML/TOML parser pulled in |
| `lib/validators.ts` | superstruct narrowing for the only unvalidated bytes in the slice |
| `ui/PmpPayloadSection.tsx` | every payload state + the Raw/Decoded tabs |
| `ui/PmpDetailsCard.tsx` | routing, title, accounts table, config/write rows |


**Shared component touched:** `CodamaInstructionBody` gains an optional `accountNames?: readonly string[]` — final positional row labels rendered verbatim, for callers with no Codama parse to read names from.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [x] New feature

## Screenshots

<img width="1000" height="796" alt="image" src="https://github.com/user-attachments/assets/ce991524-2023-4673-b2e2-1efba8fc91a0" />

<img width="1002" height="901" alt="image" src="https://github.com/user-attachments/assets/d7a19737-1e17-426e-b729-19c86c6060ad" />

<img width="936" height="635" alt="image" src="https://github.com/user-attachments/assets/880a4f90-1042-490a-b2b4-cba8427aa46a" />

<img width="938" height="849" alt="image" src="https://github.com/user-attachments/assets/ab748de3-d7d8-4418-911c-771a85de7992" />



## Testing

- `setData` without data payload `/tx/3mKzWnSVpgXprYnaVZJdtqCAdbTyTdCKM4xMewrofBqE7KpJ9pxwvD4hSky3uCMtnXxtEponB4om1kWZm5jHADS1`
- `setData` with data payload `/tx/5fD8uKYsuZcGJAA38BCsyqGqfJcT4WRjLnxFPf5it2MHS69rzRzFZ8xPZSP6PVRsj3EE8xse7jEqMqSccPCvYUF6`
- `write` and `initialize` `/tx/2otipHMe3P3GRr62nuey3Bkbi1szaoe6PMdtYMSDhUsZPEB5xoxSrMYQYYC4caKqTq8Y1qfHaW2UbMrHBxYDboLN`
## Related Issues

Any other ixs of PMP program should be rendered without changes `/address/ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S`

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
