### PR TITLE
feat(tx): polish accounts card, slideover and table spacing

### DIFF
--- a/app/components/common/BalanceDelta.tsx
+++ b/app/components/common/BalanceDelta.tsx
@@ -20,20 +20,22 @@ export function BalanceDelta({ delta, isSol = false }: { delta: DeltaValue; isSo
     if (deltaValue.gt(0)) {
         return (
             <Badge ui="dashkit" variant="success">
-                +{isSol ? sols : deltaValue.toString()}
+                {'+\u00A0'}
+                {isSol ? sols : deltaValue.toString()}
             </Badge>
         );
     } else if (deltaValue.lt(0)) {
         return (
             <Badge ui="dashkit" variant="warning">
-                {isSol ? <>-{sols}</> : deltaValue.toString()}
+                {'-\u00A0'}
+                {isSol ? sols : deltaValue.abs().toString()}
             </Badge>
         );
     }
 
     return (
         <Badge ui="dashkit" variant="secondary" className="font-mono">
-            +0
+            {'+\u00A00'}
         </Badge>
     );
 }

--- a/app/components/common/BalanceDelta.tsx
+++ b/app/components/common/BalanceDelta.tsx
@@ -19,23 +19,21 @@ export function BalanceDelta({ delta, isSol = false }: { delta: DeltaValue; isSo
 
     if (deltaValue.gt(0)) {
         return (
-            <Badge ui="dashkit" variant="success">
-                {'+\u00A0'}
-                {isSol ? sols : deltaValue.toString()}
+            <Badge ui="dashkit" variant="success" className="font-mono">
+                +{isSol ? sols : deltaValue.toString()}
             </Badge>
         );
     } else if (deltaValue.lt(0)) {
         return (
-            <Badge ui="dashkit" variant="warning">
-                {'-\u00A0'}
-                {isSol ? sols : deltaValue.abs().toString()}
+            <Badge ui="dashkit" variant="warning" className="font-mono">
+                -{isSol ? sols : deltaValue.abs().toString()}
             </Badge>
         );
     }
 
     return (
         <Badge ui="dashkit" variant="secondary" className="font-mono">
-            {'+\u00A00'}
+            +0
         </Badge>
     );
 }

--- a/app/components/shared/ui/button.stories.tsx
+++ b/app/components/shared/ui/button.stories.tsx
@@ -23,7 +23,7 @@ const twVariantOptions = [
 
 type TwVariant = (typeof twVariantOptions)[number];
 
-const sizeOptions = ['default', 'sm', 'lg', 'icon', 'compact'] as const satisfies readonly ButtonSize[];
+const sizeOptions = ['default', 'sm', 'lg', 'icon', 'compact', 'tile'] as const satisfies readonly ButtonSize[];
 
 // Dashkit migration shim — emits raw Bootstrap `.btn` + `.btn-<variant>` classes via `ui="dashkit"`.
 // Stays until consumers migrate to the OKLCH-flavored `ui="tw"` surface.
@@ -95,8 +95,15 @@ export const AllSizes: Story = {
     render: () => (
         <div className="flex items-center gap-4">
             {sizeOptions.map(size => (
-                <Button key={size} size={size}>
-                    {size === 'icon' ? <Check /> : `Size ${size}`}
+                <Button key={size} size={size} className={size === 'tile' ? 'w-20' : undefined}>
+                    {size === 'icon' && <Check />}
+                    {size === 'tile' && (
+                        <>
+                            <Check />
+                            Tile
+                        </>
+                    )}
+                    {size !== 'icon' && size !== 'tile' && `Size ${size}`}
                 </Button>
             ))}
         </div>
@@ -175,6 +182,7 @@ export const VariantsBySize: Story = {
             icon: 'Icon',
             lg: 'Large',
             sm: 'Small',
+            tile: 'Tile',
         };
 
         return (
@@ -186,8 +194,20 @@ export const VariantsBySize: Story = {
                             {twVariantOptions.map(variant => {
                                 const Icon = twVariantIcons[variant];
                                 return (
-                                    <Button key={variant} size={size} variant={variant}>
-                                        {size === 'icon' ? <Icon /> : variant}
+                                    <Button
+                                        key={variant}
+                                        size={size}
+                                        variant={variant}
+                                        className={size === 'tile' ? 'w-24' : undefined}
+                                    >
+                                        {size === 'icon' && <Icon />}
+                                        {size === 'tile' && (
+                                            <>
+                                                <Icon />
+                                                {variant}
+                                            </>
+                                        )}
+                                        {size !== 'icon' && size !== 'tile' && variant}
                                     </Button>
                                 );
                             })}

--- a/app/components/shared/ui/button.tsx
+++ b/app/components/shared/ui/button.tsx
@@ -15,20 +15,24 @@ const buttonVariants = cva([], {
         {
             class: cn(
                 'border-solid',
-                'inline-flex items-center justify-center gap-2',
-                'whitespace-nowrap rounded text-sm font-medium',
+                'inline-flex items-center justify-center',
+                'whitespace-nowrap text-sm font-medium',
                 'transition-colors',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent focus-visible:ring-neutral-950',
                 'disabled:pointer-events-none disabled:opacity-50',
-                '[&_svg]:pointer-events-none [&_svg]:size-3 [&_svg]:shrink-0',
+                '[&_svg]:pointer-events-none [&_svg]:shrink-0',
             ),
             ui: 'tw',
         },
-        { class: 'h-6 px-2 !text-[11px] !font-normal', size: 'compact', ui: 'tw' },
-        { class: 'h-9 px-2 text-xs', size: 'default', ui: 'tw' },
-        { class: 'h-7 w-7', size: 'icon', ui: 'tw' },
-        { class: 'h-10 px-8', size: 'lg', ui: 'tw' },
-        { class: 'h-7 px-2 text-xs', size: 'sm', ui: 'tw' },
+        // gap/rounding/svg sizing live on the size compounds (not the shared base) so a size
+        // can redefine them without fighting stylesheet order — cn() here does not dedupe.
+        { class: 'h-6 gap-2 rounded px-2 !text-[11px] !font-normal [&_svg]:size-3', size: 'compact', ui: 'tw' },
+        { class: 'h-9 gap-2 rounded px-2 text-xs [&_svg]:size-3', size: 'default', ui: 'tw' },
+        { class: 'h-7 w-7 gap-2 rounded [&_svg]:size-3', size: 'icon', ui: 'tw' },
+        { class: 'h-10 gap-2 rounded px-8 [&_svg]:size-3', size: 'lg', ui: 'tw' },
+        { class: 'h-7 gap-2 rounded px-2 text-xs [&_svg]:size-3', size: 'sm', ui: 'tw' },
+        // Tall icon-over-label action tile (e.g. slideover footer actions).
+        { class: 'h-16 flex-col gap-1 rounded-lg px-2 text-xs [&_svg]:size-4', size: 'tile', ui: 'tw' },
         { class: 'border-0 bg-accent text-gray-900 hover:bg-accent/90', ui: 'tw', variant: 'accent' },
         {
             class: 'border border-outer-space-800 bg-outer-space-900 text-neutral-200 rounded-sm leading-none tracking-[-0.44px]',
@@ -151,7 +155,7 @@ const buttonVariants = cva([], {
     },
     variants: {
         active: { false: '', true: '' },
-        size: { compact: '', default: '', icon: '', lg: '', sm: '' },
+        size: { compact: '', default: '', icon: '', lg: '', sm: '', tile: '' },
         ui: { dashkit: '', tw: '' },
         variant: {
             accent: '',

--- a/app/features/transaction/ui/AccountBadges.tsx
+++ b/app/features/transaction/ui/AccountBadges.tsx
@@ -12,27 +12,27 @@ export function AccountBadges({ account, index, pubkey, message }: Props) {
     return (
         <>
             {index === 0 && (
-                <Badge ui="dashkit" variant="success" className="me-1">
+                <Badge ui="dashkit" variant="success">
                     Fee Payer
                 </Badge>
             )}
             {account.signer && (
-                <Badge ui="dashkit" variant="info" className="me-1">
+                <Badge ui="dashkit" variant="info">
                     Signer
                 </Badge>
             )}
             {account.writable && (
-                <Badge ui="dashkit" variant="danger" className="me-1">
+                <Badge ui="dashkit" variant="danger">
                     Writable
                 </Badge>
             )}
             {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
-                <Badge ui="dashkit" variant="warning" className="me-1">
+                <Badge ui="dashkit" variant="warning">
                     Program
                 </Badge>
             )}
             {account.source === 'lookupTable' && (
-                <Badge ui="dashkit" variant="gray" className="me-1">
+                <Badge ui="dashkit" variant="gray">
                     Address Table Lookup
                 </Badge>
             )}

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -4,7 +4,7 @@ import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import React, { useState } from 'react';
-import { CheckCircle, Copy, ExternalLink, Tag, X } from 'react-feather';
+import { CheckCircle, Copy, ExternalLink, X } from 'react-feather';
 
 import {
     Slideover,
@@ -13,7 +13,7 @@ import {
     SlideoverContent,
     SlideoverTitle,
 } from '@/app/components/shared/ui/slideover';
-import { NicknameEditor, useNickname } from '@/app/features/nicknames';
+import { EditIcon, NicknameEditor, useNickname } from '@/app/features/nicknames';
 import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
 
 import { AccountBadges } from './AccountBadges';
@@ -59,8 +59,12 @@ export function AccountDetailSlideover({
     return (
         <>
             <Slideover open={open} onOpenChange={handleOpenChange}>
-                <SlideoverContent aria-describedby={undefined} onEscapeKeyDown={handleEscapeKeyDown}>
-                    <div className="space-y-2 px-4 pb-3 pt-4">
+                <SlideoverContent
+                    aria-describedby={undefined}
+                    className="border-t border-white/10 !bg-dk-gray-800-dark [border-top-style:solid]"
+                    onEscapeKeyDown={handleEscapeKeyDown}
+                >
+                    <div className="space-y-1.5 p-4">
                         <div className="min-w-0 flex-1">
                             <SlideoverTitle className="mb-1.5 tracking-wide !text-outer-space-300">
                                 Account {index + 1}
@@ -76,7 +80,7 @@ export function AccountDetailSlideover({
                     </div>
 
                     {/* Scrollable body */}
-                    <SlideoverBody className="border-t border-white/10 pt-2 [border-top-style:solid]">
+                    <SlideoverBody className="border-t border-white/10 py-2 [border-top-style:solid]">
                         <AccountExpandedContent
                             accountInfo={accountInfo}
                             accountInfoLoading={accountInfoLoading}
@@ -87,34 +91,24 @@ export function AccountDetailSlideover({
                     </SlideoverBody>
 
                     {/* Footer action bar */}
-                    <div className="flex shrink-0 gap-2 p-3 pb-6">
-                        <Button
-                            className="flex !h-16 w-1/4 flex-col gap-1.5"
-                            onClick={() => setNicknameOpen(true)}
-                            size="sm"
-                            variant="outline"
-                        >
-                            <Tag size={13} />
+                    <div className="flex shrink-0 gap-2 border-t border-white/10 px-3 pb-6 pt-3 [border-top-style:solid]">
+                        <Button className="w-1/4" onClick={() => setNicknameOpen(true)} size="tile" variant="outline">
+                            <EditIcon width={16} />
                             Nickname
                         </Button>
-                        <Button
-                            className="flex !h-16 w-1/4 flex-col gap-1.5"
-                            onClick={() => copy(address)}
-                            size="sm"
-                            variant="outline"
-                        >
-                            {copyState === 'copied' ? <CheckCircle size={13} /> : <Copy size={13} />}
+                        <Button className="w-1/4" onClick={() => copy(address)} size="tile" variant="outline">
+                            {copyState === 'copied' ? <CheckCircle size={16} /> : <Copy size={16} />}
                             Copy
                         </Button>
-                        <Button asChild className="flex !h-16 w-1/4 flex-col gap-1.5" size="sm" variant="accent">
+                        <Button asChild className="w-1/4" size="tile" variant="accent">
                             <Link href={addressPath} target="_blank">
-                                <ExternalLink size={13} />
+                                <ExternalLink size={16} />
                                 Open
                             </Link>
                         </Button>
                         <SlideoverClose asChild>
-                            <Button className="flex !h-16 w-1/4 flex-col gap-1.5" size="sm" variant="outline">
-                                <X size={13} />
+                            <Button className="w-1/4" size="tile" variant="outline">
+                                <X size={16} />
                                 Close
                             </Button>
                         </SlideoverClose>

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -70,7 +70,7 @@ export function AccountDetailSlideover({
                             </div>
                             {nickname && <span className="break-all text-sm text-outer-space-300">{address}</span>}
                         </div>
-                        <div className="flex">
+                        <div className="flex flex-wrap gap-1">
                             <AccountBadges index={index} account={account} message={message} pubkey={pubkey} />
                         </div>
                     </div>

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -12,12 +12,7 @@ import { Code, Info } from 'react-feather';
 
 import { DetailRow, FlatContext } from './AccountExpandedLayout';
 import { ParsedSection } from './AccountExpandedSections';
-import {
-    CONTENT_COL_SPAN,
-    DESKTOP_GRID_TEMPLATE,
-    GRID_GAP_X,
-    MOBILE_GRID_TEMPLATE,
-} from './accountsTableGrid';
+import { CONTENT_COL_SPAN, DESKTOP_GRID_TEMPLATE, GRID_GAP_X, MOBILE_GRID_TEMPLATE } from './accountsTableGrid';
 
 type InnerProps = {
     accountInfo?: AccountInfo;
@@ -49,7 +44,9 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
         <div
             className={cn(
                 'pt-1',
-                flat ? 'pb-2.5' : cn('grid items-start px-3 pb-8', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
+                flat
+                    ? 'pb-2.5'
+                    : cn('grid items-start px-3 pb-8', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
             )}
         >
             {!flat && <div />}
@@ -73,9 +70,7 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
                     )}
                 >
                     <Info size={16} className="shrink-0" />
-                    <span>
-                        Current account data. This data may have been different at the time of the transaction.
-                    </span>
+                    <span>Current account data. This data may have been different at the time of the transaction.</span>
                 </div>
             </div>
         </div>
@@ -132,7 +127,9 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
             <div
                 className={cn(
                     'py-3 text-sm text-outer-space-300',
-                    flat ? 'px-4' : cn('grid items-start px-3', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
+                    flat
+                        ? 'px-4'
+                        : cn('grid items-start px-3', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
                 )}
             >
                 {!flat && <div />}

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -48,7 +48,7 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
     return (
         <div
             className={cn(
-                'pt-2.5',
+                'pt-1',
                 flat ? 'pb-2.5' : cn('grid items-start px-3 pb-8', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
             )}
         >
@@ -97,7 +97,7 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
         return (
             <div
                 className={cn(
-                    'pt-2.5',
+                    'pt-1',
                     flat
                         ? 'pb-2.5'
                         : cn('grid items-start px-3 pb-8', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -12,6 +12,12 @@ import { Code, Info } from 'react-feather';
 
 import { DetailRow, FlatContext } from './AccountExpandedLayout';
 import { ParsedSection } from './AccountExpandedSections';
+import {
+    CONTENT_COL_SPAN,
+    DESKTOP_GRID_TEMPLATE,
+    GRID_GAP_X,
+    MOBILE_GRID_TEMPLATE,
+} from './accountsTableGrid';
 
 type InnerProps = {
     accountInfo?: AccountInfo;
@@ -40,25 +46,37 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
         );
 
     return (
-        <div className={cn(flat ? 'pb-2.5' : 'ml-14 pb-10')}>
-            {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
-            <DetailRow label="Assigned Program Id">
-                <Address pubkey={data.owner} link />
-            </DetailRow>
-            <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
-            <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
-            <DetailRow label="Balance">
-                <SolBalance lamports={data.lamports} />
-            </DetailRow>
+        <div
+            className={cn(
+                'pt-2.5',
+                flat ? 'pb-2.5' : cn('grid items-start px-3 pb-8', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
+            )}
+        >
+            {!flat && <div />}
+            <div className={cn(!flat && CONTENT_COL_SPAN)}>
+                <div className="flex flex-col gap-1.5">
+                    {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
+                    <DetailRow label="Assigned Program Id">
+                        <Address pubkey={data.owner} link />
+                    </DetailRow>
+                    <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
+                    <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
+                    <DetailRow label="Balance">
+                        <SolBalance lamports={data.lamports} />
+                    </DetailRow>
+                </div>
 
-            <div
-                className={cn(
-                    'mt-3 flex items-center gap-1.5 text-xs text-outer-space-300',
-                    flat && '!items-start px-4',
-                )}
-            >
-                <Info size={13} />
-                <span>Current account data. This data may have been different at the time of the transaction.</span>
+                <div
+                    className={cn(
+                        'mt-4 flex items-center gap-1.5 text-xs text-outer-space-300',
+                        flat && '!items-start px-4',
+                    )}
+                >
+                    <Info size={16} className="shrink-0" />
+                    <span>
+                        Current account data. This data may have been different at the time of the transaction.
+                    </span>
+                </div>
             </div>
         </div>
     );
@@ -77,27 +95,48 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
 
     if (enabled && isLoading) {
         return (
-            <div className={cn(flat ? 'pb-2.5' : 'ml-14 pb-2.5')}>
-                {[120, 160, 100, 80].map((w, i) => (
-                    <div
-                        key={i}
-                        className={cn(
-                            'grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 py-1.5',
-                            flat ? 'px-4' : 'pr-3 md:pr-4',
-                        )}
-                    >
-                        <Skeleton className="h-3.5 w-24" />
-                        <Skeleton className="h-3.5" style={{ width: w }} />
+            <div
+                className={cn(
+                    'pt-2.5',
+                    flat
+                        ? 'pb-2.5'
+                        : cn('grid items-start px-3 pb-8', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
+                )}
+            >
+                {!flat && <div />}
+                <div className={cn(!flat && CONTENT_COL_SPAN)}>
+                    <div className="flex flex-col gap-1.5">
+                        {[120, 160, 100, 80].map((w, i) => (
+                            <div
+                                key={i}
+                                className={cn(
+                                    'grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 py-0.5',
+                                    flat && 'px-4',
+                                )}
+                            >
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-4" style={{ width: w }} />
+                            </div>
+                        ))}
                     </div>
-                ))}
+                    <div className={cn('mt-4 flex items-center gap-1.5 py-0.5', flat && '!items-start px-4')}>
+                        <Skeleton className="h-3" style={{ width: 460 }} />
+                    </div>
+                </div>
             </div>
         );
     }
 
     if (enabled && isError) {
         return (
-            <div className={cn(flat ? 'px-4 py-3' : 'ml-10 px-3 py-3 md:px-4', 'text-sm text-outer-space-300')}>
-                Failed to load account info
+            <div
+                className={cn(
+                    'py-3 text-sm text-outer-space-300',
+                    flat ? 'px-4' : cn('grid items-start px-3', GRID_GAP_X, MOBILE_GRID_TEMPLATE, DESKTOP_GRID_TEMPLATE),
+                )}
+            >
+                {!flat && <div />}
+                <div className={cn(!flat && CONTENT_COL_SPAN)}>Failed to load account info</div>
             </div>
         );
     }

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -32,7 +32,7 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
         accountInfo && accountInfo.size > 0 ? (
             <Popover>
                 <PopoverTrigger asChild>
-                    <Button variant="ghost" className="h-auto !p-0 !text-sm">
+                    <Button variant="ghost" className="h-auto !items-baseline !p-0 !text-sm">
                         <Code size={11} />
                         <span>{accountInfo.size.toLocaleString('en-US')} byte(s)</span>
                     </Button>

--- a/app/features/transaction/ui/AccountExpandedLayout.tsx
+++ b/app/features/transaction/ui/AccountExpandedLayout.tsx
@@ -18,8 +18,8 @@ export function DetailRow({ children, className, label }: DetailRowProps) {
     return (
         <div
             className={cn(
-                'grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 py-1.5',
-                flat ? 'px-4' : 'pr-3 md:pr-4',
+                'grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2',
+                flat && 'px-4',
                 className,
             )}
         >

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -20,6 +20,13 @@ import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
 import { AccountBadges } from './AccountBadges';
 import { AccountDetailSlideover } from './AccountDetailSlideover';
 import { AccountExpandedContent } from './AccountExpandedContent';
+import {
+    CELL_PADDING,
+    CONTENT_COL_SPAN,
+    DESKTOP_GRID_TEMPLATE,
+    GRID_GAP_X,
+    MOBILE_GRID_TEMPLATE,
+} from './accountsTableGrid';
 import { CollapsibleSection } from './CollapsibleSection';
 
 type TransactionAccountRowProps = {
@@ -71,9 +78,12 @@ function TransactionAccountRow({
                 {/* Main row */}
                 <div
                     className={cn(
-                        'min-h-9 px-3 py-2.5 md:px-4',
-                        'grid items-start gap-x-0 gap-y-0.5 whitespace-nowrap text-sm md:gap-y-0 lg:gap-x-5 landscape:gap-x-5',
-                        'grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem] landscape:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
+                        'min-h-9',
+                        CELL_PADDING,
+                        'grid items-start gap-y-0.5 whitespace-nowrap text-sm md:gap-y-0',
+                        GRID_GAP_X,
+                        MOBILE_GRID_TEMPLATE,
+                        DESKTOP_GRID_TEMPLATE,
                         "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand'] landscape:[grid-template-areas:'number_address_delta_balance_expand']",
                         'cursor-pointer',
                     )}
@@ -94,7 +104,7 @@ function TransactionAccountRow({
                             </div>
                         </div>
                         {hasBadges && (
-                            <span className="mt-1 inline-flex flex-wrap gap-1">
+                            <span className="mb-0.5 mt-1 inline-flex flex-wrap gap-1">
                                 <AccountBadges index={index} message={message} pubkey={pubkey} account={account} />
                             </span>
                         )}
@@ -111,7 +121,7 @@ function TransactionAccountRow({
                         <Button
                             aria-expanded={expanded}
                             aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
-                            className="!h-5 w-6"
+                            className="!h-5 !w-5 [&_svg]:size-4"
                             onClick={e => {
                                 e.stopPropagation();
                                 setExpanded(v => !v);
@@ -123,7 +133,7 @@ function TransactionAccountRow({
                                 size={16}
                                 className={cn(
                                     'text-outer-space-300 transition-transform duration-200 ease-in-out',
-                                    expanded ? 'rotate-0' : 'rotate-90',
+                                    expanded ? 'rotate-180' : 'rotate-0',
                                 )}
                             />
                         </Button>
@@ -212,8 +222,11 @@ export function AccountsCard({ signature }: SignatureProps) {
         <CollapsibleSection id="accounts" title="Accounts &amp; SOL balance">
             <div
                 className={cn(
-                    'hidden px-3 py-1.5 md:px-4 lg:grid landscape:grid',
-                    'grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_2rem] gap-5 text-xs uppercase text-outer-space-300',
+                    'hidden lg:grid landscape:grid',
+                    CELL_PADDING,
+                    DESKTOP_GRID_TEMPLATE,
+                    GRID_GAP_X,
+                    'text-xs uppercase text-outer-space-300',
                     'border-1 border-b border-white/10 [border-bottom-style:solid]',
                 )}
             >
@@ -225,12 +238,24 @@ export function AccountsCard({ signature }: SignatureProps) {
             </div>
             {accountRows}
             {!loading && totalAccountSize > 0 && (
-                <div className="ml-7 flex items-baseline gap-2 px-3 py-2 text-sm text-outer-space-300 md:px-4 lg:ml-10">
-                    <div className="flex flex-col">
-                        <span className="text-sm uppercase leading-none">Total Account Size:</span>
-                        <span className="text-[10px] leading-none">reflects current state</span>
+                <div
+                    className={cn(
+                        'grid items-start px-3 py-2.5 text-sm text-outer-space-300',
+                        GRID_GAP_X,
+                        MOBILE_GRID_TEMPLATE,
+                        DESKTOP_GRID_TEMPLATE,
+                    )}
+                >
+                    <div className="mr-2 text-outer-space-300 lg:mr-0" />
+                    <div className={cn('flex flex-col', CONTENT_COL_SPAN)}>
+                        <div className="flex items-baseline gap-2">
+                            <span>Total Account Size:</span>
+                            <span className="text-white">{totalAccountSize.toLocaleString('en-US')} bytes</span>
+                        </div>
+                        <span className="text-xs">
+                            Current data. This data may have been different at the time of the transaction.
+                        </span>
                     </div>
-                    <span className="text-white">{totalAccountSize.toLocaleString('en-US')} bytes</span>
                 </div>
             )}
         </CollapsibleSection>

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -240,7 +240,7 @@ export function AccountsCard({ signature }: SignatureProps) {
             {!loading && totalAccountSize > 0 && (
                 <div
                     className={cn(
-                        'grid items-start px-3 py-2.5 text-sm text-outer-space-300',
+                        'grid items-start px-3 py-3 text-sm text-outer-space-300',
                         GRID_GAP_X,
                         MOBILE_GRID_TEMPLATE,
                         DESKTOP_GRID_TEMPLATE,

--- a/app/features/transaction/ui/TokenBalancesCard.tsx
+++ b/app/features/transaction/ui/TokenBalancesCard.tsx
@@ -15,6 +15,7 @@ import { useScaledUiAmountForMint } from '@/app/providers/accounts/tokens';
 import { useCluster } from '@/app/providers/cluster';
 import { getTokenInfos } from '@/app/utils/token-info';
 
+import { CELL_PADDING } from './accountsTableGrid';
 import { CollapsibleSection } from './CollapsibleSection';
 
 type TokenBalanceRow = {
@@ -78,7 +79,8 @@ export function TokenBalancesCardInner({ rows }: TokenBalancesCardInnerProps) {
         <CollapsibleSection id="tokens" title="Tokens">
             <div
                 className={cn(
-                    'hidden px-3 py-1.5 md:px-4 lg:grid',
+                    'hidden lg:grid',
+                    CELL_PADDING,
                     'gap-5 text-xs uppercase text-outer-space-300',
                     'border-1 border-b border-white/10 [border-bottom-style:solid]',
                     GRID_TEMPLATE,
@@ -131,7 +133,7 @@ function TokenBalanceRow({
     return (
         <div className="border-1 border-b border-white/10 [border-bottom-style:solid] last:border-b-0">
             {/* Mobile layout */}
-            <div className="flex flex-col gap-1 px-3 py-3 text-sm md:px-4 lg:hidden">
+            <div className={cn('flex flex-col gap-1 text-sm lg:hidden', CELL_PADDING)}>
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                         <span className="w-16 shrink-0 text-outer-space-300">Change</span>
@@ -168,7 +170,8 @@ function TokenBalanceRow({
             {/* Desktop layout */}
             <div
                 className={cn(
-                    'hidden min-h-9 px-3 py-2.5 md:px-4 lg:grid',
+                    'hidden min-h-9 lg:grid',
+                    CELL_PADDING,
                     'items-start gap-x-5 whitespace-nowrap text-sm',
                     "[grid-template-areas:'number_address_change_balance']",
                     GRID_TEMPLATE,

--- a/app/features/transaction/ui/__tests__/AccountDetailSlideover.test.tsx
+++ b/app/features/transaction/ui/__tests__/AccountDetailSlideover.test.tsx
@@ -14,6 +14,7 @@ vi.mock('next/link', () => ({
 }));
 
 vi.mock('@/app/features/nicknames', () => ({
+    EditIcon: () => <svg />,
     NicknameEditor: ({ address, open, onClose }: { address: string; open: boolean; onClose: () => void }) =>
         open ? (
             <div>

--- a/app/features/transaction/ui/accountsTableGrid.ts
+++ b/app/features/transaction/ui/accountsTableGrid.ts
@@ -16,5 +16,5 @@ export const GRID_GAP_X = 'gap-x-0 lg:gap-x-5 landscape:gap-x-5';
 // A full-width cell under everything but the number column, footer-style.
 export const CONTENT_COL_SPAN = 'col-span-2 lg:col-span-4 landscape:col-span-4';
 
-// Shared padding for the header, rows and footer of the table.
-export const CELL_PADDING = 'px-3 py-2';
+// Shared padding for the header and rows of the table.
+export const CELL_PADDING = 'px-3 py-2.5';

--- a/app/features/transaction/ui/accountsTableGrid.ts
+++ b/app/features/transaction/ui/accountsTableGrid.ts
@@ -1,0 +1,20 @@
+// Shared grid geometry for the accounts table. The header, the rows, the footer and the
+// expanded (spoiler) content are separate grid containers, so they must share the exact
+// same track lists to stay column-aligned.
+
+// The last desktop track hugs the chevron icon (16px); the expand button (!w-5) is
+// centered on it and overflows 2px per side into the gap / row padding to keep a sane
+// hit area.
+export const DESKTOP_GRID_TEMPLATE =
+    'lg:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1rem] landscape:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1rem]';
+
+// Column templates for the pre-desktop breakpoints and the column gap.
+export const MOBILE_GRID_TEMPLATE =
+    'grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:grid-cols-[minmax(auto,1.75rem)_1fr_auto]';
+export const GRID_GAP_X = 'gap-x-0 lg:gap-x-5 landscape:gap-x-5';
+
+// A full-width cell under everything but the number column, footer-style.
+export const CONTENT_COL_SPAN = 'col-span-2 lg:col-span-4 landscape:col-span-4';
+
+// Shared padding for the header, rows and footer of the table.
+export const CELL_PADDING = 'px-3 py-2';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,7 +53,7 @@ export const dkColors = {
     'rainbow-5': '#1dd79b',
     'popover-bg': '#1A1A1A',
     'popover-border': 'rgba(255,255,255,0.1)',
-    'card-outline-dark': '#111',
+    'card-outline-dark': 'oklch(33.501% 0.01351 189.14)', // = outer-space-800; matches the tx-inspector card outline
     'input-placeholder-dark': '#ccc',
 };
 


### PR DESCRIPTION
## Description

UI polish for the transaction page (HOO-1030):

- **Accounts & SOL balance table** — header, rows, footer and expanded details share one column grid (headers now align with values); unified paddings (12/10px cells, 12px footer); tighter chevron column, chevron points down when collapsed / up when expanded.
- **Expanded account details** — content aligns with the address column; spacing moved to the Tailwind scale; loading skeleton mirrors the loaded layout (row heights, note line).
- **Mobile account popup** — background and top border match the table card; symmetric section spacing; footer actions rebuilt as icon-over-label tiles (new `Button size="tile"`); Nickname uses the pencil icon.
- **Balance delta badges** — monospace typography, sign adjacent to the value (`+◎1.001`, `+0`).
- **Tokens table** — same cell paddings as the accounts table (shared constant).
- **Card outline** — `dk-card-outline-dark` set to `outer-space-800` to match the tx-inspector design.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Design update
-   [ ] Other (please describe):

## Screenshots

<img width="3390" height="4691" alt="tx_mobile_desktop" src="https://github.com/user-attachments/assets/ebca95d5-ba2c-4c00-8591-7f3ad07a5c51" />

## Testing

Open [transaction page](https://explorer-git-feat-hoo-1030-polish-program-page-d-7b5bbd-hoodies.vercel.app/tx/3Xvv451gogZKu87vQQoWMrNsy6ajtwXkqPGuKvkYuAngyDk36eUfV6GSrrXp8LJVSbE63Di3YzTDzjWWDvqRCmnj).

## Related Issues

[Addresses HOO-1030](https://linear.app/solana-fndn/issue/HOO-1030/polish-explorer-program-page-design-consistency)

## Checklist

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes

