### PR TITLE
feat: adapt block page layout for mobile and tablet

### DIFF
--- a/app/block/[slot]/accounts/page-client.tsx
+++ b/app/block/[slot]/accounts/page-client.tsx
@@ -24,7 +24,7 @@ export default function BlockAccountsTab({ params: { slot } }: Props) {
         }
     }, [slotNumber, status]); // eslint-disable-line react-hooks/exhaustive-deps
     if (confirmedBlock?.data?.block) {
-        return <BlockAccountsCard block={confirmedBlock.data.block} blockSlot={slotNumber} />;
+        return <BlockAccountsCard block={confirmedBlock.data.block} blockSlot={slotNumber} variant="collapsible" />;
     }
     return null;
 }

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -1,28 +1,16 @@
 'use client';
 
-import { Address } from '@components/common/Address';
-import { Epoch } from '@components/common/Epoch';
+import { BlockOverviewCard } from '@components/block/BlockOverviewCard';
 import { ErrorCard } from '@components/common/ErrorCard';
-import { ExternalLinkWarning } from '@components/common/ExternalLinkWarning';
 import { LoadingCard } from '@components/common/LoadingCard';
-import { Slot } from '@components/common/Slot';
-import { TableCardBody } from '@components/common/TableCardBody';
-import { estimateRequestedComputeUnits } from '@entities/compute-unit';
 import { BlockProvider, FetchStatus, useBlock, useFetchBlock } from '@providers/block';
 import { useCluster, useClusterInfo } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
-import { displayTimestamp, displayTimestampUtc } from '@utils/date';
-import { IBRL_EXPLORER_URL } from '@utils/env';
 import { notFound, useSearchParams } from 'next/navigation';
 import React, { PropsWithChildren, use } from 'react';
-import { ExternalLink } from 'react-feather';
 
-import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { type NavigationTab, NavigationTabs } from '@/app/shared/ui/navigation-tabs';
-import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
-import { StickyHeader } from '@/app/shared/ui/sticky-header/StickyHeader';
-import { BaseTable } from '@/app/shared/ui/Table';
-import { getEpochForSlot, getMaxComputeUnitsInBlock } from '@/app/utils/epoch-schedule';
+import { getEpochForSlot } from '@/app/utils/epoch-schedule';
 import { pickClusterParams } from '@/app/utils/url';
 
 type SlotParams = { slot: string };
@@ -36,7 +24,7 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
     }
     const confirmedBlock = useBlock(slotNumber);
     const fetchBlock = useFetchBlock();
-    const { status, cluster } = useCluster();
+    const { status } = useCluster();
     const clusterInfo = useClusterInfo();
     const refresh = () => fetchBlock(slotNumber);
 
@@ -56,182 +44,29 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
         const { block, blockLeader, childSlot, childLeader, parentLeader } = confirmedBlock.data;
         const epoch = clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(slotNumber)) : undefined;
 
-        let totalCUs = 0;
-        let totalRequestedCUs = 0;
-        let totalCostUnits = 0;
-        for (const tx of block.transactions) {
-            const requestedCUs = estimateRequestedComputeUnits(tx, epoch, cluster);
-            const cus = tx.meta?.computeUnitsConsumed ?? 0;
-            const costUnits = tx.meta?.costUnits ?? 0;
-            totalRequestedCUs += requestedCUs;
-            totalCUs += cus;
-            totalCostUnits += costUnits;
-        }
-
-        const showSuccessfulCount = block.transactions.every(tx => tx.meta !== null);
-        const successfulTxs = block.transactions.filter(tx => tx.meta?.err === null);
-        const maxComputeUnits = getMaxComputeUnitsInBlock({ cluster, epoch });
-
         content = (
             <>
-                <Card ui="dashkit">
-                    <CardHeader ui="dashkit">
-                        <CardTitle as="h3" ui="dashkit">
-                            Overview
-                        </CardTitle>
-                        {IBRL_EXPLORER_URL && (
-                            <ExternalLinkWarning href={`${IBRL_EXPLORER_URL}/block/${slotNumber}`}>
-                                <>
-                                    <ExternalLink className="me-2 align-text-top" size={13} />
-                                    IBRL Explorer
-                                </>
-                            </ExternalLinkWarning>
-                        )}
-                    </CardHeader>
-                    <TableCardBody>
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Blockhash</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <span>{block.blockhash}</span>
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Slot</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <Slot slot={slotNumber} />
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        {blockLeader !== undefined && (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Slot Leader</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right">
-                                    <Address pubkey={blockLeader} alignRight link />
-                                </BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        {block.blockTime ? (
-                            <>
-                                <BaseTable.Row>
-                                    <BaseTable.Cell>Timestamp (Local)</BaseTable.Cell>
-                                    <BaseTable.Cell className="text-right">
-                                        <span className="font-mono">
-                                            {displayTimestamp(block.blockTime * 1000, true)}
-                                        </span>
-                                    </BaseTable.Cell>
-                                </BaseTable.Row>
-                                <BaseTable.Row>
-                                    <BaseTable.Cell>Timestamp (UTC)</BaseTable.Cell>
-                                    <BaseTable.Cell className="text-right">
-                                        <span className="font-mono">
-                                            {displayTimestampUtc(block.blockTime * 1000, true)}
-                                        </span>
-                                    </BaseTable.Cell>
-                                </BaseTable.Row>
-                            </>
-                        ) : (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Timestamp</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right">Unavailable</BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        {epoch !== undefined && (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Epoch</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right font-mono">
-                                    <Epoch epoch={epoch} link />
-                                </BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Parent Blockhash</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <span>{block.previousBlockhash}</span>
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Parent Slot</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <Slot slot={block.parentSlot} link />
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        {parentLeader !== undefined && (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Parent Slot Leader</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right">
-                                    <Address pubkey={parentLeader} alignRight link />
-                                </BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        {childSlot !== undefined && (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Child Slot</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right font-mono">
-                                    <Slot slot={childSlot} link />
-                                </BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        {childLeader !== undefined && (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Child Slot Leader</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right">
-                                    <Address pubkey={childLeader} alignRight link />
-                                </BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Processed Transactions</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <span>{block.transactions.length}</span>
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        {showSuccessfulCount && (
-                            <BaseTable.Row>
-                                <BaseTable.Cell className="w-full">Successful Transactions</BaseTable.Cell>
-                                <BaseTable.Cell className="text-right font-mono">
-                                    <span>{successfulTxs.length}</span>
-                                </BaseTable.Cell>
-                            </BaseTable.Row>
-                        )}
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Total Compute Units Consumed</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <span>{totalCUs.toLocaleString()}</span>
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Transaction Cost Utilization</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <span>
-                                    {totalCostUnits.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
-                                    {Math.round((totalCostUnits / maxComputeUnits) * 100)}%)
-                                </span>
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                        <BaseTable.Row>
-                            <BaseTable.Cell className="w-full">Reserved Compute Units</BaseTable.Cell>
-                            <BaseTable.Cell className="text-right font-mono">
-                                <span>
-                                    {totalRequestedCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
-                                    {Math.round((totalRequestedCUs / maxComputeUnits) * 100)}%)
-                                </span>
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                    </TableCardBody>
-                </Card>
+                <BlockOverviewCard
+                    block={block}
+                    slot={slotNumber}
+                    epoch={epoch}
+                    blockLeader={blockLeader}
+                    childSlot={childSlot}
+                    childLeader={childLeader}
+                    parentLeader={parentLeader}
+                />
                 <MoreSection slot={slotNumber}>{children}</MoreSection>
             </>
         );
     }
     return (
-        <PageContainer variant="pulled-up">
-            <div className="mb-8">
-                <div className="border-0 border-b border-solid border-dk-gray-700-dark py-6">
-                    <h6 className="uppercase tracking-[0.08em] text-dk-gray-700">Details</h6>
-                    <h2 className="mb-0">Block</h2>
-                </div>
-            </div>
+        <div className="mx-auto flex max-w-5xl flex-col space-y-9 px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:space-y-12 lg:px-6 lg:pt-5">
+            <header className="-mb-6 flex flex-col gap-1.5 pb-3 pt-2 lg:mb-0">
+                <span className="text-xs font-normal uppercase text-muted">Details</span>
+                <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Block</h1>
+            </header>
             {content}
-        </PageContainer>
+        </div>
     );
 }
 
@@ -263,11 +98,12 @@ function MoreSection({ children, slot }: { children: React.ReactNode; slot: numb
 
     return (
         <>
-            <StickyHeader>
-                <PageContainer>
-                    <NavigationTabs buildHref={buildHref} tabs={TABS} />
-                </PageContainer>
-            </StickyHeader>
+            {/* Full-bleed sticky tab bar, mirroring the transaction page's tab bar: the negative
+                margins stretch the background edge-to-edge while the matching padding pulls the tabs
+                back onto the page's content column. */}
+            <div className="sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <NavigationTabs buildHref={buildHref} tabs={TABS} className="gap-5" />
+            </div>
             {children}
         </>
     );

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -54,6 +54,9 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
                     childSlot={childSlot}
                     childLeader={childLeader}
                     parentLeader={parentLeader}
+                    // Tighten the mobile gap down to the tab bar to ~12px. `!` because `space-y-9` sets
+                    // margin-bottom:0 on non-first children (beating a plain `-mb-6`); reset at `lg`.
+                    className="!-mb-6 lg:!mb-0"
                 />
                 <MoreSection slot={slotNumber}>{children}</MoreSection>
             </>
@@ -100,7 +103,9 @@ function MoreSection({ children, slot }: { children: React.ReactNode; slot: numb
         <>
             {/* Full-bleed sticky tab bar, mirroring the transaction page's tab bar: the negative
                 margins stretch the background edge-to-edge while the matching padding pulls the tabs
-                back onto the page's content column. */}
+                back onto the page's content column. Below the bar we keep the natural `space-y-9` gap
+                (~36px) — 8px more than the 28px band above the labels — so no `-mb` reduction is needed
+                here (unlike the overview card above, which uses `!-mb-6` to sit ~12px off the bar). */}
             <div className="sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                 <NavigationTabs buildHref={buildHref} tabs={TABS} className="gap-5" />
             </div>

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -63,12 +63,15 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
         );
     }
     return (
-        <div className="mx-auto flex max-w-5xl flex-col space-y-9 px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:space-y-12 lg:px-6 lg:pt-5">
-            <header className="-mb-6 flex flex-col gap-1.5 pb-3 pt-2 lg:mb-0">
+        <div className="mx-auto flex max-w-5xl flex-col px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:px-6 lg:pt-5">
+            <header className="mb-3 flex flex-col gap-1.5 py-6">
                 <span className="text-xs font-normal uppercase text-muted">Details</span>
                 <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Block</h1>
             </header>
-            {content}
+            {/* Section rhythm lives on this inner wrapper, not the outer container, so the header sits
+                OUTSIDE the `space-y` — mirroring the inspector page. The header's own `mb-3` then controls
+                the gap to the first section (no extra `space-y` band stacking on top of it). */}
+            <div className="flex flex-col space-y-9 lg:space-y-12">{content}</div>
         </div>
     );
 }

--- a/app/block/[slot]/page-client.tsx
+++ b/app/block/[slot]/page-client.tsx
@@ -35,7 +35,7 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
         }
     }, [slotNumber, status]); // eslint-disable-line react-hooks/exhaustive-deps
     if (confirmedBlock?.data?.block) {
-        return <BlockHistoryCard block={confirmedBlock.data.block} epoch={epoch} />;
+        return <BlockHistoryCard block={confirmedBlock.data.block} epoch={epoch} variant="collapsible" />;
     }
     return null;
 }

--- a/app/block/[slot]/programs/page-client.tsx
+++ b/app/block/[slot]/programs/page-client.tsx
@@ -24,7 +24,7 @@ export default function BlockProgramsTab({ params: { slot } }: Props) {
         }
     }, [slotNumber, status]); // eslint-disable-line react-hooks/exhaustive-deps
     if (confirmedBlock?.data?.block) {
-        return <BlockProgramsCard block={confirmedBlock.data.block} />;
+        return <BlockProgramsCard block={confirmedBlock.data.block} variant="collapsible" />;
     }
     return null;
 }

--- a/app/block/[slot]/rewards/page-client.tsx
+++ b/app/block/[slot]/rewards/page-client.tsx
@@ -24,7 +24,7 @@ export default function BlockRewardsTabClient({ params: { slot } }: Props) {
         }
     }, [slotNumber, status]); // eslint-disable-line react-hooks/exhaustive-deps
     if (confirmedBlock?.data?.block) {
-        return <BlockRewardsCard block={confirmedBlock.data.block} />;
+        return <BlockRewardsCard block={confirmedBlock.data.block} variant="collapsible" />;
     }
     return null;
 }

--- a/app/components/account/__stories__/TokenHistoryCard.stories.tsx
+++ b/app/components/account/__stories__/TokenHistoryCard.stories.tsx
@@ -1,76 +1,122 @@
+import type { AccountHistory } from '@features/transaction-history/lib/types';
 import {
     DispatchContext as TokensDispatch,
     type State as TokensState,
     StateContext as TokensStateCtx,
+    type TokenInfoWithPubkey,
 } from '@providers/accounts/tokens';
-import { FetchStatus } from '@providers/cache';
+import { type CacheEntry, FetchStatus } from '@providers/cache';
 import {
     DispatchContext as ParsedDetailsDispatch,
     StateContext as ParsedDetailsStateCtx,
 } from '@providers/transactions/parsed';
-import { PublicKey } from '@solana/web3.js';
+import { ConfirmedSignatureInfo, PublicKey } from '@solana/web3.js';
 import { MockAccountsProvider } from '@storybook-config/__mocks__/MockAccountsProvider';
 import { MockClusterProvider as ClusterProvider } from '@storybook-config/__mocks__/MockClusterProvider';
 import { MockHistoryProvider } from '@storybook-config/__mocks__/MockHistoryProvider';
-import { nextjsParameters, withTokenInfoBatch } from '@storybook-config/decorators';
+import { createNextjsParameters, nextjsParameters, withTokenInfoBatch } from '@storybook-config/decorators';
 import type { Decorator, Meta, StoryObj } from '@storybook-config/types';
 import React from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { TokenHistoryCard } from '../TokenHistoryCard';
 
 const ADDRESS = PublicKey.default.toBase58();
-const MAINNET_RPC_URL = 'https://api.mainnet-beta.solana.com';
+const RPC = 'https://api.mainnet-beta.solana.com';
 const noop = () => undefined;
+
+// A couple of real mints so the filter dropdown resolves recognisable labels through the token-info batch.
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const BONK = 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263';
+// Token-account pubkeys (any valid base58 keys — these are program ids, handy as stable distinct keys).
+const TOKEN_ACC_A = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const TOKEN_ACC_B = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
 
 type ParsedDetailsState = React.ContextType<typeof ParsedDetailsStateCtx>;
 
-// Single owned token; history will start empty so the card renders the empty/no-history state.
-const tokensStateValue: TokensState = {
-    entries: {
-        [ADDRESS]: {
-            data: {
-                tokens: [
-                    {
-                        info: {
-                            isNative: false,
-                            mint: new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
-                            owner: PublicKey.default,
-                            state: 'initialized',
-                            tokenAmount: { amount: '0', decimals: 6, uiAmountString: '0' },
-                        },
-                        pubkey: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
-                    },
-                ],
-            },
-            status: FetchStatus.Fetched,
+function token(pubkey: string, mint: string): TokenInfoWithPubkey {
+    return {
+        info: {
+            isNative: false,
+            mint: new PublicKey(mint),
+            owner: PublicKey.default,
+            state: 'initialized',
+            tokenAmount: { amount: '0', decimals: 6, uiAmountString: '0' },
         },
-    },
-    url: MAINNET_RPC_URL,
+        pubkey: new PublicKey(pubkey),
+    };
+}
+
+function ownedTokensState(tokens: TokenInfoWithPubkey[]): TokensState {
+    return { entries: { [ADDRESS]: { data: { tokens }, status: FetchStatus.Fetched } }, url: RPC };
+}
+
+// Signatures only need to be display strings — the Signature cell truncates and never base58-decodes.
+function sig(signature: string, slot: number, failed = false): ConfirmedSignatureInfo {
+    return {
+        blockTime: 1_700_000_000,
+        confirmationStatus: 'finalized',
+        err: failed ? { InstructionError: [0, 'Custom'] } : null,
+        memo: null,
+        signature,
+        slot,
+    };
+}
+
+// `foundOldest: true` pins the oldest-slot cutoff to 0 so every seeded signature clears the slot filter.
+function fetchedHistory(sigs: ConfirmedSignatureInfo[]): CacheEntry<AccountHistory> {
+    return { data: { fetched: sigs, foundOldest: true }, status: FetchStatus.Fetched };
+}
+
+function pendingHistory(status: FetchStatus): CacheEntry<AccountHistory> {
+    return { status };
+}
+
+const SIGS_A = [
+    sig('TokenHistoryStorySignatureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1', 250_000_030),
+    sig('TokenHistoryStorySignatureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2', 250_000_020, true),
+    sig('TokenHistoryStorySignatureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3', 250_000_010),
+];
+const SIGS_B = [
+    sig('TokenHistoryStorySignatureBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB1', 250_000_015),
+    sig('TokenHistoryStorySignatureBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB2', 250_000_005),
+];
+
+// Wires every provider TokenHistoryCard reads: cluster, accounts, owned-tokens (from `parameters.tokens`),
+// seeded account-history cache (`parameters.history`), and an empty parsed-details cache.
+const withCard: Decorator = (Story, ctx) => {
+    const tokens: TokenInfoWithPubkey[] = ctx.parameters.tokens ?? [token(TOKEN_ACC_A, USDC)];
+    const emptyParsedDetails: ParsedDetailsState = { entries: {}, url: RPC };
+    return (
+        <ClusterProvider>
+            <MockAccountsProvider>
+                <TokensStateCtx.Provider value={ownedTokensState(tokens)}>
+                    <TokensDispatch.Provider value={noop}>
+                        <MockHistoryProvider history={ctx.parameters.history}>
+                            <ParsedDetailsStateCtx.Provider value={emptyParsedDetails}>
+                                <ParsedDetailsDispatch.Provider value={noop}>
+                                    <Story />
+                                </ParsedDetailsDispatch.Provider>
+                            </ParsedDetailsStateCtx.Provider>
+                        </MockHistoryProvider>
+                    </TokensDispatch.Provider>
+                </TokensStateCtx.Provider>
+            </MockAccountsProvider>
+        </ClusterProvider>
+    );
 };
 
-const emptyParsedDetailsState: ParsedDetailsState = { entries: {}, url: MAINNET_RPC_URL };
-
-const withToken: Decorator = Story => (
-    <ClusterProvider>
-        <MockAccountsProvider>
-            <TokensStateCtx.Provider value={tokensStateValue}>
-                <TokensDispatch.Provider value={noop}>
-                    <MockHistoryProvider>
-                        <ParsedDetailsStateCtx.Provider value={emptyParsedDetailsState}>
-                            <ParsedDetailsDispatch.Provider value={noop}>
-                                <Story />
-                            </ParsedDetailsDispatch.Provider>
-                        </ParsedDetailsStateCtx.Provider>
-                    </MockHistoryProvider>
-                </TokensDispatch.Provider>
-            </TokensStateCtx.Provider>
-        </MockAccountsProvider>
-    </ClusterProvider>
-);
+// The card fetches lazily (INITIAL_TOKENS_TO_FETCH = 0), so every populated state starts on the
+// "Load Token History" prompt; clicking it flips the internal counter and reveals the seeded data.
+async function loadHistory(canvasElement: HTMLElement) {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', { name: 'Load Token History' }));
+    return canvas;
+}
 
 const meta = {
     component: TokenHistoryCard,
-    decorators: [withTokenInfoBatch],
+    decorators: [withCard, withTokenInfoBatch],
     parameters: nextjsParameters,
     tags: ['autodocs', 'test'],
     title: 'Components/Account/TokenHistoryCard',
@@ -79,8 +125,104 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Token present but no history seeded → renders the initial "Click to load token history" card.
+// Token present but no history seeded → the initial "Click to load token history" prompt.
 export const InitialLoadPrompt: Story = {
     args: { address: ADDRESS },
-    decorators: [withToken],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await expect(
+            await canvas.findByText('Click the button below to load token transaction history'),
+        ).toBeInTheDocument();
+    },
+};
+
+// After loading, the table lists the fetched signatures with the filter dropdown in the header.
+export const Populated: Story = {
+    args: { address: ADDRESS },
+    parameters: { history: { [TOKEN_ACC_A]: fetchedHistory(SIGS_A) } },
+    play: async ({ canvasElement }) => {
+        const canvas = await loadHistory(canvasElement);
+        await expect(await canvas.findByText('Instruction Type')).toBeInTheDocument();
+        await expect(canvas.getByText('Failed')).toBeInTheDocument();
+        await expect(canvas.getByRole('button', { name: 'All Tokens' })).toBeInTheDocument();
+    },
+};
+
+// Opening the filter dropdown reveals "All Tokens" plus one option per owned mint.
+export const FilterMenuOpen: Story = {
+    args: { address: ADDRESS },
+    parameters: {
+        history: { [TOKEN_ACC_A]: fetchedHistory(SIGS_A), [TOKEN_ACC_B]: fetchedHistory(SIGS_B) },
+        tokens: [token(TOKEN_ACC_A, USDC), token(TOKEN_ACC_B, BONK)],
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = await loadHistory(canvasElement);
+        await userEvent.click(await canvas.findByRole('button', { name: 'All Tokens' }));
+        // Toggle label + the menu's "All Tokens" entry both read "All Tokens".
+        await expect((await canvas.findAllByText('All Tokens')).length).toBeGreaterThanOrEqual(2);
+    },
+};
+
+// `?filter=<mint>` narrows the table (and header label) to a single mint.
+export const FilteredByToken: Story = {
+    args: { address: ADDRESS },
+    parameters: {
+        ...createNextjsParameters({ query: { filter: BONK } }),
+        history: { [TOKEN_ACC_A]: fetchedHistory(SIGS_A), [TOKEN_ACC_B]: fetchedHistory(SIGS_B) },
+        tokens: [token(TOKEN_ACC_A, USDC), token(TOKEN_ACC_B, BONK)],
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = await loadHistory(canvasElement);
+        await expect(await canvas.findByText('Instruction Type')).toBeInTheDocument();
+        // Filtered to BONK → the "All Tokens" default is no longer the active toggle label.
+        await expect(canvas.queryByRole('button', { name: 'All Tokens' })).not.toBeInTheDocument();
+    },
+};
+
+// History still fetching → the loading card.
+export const Loading: Story = {
+    args: { address: ADDRESS },
+    parameters: { history: { [TOKEN_ACC_A]: pendingHistory(FetchStatus.Fetching) } },
+    play: async ({ canvasElement }) => {
+        const canvas = await loadHistory(canvasElement);
+        await expect(await canvas.findByText('Loading history')).toBeInTheDocument();
+    },
+};
+
+// History fetch failed → the retryable error card.
+export const FetchFailed: Story = {
+    args: { address: ADDRESS },
+    parameters: { history: { [TOKEN_ACC_A]: pendingHistory(FetchStatus.FetchFailed) } },
+    play: async ({ canvasElement }) => {
+        const canvas = await loadHistory(canvasElement);
+        await expect(await canvas.findByText('Failed to fetch transaction history')).toBeInTheDocument();
+    },
+};
+
+// Fetched but empty → the "no history" error card.
+export const NoHistoryFound: Story = {
+    args: { address: ADDRESS },
+    parameters: { history: { [TOKEN_ACC_A]: fetchedHistory([]) } },
+    play: async ({ canvasElement }) => {
+        const canvas = await loadHistory(canvasElement);
+        await expect(await canvas.findByText('No transaction history found')).toBeInTheDocument();
+    },
+};
+
+// More than 25 token accounts → the card short-circuits to an error before any history is fetched.
+export const TooManyTokens: Story = {
+    args: { address: ADDRESS },
+    parameters: {
+        tokens: Array.from({ length: 26 }, (_, i) =>
+            token(new PublicKey(new Uint8Array(32).fill(i + 1)).toBase58(), USDC),
+        ),
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await expect(
+            await canvas.findByText(
+                'Token transaction history is not available for accounts with over 25 token accounts',
+            ),
+        ).toBeInTheDocument();
+    },
 };

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -5,6 +5,7 @@ import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import React from 'react';
 
+import { HeaderLabel } from '@/app/components/block/BlockProgramsCard';
 import { Button } from '@/app/components/shared/ui/button';
 import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
 import { invariant } from '@/app/shared/lib/invariant';
@@ -178,11 +179,27 @@ function StatsRow({
     );
 }
 
-// Program takes the slack; the numeric columns are capped. Header + rows share this template so
-// columns stay aligned. Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it.
+// Account takes the slack; the numeric columns are capped. The last column pairs Total with its % of
+// transactions in one wider track (Block Programs style). Header + rows share this template so columns
+// stay aligned. Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it.
 const ACCOUNTS_GRID: React.CSSProperties = {
-    gridTemplateColumns: 'minmax(0,1fr) repeat(3, minmax(auto,5rem)) minmax(auto,7.5rem)',
+    gridTemplateColumns: 'minmax(0,1fr) repeat(2, minmax(auto,5rem)) minmax(auto,8.5rem)',
 };
+
+// Merged numeric cell mirroring the Block Programs card: a count and its percentage as two fixed-width
+// parts (count bright, percentage muted) so figures line up. `tabular-nums` aligns digits in the sans face.
+function MergedFigure({ count, percent }: { count: string; percent: string }) {
+    return (
+        <div className="flex justify-end gap-1 tabular-nums">
+            <span className="text-right" style={{ width: '6ch' }}>
+                {count}
+            </span>
+            <span className="text-right text-outer-space-300" style={{ width: '7ch' }}>
+                {percent}
+            </span>
+        </div>
+    );
+}
 
 // Domains-card style — a CSS grid on lg+, stacked labelled rows below lg.
 function AccountsGrid({
@@ -198,7 +215,15 @@ function AccountsGrid({
     hasMore: boolean;
     onLoadMore: () => void;
 }) {
-    const headers = ['Account', 'Read-Write', 'Read-Only', 'Total', '% of Transactions'];
+    // Header reads a plain "Total" — the % lives in the cells, not the header — but carries an info icon
+    // with a hover explanation. Phrasing mirrors the Block Programs headers for consistency across tabs.
+    const totalHelp = `Share of the block's ${totalTransactions.toLocaleString('en-US')} processed transactions that used this account.`;
+    const headers: { label: string; help?: string }[] = [
+        { label: 'Account' },
+        { label: 'Read-Write' },
+        { label: 'Read-Only' },
+        { help: totalHelp, label: 'Total' },
+    ];
     return (
         <div className="text-sm text-white">
             <div
@@ -209,9 +234,9 @@ function AccountsGrid({
                     'text-xs uppercase text-outer-space-300',
                 )}
             >
-                {headers.map((label, i) => (
+                {headers.map((h, i) => (
                     <div key={i} className={cn(i > 0 && 'text-right')}>
-                        {label}
+                        <HeaderLabel help={h.help} label={h.label} />
                     </div>
                 ))}
             </div>
@@ -255,11 +280,12 @@ function AccountsGridRow({
         additionalParams: new URLSearchParams(`accountFilter=${address}&filter=all`),
         pathname: `/block/${blockSlot}`,
     });
-    const fields = [
+    const total = writes + reads;
+    const totalPct = `${((100 * total) / totalTransactions).toFixed(2)}%`;
+    // Read-Write / Read-Only are single values; Total carries its % of transactions in the same cell.
+    const plainFields = [
         { label: 'Read-Write', value: `${writes}` },
         { label: 'Read-Only', value: `${reads}` },
-        { label: 'Total', value: `${writes + reads}` },
-        { label: '% of Transactions', value: `${((100 * (writes + reads)) / totalTransactions).toFixed(2)}%` },
     ];
     return (
         <div className="border-b border-solid border-white/10 last:border-b-0">
@@ -271,12 +297,19 @@ function AccountsGridRow({
                         <Address pubkey={new PublicKey(address)} />
                     </Link>
                 </div>
-                {fields.map((f, i) => (
+                {plainFields.map((f, i) => (
                     <div key={i} className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2">
                         <span className="text-outer-space-300">{f.label}</span>
                         <span>{f.value}</span>
                     </div>
                 ))}
+                <div className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2">
+                    <span className="text-outer-space-300">Total</span>
+                    <span>
+                        {total}
+                        <span className="text-outer-space-300"> {totalPct} of transactions</span>
+                    </span>
+                </div>
             </div>
 
             {/* Desktop grid row. */}
@@ -286,11 +319,12 @@ function AccountsGridRow({
                         <Address pubkey={new PublicKey(address)} />
                     </Link>
                 </div>
-                {fields.map((f, i) => (
+                {plainFields.map((f, i) => (
                     <div key={i} className="text-right">
                         {f.value}
                     </div>
                 ))}
+                <MergedFigure count={`${total}`} percent={totalPct} />
             </div>
         </div>
     );

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -1,10 +1,12 @@
 import { Address } from '@components/common/Address';
+import { cn } from '@components/shared/utils';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import React from 'react';
 
 import { Button } from '@/app/components/shared/ui/button';
+import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -14,9 +16,27 @@ type AccountStats = {
     writes: number;
 };
 
+// Design variant, switchable via prop (see BlockRewardsCard for the same pattern):
+//   - 'default'     — the original Dashkit card + table.
+//   - 'collapsible' — the domains-card treatment (PR #115): heading lifted out above a collapsible
+//                     section, list on a `tight` card surface, CSS-grid body on `lg+` and a stacked,
+//                     labelled layout below `lg`.
+export type BlockAccountsVariant = 'default' | 'collapsible';
+
+// Surface matched to the transaction tables (see BaseDomainsCard) — set on a `variant="tight"` Card.
+const TIGHT_CARD = 'overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900';
+
 const PAGE_SIZE = 25;
 
-export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockResponse; blockSlot: number }) {
+export function BlockAccountsCard({
+    block,
+    blockSlot,
+    variant = 'default',
+}: {
+    block: VersionedBlockResponse;
+    blockSlot: number;
+    variant?: BlockAccountsVariant;
+}) {
     const [numDisplayed, setNumDisplayed] = React.useState(10);
     const totalTransactions = block.transactions.length;
 
@@ -64,6 +84,26 @@ export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockR
         return accountEntries;
     }, [block]);
 
+    const visible = accountStats.slice(0, numDisplayed);
+    const hasMore = accountStats.length > numDisplayed;
+    const loadMore = () => setNumDisplayed(displayed => displayed + PAGE_SIZE);
+
+    if (variant === 'collapsible') {
+        return (
+            <CollapsibleSection title="Block Account Usage" className="">
+                <Card variant="tight" className={TIGHT_CARD}>
+                    <AccountsGrid
+                        blockSlot={blockSlot}
+                        hasMore={hasMore}
+                        onLoadMore={loadMore}
+                        rows={visible}
+                        totalTransactions={totalTransactions}
+                    />
+                </Card>
+            </CollapsibleSection>
+        );
+    }
+
     return (
         <Card ui="dashkit">
             <CardHeader ui="dashkit">
@@ -82,7 +122,7 @@ export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockR
                     </BaseTable.Row>
                 </BaseTable.Head>
                 <BaseTable.Body>
-                    {accountStats.slice(0, numDisplayed).map(([address, { writes, reads }]) => (
+                    {visible.map(([address, { writes, reads }]) => (
                         <StatsRow
                             address={address}
                             blockSlot={blockSlot}
@@ -95,14 +135,9 @@ export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockR
                 </BaseTable.Body>
             </BaseTable>
 
-            {accountStats.length > numDisplayed && (
+            {hasMore && (
                 <CardFooter ui="dashkit">
-                    <Button
-                        ui="dashkit"
-                        variant="primary"
-                        className="w-full"
-                        onClick={() => setNumDisplayed(displayed => displayed + PAGE_SIZE)}
-                    >
+                    <Button ui="dashkit" variant="primary" className="w-full" onClick={loadMore}>
                         Load More
                     </Button>
                 </CardFooter>
@@ -140,5 +175,123 @@ function StatsRow({
             <BaseTable.Cell>{writes + reads}</BaseTable.Cell>
             <BaseTable.Cell>{((100 * (writes + reads)) / totalTransactions).toFixed(2)}%</BaseTable.Cell>
         </BaseTable.Row>
+    );
+}
+
+// Program takes the slack; the numeric columns are capped. Header + rows share this template so
+// columns stay aligned. Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it.
+const ACCOUNTS_GRID: React.CSSProperties = {
+    gridTemplateColumns: 'minmax(0,1fr) repeat(3, minmax(auto,5rem)) minmax(auto,7.5rem)',
+};
+
+// Domains-card style — a CSS grid on lg+, stacked labelled rows below lg.
+function AccountsGrid({
+    rows,
+    blockSlot,
+    totalTransactions,
+    hasMore,
+    onLoadMore,
+}: {
+    rows: [string, AccountStats][];
+    blockSlot: number;
+    totalTransactions: number;
+    hasMore: boolean;
+    onLoadMore: () => void;
+}) {
+    const headers = ['Account', 'Read-Write', 'Read-Only', 'Total', '% of Transactions'];
+    return (
+        <div className="text-sm text-white">
+            <div
+                style={ACCOUNTS_GRID}
+                className={cn(
+                    'hidden gap-5 px-3 py-2.5 md:px-4 md:grid',
+                    'border-b border-solid border-white/10',
+                    'text-xs uppercase text-outer-space-300',
+                )}
+            >
+                {headers.map((label, i) => (
+                    <div key={i} className={cn(i > 0 && 'text-right')}>
+                        {label}
+                    </div>
+                ))}
+            </div>
+
+            {rows.map(([address, stats]) => (
+                <AccountsGridRow
+                    address={address}
+                    blockSlot={blockSlot}
+                    key={address}
+                    reads={stats.reads}
+                    totalTransactions={totalTransactions}
+                    writes={stats.writes}
+                />
+            ))}
+
+            {hasMore && (
+                <div className="border-t border-solid border-white/10 px-3 py-4 md:px-4">
+                    <Button ui="dashkit" variant="primary" className="w-full" onClick={onLoadMore}>
+                        Load More
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function AccountsGridRow({
+    address,
+    blockSlot,
+    writes,
+    reads,
+    totalTransactions,
+}: {
+    address: string;
+    blockSlot: number;
+    writes: number;
+    reads: number;
+    totalTransactions: number;
+}) {
+    const accountPath = useClusterPath({
+        additionalParams: new URLSearchParams(`accountFilter=${address}&filter=all`),
+        pathname: `/block/${blockSlot}`,
+    });
+    const fields = [
+        { label: 'Read-Write', value: `${writes}` },
+        { label: 'Read-Only', value: `${reads}` },
+        { label: 'Total', value: `${writes + reads}` },
+        { label: '% of Transactions', value: `${((100 * (writes + reads)) / totalTransactions).toFixed(2)}%` },
+    ];
+    return (
+        <div className="border-b border-solid border-white/10 last:border-b-0">
+            {/* Mobile / tablet — stacked, labelled rows. Label column matches BlockOverviewCard. */}
+            <div className="flex flex-col gap-1 px-3 py-3 md:px-4 md:hidden">
+                <div className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2">
+                    <span className="text-outer-space-300">Account</span>
+                    <Link href={accountPath}>
+                        <Address pubkey={new PublicKey(address)} />
+                    </Link>
+                </div>
+                {fields.map((f, i) => (
+                    <div key={i} className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2">
+                        <span className="text-outer-space-300">{f.label}</span>
+                        <span>{f.value}</span>
+                    </div>
+                ))}
+            </div>
+
+            {/* Desktop grid row. */}
+            <div style={ACCOUNTS_GRID} className="hidden items-start gap-5 px-3 py-2.5 md:px-4 md:grid">
+                <div className="min-w-0">
+                    <Link href={accountPath}>
+                        <Address pubkey={new PublicKey(address)} />
+                    </Link>
+                </div>
+                {fields.map((f, i) => (
+                    <div key={i} className="text-right">
+                        {f.value}
+                    </div>
+                ))}
+            </div>
+        </div>
     );
 }

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -25,7 +25,8 @@ type AccountStats = {
 export type BlockAccountsVariant = 'default' | 'collapsible';
 
 // Surface matched to the transaction tables (see BaseDomainsCard) — set on a `variant="tight"` Card.
-const TIGHT_CARD = 'overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900';
+// `!rounded-lg` (8px) forces the radius over the tw base's `rounded-xl` (12px) — see BlockHistoryCard.
+const TIGHT_CARD = 'overflow-hidden !rounded-lg border-outer-space-800 bg-outer-space-900';
 
 const PAGE_SIZE = 25;
 
@@ -229,7 +230,7 @@ function AccountsGrid({
             <div
                 style={ACCOUNTS_GRID}
                 className={cn(
-                    'hidden gap-5 px-3 py-2.5 md:px-4 md:grid',
+                    'hidden gap-5 px-3 py-2.5 md:grid md:px-4',
                     'border-b border-solid border-white/10',
                     'text-xs uppercase text-outer-space-300',
                 )}
@@ -290,7 +291,7 @@ function AccountsGridRow({
     return (
         <div className="border-b border-solid border-white/10 last:border-b-0">
             {/* Mobile / tablet — stacked, labelled rows. Label column matches BlockOverviewCard. */}
-            <div className="flex flex-col gap-1 px-3 py-3 md:px-4 md:hidden">
+            <div className="flex flex-col gap-1 px-3 py-3 md:hidden md:px-4">
                 <div className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2">
                     <span className="text-outer-space-300">Account</span>
                     <Link href={accountPath} className="block min-w-0">
@@ -313,7 +314,7 @@ function AccountsGridRow({
             </div>
 
             {/* Desktop grid row. */}
-            <div style={ACCOUNTS_GRID} className="hidden items-start gap-5 px-3 py-2.5 md:px-4 md:grid">
+            <div style={ACCOUNTS_GRID} className="hidden items-start gap-5 px-3 py-2.5 md:grid md:px-4">
                 <div className="min-w-0">
                     <Link href={accountPath} className="block min-w-0">
                         <Address pubkey={new PublicKey(address)} />

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -187,17 +187,13 @@ const ACCOUNTS_GRID: React.CSSProperties = {
     gridTemplateColumns: 'minmax(0,1fr) repeat(2, minmax(auto,5rem)) minmax(auto,8.5rem)',
 };
 
-// Merged numeric cell mirroring the Block Programs card: a count and its percentage as two fixed-width
-// parts (count bright, percentage muted) so figures line up. `tabular-nums` aligns digits in the sans face.
-function MergedFigure({ count, percent }: { count: string; percent: string }) {
+// A count with its percentage in parentheses on one right-aligned mono line ("count (percent)"), matching
+// the Block Programs card. `tabular-nums` aligns digits in the sans face.
+function BracketedFigure({ count, percent }: { count: string; percent: string }) {
     return (
-        <div className="flex justify-end gap-1 tabular-nums">
-            <span className="text-right" style={{ width: '6ch' }}>
-                {count}
-            </span>
-            <span className="text-right text-outer-space-300" style={{ width: '7ch' }}>
-                {percent}
-            </span>
+        <div className="text-right tabular-nums">
+            {count}
+            <span className="text-outer-space-300"> ({percent})</span>
         </div>
     );
 }
@@ -308,7 +304,7 @@ function AccountsGridRow({
                     <span className="text-outer-space-300">Total</span>
                     <span>
                         {total}
-                        <span className="text-outer-space-300"> {totalPct} of block transactions</span>
+                        <span className="text-outer-space-300"> ({totalPct} of Total)</span>
                     </span>
                 </div>
             </div>
@@ -325,7 +321,7 @@ function AccountsGridRow({
                         {f.value}
                     </div>
                 ))}
-                <MergedFigure count={`${total}`} percent={totalPct} />
+                <BracketedFigure count={`${total}`} percent={totalPct} />
             </div>
         </div>
     );

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -293,7 +293,7 @@ function AccountsGridRow({
             <div className="flex flex-col gap-1 px-3 py-3 md:px-4 md:hidden">
                 <div className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2">
                     <span className="text-outer-space-300">Account</span>
-                    <Link href={accountPath}>
+                    <Link href={accountPath} className="block min-w-0">
                         <Address pubkey={new PublicKey(address)} />
                     </Link>
                 </div>
@@ -307,7 +307,7 @@ function AccountsGridRow({
                     <span className="text-outer-space-300">Total</span>
                     <span>
                         {total}
-                        <span className="text-outer-space-300"> {totalPct} of transactions</span>
+                        <span className="text-outer-space-300"> {totalPct} of block transactions</span>
                     </span>
                 </div>
             </div>
@@ -315,7 +315,7 @@ function AccountsGridRow({
             {/* Desktop grid row. */}
             <div style={ACCOUNTS_GRID} className="hidden items-start gap-5 px-3 py-2.5 md:px-4 md:grid">
                 <div className="min-w-0">
-                    <Link href={accountPath}>
+                    <Link href={accountPath} className="block min-w-0">
                         <Address pubkey={new PublicKey(address)} />
                     </Link>
                 </div>

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -18,7 +18,7 @@ import { pickClusterParams } from '@utils/url';
 import Link from 'next/link';
 import { ReadonlyURLSearchParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useMemo } from 'react';
-import { ChevronDown } from 'react-feather';
+import { ChevronDown, ChevronUp } from 'react-feather';
 
 import { Badge } from '@/app/components/shared/ui/badge';
 import { Button } from '@/app/components/shared/ui/button';
@@ -59,13 +59,32 @@ const useQueryAccountFilter = (query: ReadonlyURLSearchParams): PublicKey | null
 };
 
 type SortMode = 'index' | 'compute' | 'txnCost' | 'fee' | 'reservedCUs';
-const useQuerySort = (query: ReadonlyURLSearchParams): SortMode => {
+type SortDirection = 'asc' | 'desc';
+
+// Each column's natural first-click direction — index reads low→high, the numeric columns high→low.
+const DEFAULT_DIRECTION: Record<SortMode, SortDirection> = {
+    compute: 'desc',
+    fee: 'desc',
+    index: 'asc',
+    reservedCUs: 'desc',
+    txnCost: 'desc',
+};
+
+const useQuerySort = (query: ReadonlyURLSearchParams): { mode: SortMode; direction: SortDirection } => {
     const sort = query.get('sort');
-    if (sort === 'compute') return 'compute';
-    if (sort === 'txnCost') return 'txnCost';
-    if (sort === 'fee') return 'fee';
-    if (sort === 'reservedCUs') return 'reservedCUs';
-    return 'index';
+    const mode: SortMode =
+        sort === 'compute'
+            ? 'compute'
+            : sort === 'txnCost'
+              ? 'txnCost'
+              : sort === 'fee'
+                ? 'fee'
+                : sort === 'reservedCUs'
+                  ? 'reservedCUs'
+                  : 'index';
+    const dir = query.get('dir');
+    const direction: SortDirection = dir === 'asc' || dir === 'desc' ? dir : DEFAULT_DIRECTION[mode];
+    return { direction, mode };
 };
 
 type TransactionWithInvocations = {
@@ -93,26 +112,37 @@ export function BlockHistoryCard({
     const currentSearchParams = useSearchParams();
     const programFilter = useQueryProgramFilter(currentSearchParams);
     const accountFilter = useQueryAccountFilter(currentSearchParams);
-    const sortMode = useQuerySort(currentSearchParams);
+    const { direction: sortDirection, mode: sortMode } = useQuerySort(currentSearchParams);
     const router = useRouter();
     const { cluster } = useCluster();
 
-    // Sort is driven by a URL param; the grid variant's sortable headers push through here. Passing no
-    // key clears the sort (the "#" header's reset back to index order). We build the URL from a copy of the
-    // current params so a `delete` actually drops `sort` — `pickClusterParams` only ever adds/overrides
-    // keys, so routing the reset through it would leave the stale `sort` in place.
+    // Sort is driven by URL params (`sort` + `dir`); the grid variant's sortable headers push through here.
+    // Clicking the active column flips its direction; clicking another column selects it at its natural
+    // default direction. `index` ascending is the default view, so it's written as no params (clean URL);
+    // passing no key clears the sort entirely (the old table's "#" reset). We build the URL from a copy of
+    // the current params so a `delete` actually drops the keys — `pickClusterParams` only adds/overrides.
     const pushSort = React.useCallback(
-        (sortKey?: string) => {
+        (sortKey?: SortMode) => {
             const nextParams = new URLSearchParams(currentSearchParams?.toString());
-            if (sortKey) {
+            const nextDirection: SortDirection =
+                sortKey && sortKey === sortMode
+                    ? sortDirection === 'asc'
+                        ? 'desc'
+                        : 'asc'
+                    : sortKey
+                      ? DEFAULT_DIRECTION[sortKey]
+                      : 'asc';
+            if (sortKey && !(sortKey === 'index' && nextDirection === 'asc')) {
                 nextParams.set('sort', sortKey);
+                nextParams.set('dir', nextDirection);
             } else {
                 nextParams.delete('sort');
+                nextParams.delete('dir');
             }
             const queryString = nextParams.toString();
             router.push(`${currentPathname}${queryString ? `?${queryString}` : ''}`);
         },
-        [currentPathname, currentSearchParams, router],
+        [currentPathname, currentSearchParams, router, sortMode, sortDirection],
     );
 
     const { transactions, invokedPrograms } = React.useMemo(() => {
@@ -215,18 +245,22 @@ export function BlockHistoryCard({
 
         const showComputeUnits = filteredTxs.every(tx => tx.computeUnits !== undefined);
 
-        if (sortMode === 'compute' && showComputeUnits) {
-            filteredTxs.sort((a, b) => (b.computeUnits ?? 0) - (a.computeUnits ?? 0));
+        // Base comparators are ascending; `dir` flips them so a repeat click reverses the order.
+        const dir = sortDirection === 'asc' ? 1 : -1;
+        if (sortMode === 'index') {
+            filteredTxs.sort((a, b) => dir * (a.index - b.index));
+        } else if (sortMode === 'compute' && showComputeUnits) {
+            filteredTxs.sort((a, b) => dir * ((a.computeUnits ?? 0) - (b.computeUnits ?? 0)));
         } else if (sortMode === 'txnCost') {
-            filteredTxs.sort((a, b) => (b.costUnits ?? 0) - (a.costUnits ?? 0));
+            filteredTxs.sort((a, b) => dir * ((a.costUnits ?? 0) - (b.costUnits ?? 0)));
         } else if (sortMode === 'fee') {
-            filteredTxs.sort((a, b) => (b.meta?.fee || 0) - (a.meta?.fee || 0));
+            filteredTxs.sort((a, b) => dir * ((a.meta?.fee || 0) - (b.meta?.fee || 0)));
         } else if (sortMode === 'reservedCUs') {
-            filteredTxs.sort((a, b) => (b.reservedComputeUnits || 0) - (a.reservedComputeUnits || 0));
+            filteredTxs.sort((a, b) => dir * ((a.reservedComputeUnits || 0) - (b.reservedComputeUnits || 0)));
         }
 
         return [filteredTxs, showComputeUnits];
-    }, [block.transactions, transactions, programFilter, accountFilter, sortMode]);
+    }, [block.transactions, transactions, programFilter, accountFilter, sortMode, sortDirection]);
 
     if (transactions.length === 0) {
         return <ErrorCard text="This block has no transactions" />;
@@ -272,7 +306,13 @@ export function BlockHistoryCard({
                         {filteredTransactions.length === 0 ? (
                             <div className="px-4 py-3 text-sm text-white">{emptyFilterMessage}</div>
                         ) : (
-                            <BlockHistoryGrid rows={visible} showComputeUnits={showComputeUnits} onSort={pushSort} />
+                            <BlockHistoryGrid
+                                rows={visible}
+                                showComputeUnits={showComputeUnits}
+                                onSort={pushSort}
+                                sortMode={sortMode}
+                                sortDirection={sortDirection}
+                            />
                         )}
                         {hasMore && (
                             <div className="border-t border-solid border-white/10 px-3 py-4 md:px-4">
@@ -481,35 +521,70 @@ const HISTORY_STATUS = {
 
 const numberFmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
 
+// Sort affordance for a header: a dim up/down chevron pair signals the column is clickable; on the
+// active column the arrow for the current direction lights up bright white (the other stays dim).
+// The chevron stack is taller than the header text, so it's absolutely positioned inside a text-height
+// box — it never grows the row. `-translate-y-[calc(50%+1px)]` centres it, then nudges it 1px higher.
+function SortIndicator({ active, direction }: { active: boolean; direction: 'asc' | 'desc' }) {
+    return (
+        <span className="relative inline-block h-4 w-3 align-top">
+            <span className="absolute inset-x-0 top-1/2 flex -translate-y-[calc(50%+1px)] flex-col items-center leading-none">
+                <ChevronUp
+                    size={11}
+                    strokeWidth={2.5}
+                    className={active && direction === 'asc' ? 'text-white' : 'text-outer-space-300'}
+                />
+                <ChevronDown
+                    size={11}
+                    strokeWidth={2.5}
+                    className={cn('-mt-1', active && direction === 'desc' ? 'text-white' : 'text-outer-space-300')}
+                />
+            </span>
+        </span>
+    );
+}
+
 // Domains-card style — a CSS grid on md+, stacked labelled rows below md. Sortable numeric headers push
 // the sort through `onSort` (same URL-param mechanism as the default table).
 function BlockHistoryGrid({
     rows,
     showComputeUnits,
     onSort,
+    sortMode,
+    sortDirection,
 }: {
     rows: TransactionWithInvocations[];
     showComputeUnits: boolean;
-    onSort: (sortKey?: string) => void;
+    onSort: (sortKey?: SortMode) => void;
+    sortMode: SortMode;
+    sortDirection: SortDirection;
 }) {
     // Signature takes the slack; the numeric columns are capped tight (≈ content + ~1rem of headroom).
     // Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it. The Compute column only
     // exists when compute data is available. Following the transaction-history card, Result (badge) sits
     // inline with the signature and the invoked programs stack beneath it — so neither gets its own column.
+    // CU columns are wide enough to hold "CUs Consumed"/"CUs Reserved" + the sort chevrons on one line;
+    // Cost gets a touch more room for its chevrons too.
     const gridStyle: React.CSSProperties = {
-        gridTemplateColumns: `minmax(auto,2.5rem) minmax(0,1fr) minmax(auto,7rem) minmax(auto,6rem) ${
-            showComputeUnits ? 'minmax(auto,6rem) ' : ''
+        gridTemplateColumns: `minmax(auto,2.5rem) minmax(0,1fr) minmax(auto,7rem) minmax(auto,7.5rem) ${
+            showComputeUnits ? 'minmax(auto,7.5rem) ' : ''
         }minmax(auto,4rem)`,
     };
 
-    const headers: { label: string; numeric?: boolean; onClick?: () => void }[] = [
-        { label: '#', onClick: () => onSort() },
+    // `sortKey` maps the header to the URL sort param (undefined = not sortable). The active column's
+    // SortIndicator reflects the live `sortDirection`; inactive sortable columns show a dim chevron pair.
+    const headers: { label: string; numeric?: boolean; sortKey?: SortMode }[] = [
+        { label: '#', sortKey: 'index' },
         { label: 'Signature / Programs' },
-        { label: 'Fee', numeric: true, onClick: () => onSort('fee') },
-        { label: 'CUs Reserved', numeric: true, onClick: () => onSort('reservedCUs') },
-        ...(showComputeUnits ? [{ label: 'CUs Consumed', numeric: true, onClick: () => onSort('compute') }] : []),
-        { label: 'Cost', numeric: true, onClick: () => onSort('txnCost') },
+        { label: 'Fee', numeric: true, sortKey: 'fee' },
     ];
+    if (showComputeUnits) {
+        headers.push({ label: 'CUs Consumed', numeric: true, sortKey: 'compute' });
+    }
+    headers.push(
+        { label: 'CUs Reserved', numeric: true, sortKey: 'reservedCUs' },
+        { label: 'Cost', numeric: true, sortKey: 'txnCost' },
+    );
 
     return (
         <div className="text-sm text-white">
@@ -517,15 +592,34 @@ function BlockHistoryGrid({
                 style={gridStyle}
                 className="hidden gap-4 border-b border-solid border-white/10 px-4 py-2.5 text-xs uppercase text-outer-space-300 md:grid"
             >
-                {headers.map(header => (
-                    <div
-                        key={header.label}
-                        className={cn(header.numeric && 'text-right', header.onClick && 'cursor-pointer select-none')}
-                        onClick={header.onClick}
-                    >
-                        {header.label}
-                    </div>
-                ))}
+                {headers.map(header => {
+                    const sortable = header.sortKey !== undefined;
+                    const active = sortable && sortMode === header.sortKey;
+                    return (
+                        <div
+                            key={header.label}
+                            className={cn(
+                                header.numeric && 'text-right',
+                                sortable && 'cursor-pointer select-none',
+                                active && 'text-white',
+                            )}
+                            onClick={sortable ? () => onSort(header.sortKey) : undefined}
+                        >
+                            {/* For right-aligned numeric columns the indicator goes to the LEFT of the label so
+                                the label's right edge still lines up exactly with the values below; the "#"
+                                column (left-aligned) keeps it on the right. */}
+                            <span className="inline-flex items-center gap-1">
+                                {sortable && header.numeric && (
+                                    <SortIndicator active={active} direction={active ? sortDirection : 'desc'} />
+                                )}
+                                {header.label}
+                                {sortable && !header.numeric && (
+                                    <SortIndicator active={active} direction={active ? sortDirection : 'desc'} />
+                                )}
+                            </span>
+                        </div>
+                    );
+                })}
             </div>
             {rows.map((tx, i) => (
                 <BlockHistoryGridRow key={i} tx={tx} showComputeUnits={showComputeUnits} gridStyle={gridStyle} />
@@ -602,8 +696,8 @@ function BlockHistoryGridRow({
                     <div className="pr-10">{signatureHeader}</div>
                 </BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Fee">{feeNode}</BlockHistoryMobileField>
-                <BlockHistoryMobileField label="CUs Reserved">{reserved}</BlockHistoryMobileField>
                 {showComputeUnits && <BlockHistoryMobileField label="CUs Consumed">{compute}</BlockHistoryMobileField>}
+                <BlockHistoryMobileField label="CUs Reserved">{reserved}</BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Cost">{txnCost}</BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Programs" align="start">
                     {invokedNode}
@@ -615,8 +709,8 @@ function BlockHistoryGridRow({
                 <div className="text-outer-space-300">{tx.index + 1}</div>
                 {signatureBlock}
                 <div className="text-right">{feeNode}</div>
-                <div className="text-right">{reserved}</div>
                 {showComputeUnits && <div className="text-right">{compute}</div>}
+                <div className="text-right">{reserved}</div>
                 <div className="text-right">{txnCost}</div>
             </div>
         </div>

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -18,11 +18,12 @@ import { pickClusterParams } from '@utils/url';
 import Link from 'next/link';
 import { ReadonlyURLSearchParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useMemo } from 'react';
-import { ChevronDown, ChevronUp } from 'react-feather';
+import { ChevronDown, ChevronUp, Filter, Search, X } from 'react-feather';
 
 import { Badge } from '@/app/components/shared/ui/badge';
 import { Button } from '@/app/components/shared/ui/button';
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from '@/app/components/shared/ui/dropdown';
+import { Input } from '@/app/components/shared/ui/input';
 import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardBody, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
@@ -39,7 +40,10 @@ const PAGE_SIZE = 25;
 export type BlockHistoryVariant = 'default' | 'collapsible';
 
 // Surface matched to the transaction tables (see BaseDomainsCard) — set on a `variant="tight"` Card.
-const TIGHT_CARD = 'overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900';
+// `!rounded-lg` (8px) forces the radius over the tw base's `rounded-xl` (12px): without Preflight the
+// two utilities collide and source order — not class order — would otherwise leave the card at 12px,
+// out of step with the dashkit cards (Overview / transaction page) that sit at 8px.
+const TIGHT_CARD = 'overflow-hidden !rounded-lg border-outer-space-800 bg-outer-space-900';
 
 const useQueryProgramFilter = (query: ReadonlyURLSearchParams): string => {
     const filter = query.get('filter');
@@ -262,6 +266,15 @@ export function BlockHistoryCard({
         return [filteredTxs, showComputeUnits];
     }, [block.transactions, transactions, programFilter, accountFilter, sortMode, sortDirection]);
 
+    // Shared by the filter dropdown (menu options + active row) and the removable chip below the title.
+    // "Set" means anything other than "All Transactions": the empty-param default ("All Except Votes")
+    // already hides votes, so it counts as an active filter — clearing the chip lands on "All Transactions".
+    const filterModel = React.useMemo(
+        () => buildFilterModel(programFilter, invokedPrograms, cluster, transactions.length),
+        [programFilter, invokedPrograms, cluster, transactions.length],
+    );
+    const isProgramFilterSet = programFilter !== ALL_TRANSACTIONS;
+
     if (transactions.length === 0) {
         return <ErrorCard text="This block has no transactions" />;
     }
@@ -283,13 +296,40 @@ export function BlockHistoryCard({
 
         return (
             <CollapsibleSection
-                title={title}
+                // The record count rides in the title as a muted, smaller run — "N filtered records" when a
+                // filter is active, otherwise "N records".
+                title={
+                    <>
+                        {/* Gap lives on the title (`mr-2`), not the count, so when the count wraps to its own
+                            line it sits flush-left under the title instead of indented. */}
+                        <span className="mr-2">Block Transactions</span>
+                        {/* `inline-block` makes the count an atomic unit: it stays on one line and wraps to
+                            the next line whole when it can't sit beside the title; its width is measured
+                            against the full container, so words only break once the block itself overflows. */}
+                        <span className="inline-block text-sm font-normal text-outer-space-300">
+                            {filteredTransactions.length}{' '}
+                            {isProgramFilterSet || accountFilter !== null ? 'filtered records' : 'records'}
+                        </span>
+                    </>
+                }
                 className=""
+                // Buttons form the second column, bottom-aligned; `gap-4` keeps the chip off them.
+                titleClassName="!items-end gap-4"
+                // Only the active-filter chip sits under the title now. `-mt-1` trims 4px off the title
+                // column's 8px gap (bringing the count text closer); `mb-0.5` adds 2px under the chip on
+                // top of the section's own 12px gap to the table.
+                belowTitle={
+                    isProgramFilterSet ? (
+                        <div className="-mt-1 mb-0.5 flex flex-wrap items-center gap-2">
+                            <FilterChip label={filterModel.current.name} />
+                        </div>
+                    ) : undefined
+                }
                 actions={
                     <FilterDropdown
-                        filter={programFilter}
-                        invokedPrograms={invokedPrograms}
-                        totalTransactionCount={transactions.length}
+                        options={filterModel.options}
+                        currentFilter={programFilter}
+                        isFilterSet={isProgramFilterSet}
                     />
                 }
             >
@@ -339,11 +379,17 @@ export function BlockHistoryCard({
                     {title}
                 </CardTitle>
                 <FilterDropdown
-                    filter={programFilter}
-                    invokedPrograms={invokedPrograms}
-                    totalTransactionCount={transactions.length}
-                ></FilterDropdown>
+                    options={filterModel.options}
+                    currentFilter={programFilter}
+                    isFilterSet={isProgramFilterSet}
+                />
             </CardHeader>
+
+            {isProgramFilterSet && (
+                <CardBody ui="dashkit">
+                    <FilterChip label={filterModel.current.name} />
+                </CardBody>
+            )}
 
             {accountFilter !== null && (
                 <CardBody ui="dashkit">
@@ -364,7 +410,10 @@ export function BlockHistoryCard({
                 <BaseTable ui="dashkit" variant="card" nowrap>
                     <BaseTable.Head>
                         <BaseTable.Row>
-                            <BaseTable.HeaderCell className="cursor-pointer text-dk-gray-700" onClick={() => pushSort()}>
+                            <BaseTable.HeaderCell
+                                className="cursor-pointer text-dk-gray-700"
+                                onClick={() => pushSort()}
+                            >
                                 #
                             </BaseTable.HeaderCell>
                             <BaseTable.HeaderCell className="text-dk-gray-700">Result</BaseTable.HeaderCell>
@@ -523,12 +572,14 @@ const numberFmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
 
 // Sort affordance for a header: a dim up/down chevron pair signals the column is clickable; on the
 // active column the arrow for the current direction lights up bright white (the other stays dim).
-// The chevron stack is taller than the header text, so it's absolutely positioned inside a text-height
-// box — it never grows the row. `-translate-y-[calc(50%+1px)]` centres it, then nudges it 1px higher.
+// The chevron stack is taller than the header text, so it's absolutely positioned inside a box whose
+// height matches the header line (`h-4` = text-xs line-height) and centred — it never grows the row,
+// and the top/bottom overflow stays symmetric so the header's own padding reads even. The box is `w-1`
+// (narrower than the glyphs) so the chevrons overflow it and centre tightly under the label.
 function SortIndicator({ active, direction }: { active: boolean; direction: 'asc' | 'desc' }) {
     return (
-        <span className="relative inline-block h-4 w-3 align-top">
-            <span className="absolute inset-x-0 top-1/2 flex -translate-y-[calc(50%+1px)] flex-col items-center leading-none">
+        <span className="relative inline-block h-4 w-1">
+            <span className="absolute inset-x-0 top-1/2 flex -translate-y-1/2 flex-col items-center leading-none">
                 <ChevronUp
                     size={11}
                     strokeWidth={2.5}
@@ -605,15 +656,11 @@ function BlockHistoryGrid({
                             )}
                             onClick={sortable ? () => onSort(header.sortKey) : undefined}
                         >
-                            {/* For right-aligned numeric columns the indicator goes to the LEFT of the label so
-                                the label's right edge still lines up exactly with the values below; the "#"
-                                column (left-aligned) keeps it on the right. */}
-                            <span className="inline-flex items-center gap-1">
-                                {sortable && header.numeric && (
-                                    <SortIndicator active={active} direction={active ? sortDirection : 'desc'} />
-                                )}
+                            {/* The chevron pair always follows the label (right-aligned numeric columns keep it
+                                to the right of the label too). */}
+                            <span className="inline-flex items-center gap-2">
                                 {header.label}
-                                {sortable && !header.numeric && (
+                                {sortable && (
                                     <SortIndicator active={active} direction={active ? sortDirection : 'desc'} />
                                 )}
                             </span>
@@ -662,7 +709,9 @@ function BlockHistoryGridRow({
             <div className="grid items-center gap-x-1.5 gap-y-0.5" style={{ gridTemplateColumns: 'auto 1fr' }}>
                 {entries.map(([programId, count]) => (
                     <React.Fragment key={programId}>
-                        <span className="whitespace-nowrap text-right tabular-nums text-outer-space-300">{count} ×</span>
+                        <span className="whitespace-nowrap text-right tabular-nums text-outer-space-300">
+                            {count} ×
+                        </span>
                         <Address pubkey={new PublicKey(programId)} link />
                     </React.Fragment>
                 ))}
@@ -740,12 +789,6 @@ function BlockHistoryMobileField({
     );
 }
 
-type FilterProps = {
-    filter: string;
-    invokedPrograms: Map<string, number>;
-    totalTransactionCount: number;
-};
-
 const ALL_TRANSACTIONS = 'all';
 const HIDE_VOTES = '';
 
@@ -755,37 +798,38 @@ type FilterOption = {
     transactionCount: number;
 };
 
-const FilterDropdown = ({ filter, invokedPrograms, totalTransactionCount }: FilterProps) => {
-    const { cluster } = useCluster();
+// Builds the dropdown's option list plus the currently-active option. Kept as a plain function (not a
+// component) so both the dropdown and the removable chip below the title work off the same model.
+// "All Except Votes" is the empty-param default; "All Transactions" is the "no filter" state.
+function buildFilterModel(
+    filter: string,
+    invokedPrograms: Map<string, number>,
+    cluster: Parameters<typeof displayAddress>[1],
+    totalTransactionCount: number,
+): { current: FilterOption; options: FilterOption[] } {
     const defaultFilterOption: FilterOption = {
         name: 'All Except Votes',
         programId: HIDE_VOTES,
         transactionCount: totalTransactionCount - (invokedPrograms.get(VOTE_PROGRAM_ID.toBase58()) || 0),
     };
-
     const allTransactionsOption: FilterOption = {
         name: 'All Transactions',
         programId: ALL_TRANSACTIONS,
         transactionCount: totalTransactionCount,
     };
 
-    let currentFilterOption = filter !== ALL_TRANSACTIONS ? defaultFilterOption : allTransactionsOption;
-
-    const filterOptions: FilterOption[] = [defaultFilterOption, allTransactionsOption];
+    let current = filter === ALL_TRANSACTIONS ? allTransactionsOption : defaultFilterOption;
+    const options: FilterOption[] = [defaultFilterOption, allTransactionsOption];
 
     invokedPrograms.forEach((transactionCount, programId) => {
-        const name = displayAddress(programId, cluster);
+        const option: FilterOption = { name: displayAddress(programId, cluster), programId, transactionCount };
         if (filter === programId) {
-            currentFilterOption = {
-                name: `${name} Transactions (${transactionCount})`,
-                programId,
-                transactionCount,
-            };
+            current = option;
         }
-        filterOptions.push({ name, programId, transactionCount });
+        options.push(option);
     });
 
-    filterOptions.sort((a, b) => {
+    options.sort((a, b) => {
         if (a.transactionCount !== b.transactionCount) {
             return b.transactionCount - a.transactionCount;
         } else {
@@ -793,27 +837,105 @@ const FilterDropdown = ({ filter, invokedPrograms, totalTransactionCount }: Filt
         }
     });
 
+    return { current, options };
+}
+
+const FilterDropdown = ({
+    options,
+    currentFilter,
+    isFilterSet,
+}: {
+    options: FilterOption[];
+    currentFilter: string;
+    isFilterSet: boolean;
+}) => {
+    const [query, setQuery] = React.useState('');
+    const trimmed = query.trim().toLowerCase();
+    const visibleOptions = trimmed === '' ? options : options.filter(o => o.name.toLowerCase().includes(trimmed));
+
     return (
         <Dropdown className="mr-1.5">
             <DropdownToggle asChild>
-                <Button ui="dashkit" variant="white" size="sm" type="button">
-                    {currentFilterOption.name} <ChevronDown className="align-text-top" size={13} />
+                {/* Icon-only below md; the label appears from md up. The dot marks an active filter. */}
+                <Button ui="dashkit" variant="white" size="sm" type="button" className="relative" aria-label="Filters">
+                    <Filter size={13} className="relative top-0.5 inline align-text-top md:mr-1.5" />
+                    <span className="hidden md:inline">Filters</span>
+                    {isFilterSet && (
+                        // `bg-accent` (≈ accent-600) is the dot; the ring is `accent-700`, the next darker
+                        // step in the tw palette, so the badge reads as a two-tone green.
+                        <span
+                            aria-hidden
+                            className="absolute -right-[3px] -top-[3px] h-2.5 w-2.5 rounded-full border border-solid border-accent-700 bg-accent"
+                        />
+                    )}
                 </Button>
             </DropdownToggle>
-            <DropdownMenu align="end" className="max-h-80 overflow-y-auto !border-white/20">
-                {filterOptions.map(({ name, programId, transactionCount }) => (
-                    <FilterLink
-                        currentFilter={filter}
-                        key={programId}
-                        name={name}
-                        programId={programId}
-                        transactionCount={transactionCount}
-                    />
-                ))}
+            <DropdownMenu align="end" className="mt-0.5 w-[280px] !border-white/20">
+                {/* `-mt-2` cancels the menu's base `py-2` (8px) above the field so the search box sits 10px
+                    from every edge — otherwise the menu's top padding stacks with this container's. */}
+                <div className="-mt-2 p-2.5">
+                    <div className="relative">
+                        <Search
+                            size={13}
+                            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-outer-space-300"
+                        />
+                        <Input
+                            variant="dark"
+                            value={query}
+                            onChange={event => setQuery(event.target.value)}
+                            placeholder="Program"
+                            // Height comes from the base py-2.5 (10px) alone — a fixed height would add to
+                            // the padding under Storybook's content-box (no Preflight) and read as > 10px.
+                            className="!h-auto pl-8"
+                        />
+                    </div>
+                </div>
+                <div className="max-h-72 overflow-y-auto">
+                    {visibleOptions.length === 0 ? (
+                        <div className="px-6 py-1.5 text-dk-base text-dark-muted-foreground">No matches</div>
+                    ) : (
+                        visibleOptions.map(({ name, programId, transactionCount }) => (
+                            <FilterLink
+                                currentFilter={currentFilter}
+                                key={programId}
+                                name={name}
+                                programId={programId}
+                                transactionCount={transactionCount}
+                            />
+                        ))
+                    )}
+                </div>
             </DropdownMenu>
         </Dropdown>
     );
 };
+
+// The active filter shown as a removable chip below the block title. Clearing it resets to
+// "All Transactions" (the "no filter" state), so the trailing param lands on `filter=all`.
+function FilterChip({ label }: { label: string }) {
+    const currentSearchParams = useSearchParams();
+    const currentPathname = usePathname();
+    const resetHref = useMemo(() => {
+        const params = new URLSearchParams(currentSearchParams?.toString());
+        params.set('filter', ALL_TRANSACTIONS);
+        const nextQueryString = params.toString();
+        return `${currentPathname}${nextQueryString ? `?${nextQueryString}` : ''}`;
+    }, [currentPathname, currentSearchParams]);
+
+    return (
+        <div className="inline-flex max-w-full items-center rounded-full border border-solid border-outer-space-800 bg-outer-space-900 py-0.5 pl-2.5 pr-0.5 text-sm text-white">
+            <span className="mr-1.5 shrink-0 text-outer-space-300">Program</span>
+            <span className="min-w-0 truncate">{label}</span>
+            <Link
+                href={resetHref}
+                aria-label="Clear filter"
+                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-outer-space-300 hover:bg-white/10 hover:text-white"
+            >
+                <X size={13} />
+            </Link>
+        </div>
+    );
+}
 
 function FilterLink({
     currentFilter,
@@ -830,16 +952,21 @@ function FilterLink({
     const currentPathname = usePathname();
     const href = useMemo(() => {
         const params = new URLSearchParams(currentSearchParams?.toString());
-        if (name === HIDE_VOTES) {
+        if (programId === HIDE_VOTES) {
             params.delete('filter');
         } else {
             params.set('filter', programId);
         }
         const nextQueryString = params.toString();
         return `${currentPathname}${nextQueryString ? `?${nextQueryString}` : ''}`;
-    }, [currentPathname, currentSearchParams, name, programId]);
+    }, [currentPathname, currentSearchParams, programId]);
     return (
-        <DropdownItem asChild className={cn(programId === currentFilter && 'active')} key={programId}>
+        <DropdownItem
+            asChild
+            // Fixed-width menu: long program names wrap instead of widening it (override the base nowrap).
+            className={cn('!whitespace-normal break-words', programId === currentFilter && 'active')}
+            key={programId}
+        >
             <Link href={href} className="relative">
                 {programId === currentFilter && (
                     <span

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -123,19 +123,21 @@ export function BlockHistoryCard({
     // Sort is driven by URL params (`sort` + `dir`); the grid variant's sortable headers push through here.
     // Clicking the active column flips its direction; clicking another column selects it at its natural
     // default direction. `index` ascending is the default view, so it's written as no params (clean URL);
-    // passing no key clears the sort entirely (the old table's "#" reset). We build the URL from a copy of
-    // the current params so a `delete` actually drops the keys — `pickClusterParams` only adds/overrides.
+    // passing no key clears the sort entirely (the old table's "#" reset). The mobile sort menu passes an
+    // explicit direction (its rows are per-direction) which short-circuits the toggle. We build the URL
+    // from a copy of the current params so a `delete` drops the keys — `pickClusterParams` only overrides.
     const pushSort = React.useCallback(
-        (sortKey?: SortMode) => {
+        (sortKey?: SortMode, explicitDirection?: SortDirection) => {
             const nextParams = new URLSearchParams(currentSearchParams?.toString());
             const nextDirection: SortDirection =
-                sortKey && sortKey === sortMode
+                explicitDirection ??
+                (sortKey && sortKey === sortMode
                     ? sortDirection === 'asc'
                         ? 'desc'
                         : 'asc'
                     : sortKey
                       ? DEFAULT_DIRECTION[sortKey]
-                      : 'asc';
+                      : 'asc');
             if (sortKey && !(sortKey === 'index' && nextDirection === 'asc')) {
                 nextParams.set('sort', sortKey);
                 nextParams.set('dir', nextDirection);
@@ -326,11 +328,21 @@ export function BlockHistoryCard({
                     ) : undefined
                 }
                 actions={
-                    <FilterDropdown
-                        options={filterModel.options}
-                        currentFilter={programFilter}
-                        isFilterSet={isProgramFilterSet}
-                    />
+                    <>
+                        {/* Mobile-only: the grid's sort headers are hidden below md, so surface them here,
+                            to the left of the filter. */}
+                        <SortDropdown
+                            showComputeUnits={showComputeUnits}
+                            sortMode={sortMode}
+                            sortDirection={sortDirection}
+                            onSort={pushSort}
+                        />
+                        <FilterDropdown
+                            options={filterModel.options}
+                            currentFilter={programFilter}
+                            isFilterSet={isProgramFilterSet}
+                        />
+                    </>
                 }
             >
                 <div className="flex flex-col gap-3">
@@ -905,6 +917,102 @@ const FilterDropdown = ({
                         ))
                     )}
                 </div>
+            </DropdownMenu>
+        </Dropdown>
+    );
+};
+
+// Sortable columns in header order, mirroring the grid's clickable headers (Compute only when its data
+// exists). The nouns fill the "Lowest …" / "Highest …" sort-menu labels.
+const SORT_NOUNS: Record<SortMode, string> = {
+    compute: 'CUs consumed',
+    fee: 'fee',
+    index: 'index',
+    reservedCUs: 'CUs reserved',
+    txnCost: 'cost',
+};
+
+function sortModes(showComputeUnits: boolean): SortMode[] {
+    return ['index', 'fee', ...(showComputeUnits ? (['compute'] as const) : []), 'reservedCUs', 'txnCost'];
+}
+
+// The two-glyph indicator used in the sort menu: the arrow for this row's direction takes the row's text
+// colour (`text-current`), the other stays a dimmer, darker grey.
+function SortOptionGlyph({ direction }: { direction: SortDirection }) {
+    return (
+        <span aria-hidden className="relative inline-block h-4 w-2 align-text-top">
+            <span className="absolute inset-x-0 top-1/2 flex -translate-y-1/2 flex-col items-center leading-none">
+                <ChevronUp
+                    size={11}
+                    strokeWidth={2.5}
+                    className={direction === 'asc' ? 'text-current' : 'text-outer-space-600'}
+                />
+                <ChevronDown
+                    size={11}
+                    strokeWidth={2.5}
+                    className={cn('-mt-1', direction === 'desc' ? 'text-current' : 'text-outer-space-600')}
+                />
+            </span>
+        </span>
+    );
+}
+
+// Mobile-only counterpart to the grid's sortable headers (hidden below md): a "Filters"-style button
+// opening every sort column split into its two directions ("Lowest …" ascending, "Highest …" descending).
+// Each row pushes an explicit direction through the same `onSort` (pushSort) path the headers use.
+const SortDropdown = ({
+    showComputeUnits,
+    sortMode,
+    sortDirection,
+    onSort,
+}: {
+    showComputeUnits: boolean;
+    sortMode: SortMode;
+    sortDirection: SortDirection;
+    onSort: (sortKey: SortMode, direction: SortDirection) => void;
+}) => {
+    const options = sortModes(showComputeUnits).flatMap(mode => [
+        { direction: 'asc' as SortDirection, label: `Lowest ${SORT_NOUNS[mode]}`, mode },
+        { direction: 'desc' as SortDirection, label: `Highest ${SORT_NOUNS[mode]}`, mode },
+    ]);
+
+    return (
+        <Dropdown className="mr-1.5 md:hidden">
+            <DropdownToggle asChild>
+                <Button ui="dashkit" variant="white" size="sm" type="button" aria-label="Sort">
+                    {/* Up/down chevron pair — the same sort motif the table headers carry. */}
+                    <span aria-hidden className="relative inline-block h-4 w-3 align-text-top">
+                        <span className="absolute inset-x-0 top-1/2 flex -translate-y-1/2 flex-col items-center leading-none">
+                            <ChevronUp size={11} strokeWidth={2.5} />
+                            <ChevronDown size={11} strokeWidth={2.5} className="-mt-1" />
+                        </span>
+                    </span>
+                </Button>
+            </DropdownToggle>
+            <DropdownMenu align="end" className="mt-0.5 w-[220px] !border-white/20">
+                {options.map(({ direction, label, mode }) => {
+                    const active = sortMode === mode && sortDirection === direction;
+                    return (
+                        <DropdownItem
+                            key={`${mode}-${direction}`}
+                            role="button"
+                            onClick={() => onSort(mode, direction)}
+                            className={cn('relative cursor-pointer', active && 'active')}
+                        >
+                            {active && (
+                                <span
+                                    aria-hidden
+                                    className="absolute left-2.5 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-current"
+                                />
+                            )}
+                            {/* Glyph sits right after the label, not pushed to the row's end. */}
+                            <span className="inline-flex items-center gap-1.5">
+                                {label}
+                                <SortOptionGlyph direction={direction} />
+                            </span>
+                        </DropdownItem>
+                    );
+                })}
             </DropdownMenu>
         </Dropdown>
     );

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -23,11 +23,23 @@ import { ChevronDown } from 'react-feather';
 import { Badge } from '@/app/components/shared/ui/badge';
 import { Button } from '@/app/components/shared/ui/button';
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from '@/app/components/shared/ui/dropdown';
+import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardBody, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 const PAGE_SIZE = 25;
+
+// Design variant, switchable via prop (see the other block cards for the same pattern):
+//   - 'default'     — the original Dashkit table.
+//   - 'collapsible' — the domains-card treatment (PR #115): the title lifted out above a collapsible
+//                     section (filter dropdown kept as its action), list on a `tight` card surface,
+//                     CSS-grid body on `lg+` and a stacked, labelled layout below `lg`. Sorting and
+//                     "Load More" are preserved.
+export type BlockHistoryVariant = 'default' | 'collapsible';
+
+// Surface matched to the transaction tables (see BaseDomainsCard) — set on a `variant="tight"` Card.
+const TIGHT_CARD = 'overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900';
 
 const useQueryProgramFilter = (query: ReadonlyURLSearchParams): string => {
     const filter = query.get('filter');
@@ -67,7 +79,15 @@ type TransactionWithInvocations = {
     logTruncated: boolean;
 };
 
-export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockResponse; epoch: bigint | undefined }) {
+export function BlockHistoryCard({
+    block,
+    epoch,
+    variant = 'default',
+}: {
+    block: VersionedBlockResponse;
+    epoch: bigint | undefined;
+    variant?: BlockHistoryVariant;
+}) {
     const [numDisplayed, setNumDisplayed] = React.useState(PAGE_SIZE);
     const currentPathname = usePathname();
     const currentSearchParams = useSearchParams();
@@ -76,6 +96,21 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
     const sortMode = useQuerySort(currentSearchParams);
     const router = useRouter();
     const { cluster } = useCluster();
+
+    // Sort is driven by a URL param; the grid variant's sortable headers push through here. Passing no
+    // key clears the sort (the "#" header's reset behaviour).
+    const pushSort = React.useCallback(
+        (sortKey?: string) => {
+            const additionalParams = new URLSearchParams(currentSearchParams?.toString());
+            if (sortKey) {
+                additionalParams.set('sort', sortKey);
+            } else {
+                additionalParams.delete('sort');
+            }
+            router.push(pickClusterParams(currentPathname, currentSearchParams, additionalParams));
+        },
+        [currentPathname, currentSearchParams, router],
+    );
 
     const { transactions, invokedPrograms } = React.useMemo(() => {
         const invokedPrograms = new Map<string, number>();
@@ -199,6 +234,59 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
         title = `Block Transactions (${filteredTransactions.length})`;
     } else {
         title = `Filtered Block Transactions (${filteredTransactions.length}/${transactions.length})`;
+    }
+
+    if (variant === 'collapsible') {
+        const visible = filteredTransactions.slice(0, numDisplayed);
+        const hasMore = filteredTransactions.length > numDisplayed;
+        const emptyFilterMessage =
+            accountFilter === null && programFilter === HIDE_VOTES
+                ? "This block doesn't contain any non-vote transactions"
+                : 'No transactions found with this filter';
+
+        return (
+            <CollapsibleSection
+                title={title}
+                className=""
+                actions={
+                    <FilterDropdown
+                        filter={programFilter}
+                        invokedPrograms={invokedPrograms}
+                        totalTransactionCount={transactions.length}
+                    />
+                }
+            >
+                <div className="flex flex-col gap-3">
+                    {accountFilter !== null && (
+                        <div className="text-sm text-white">
+                            Showing transactions which load account:
+                            <span className="ml-1.5 inline-block align-middle">
+                                <Address pubkey={accountFilter} link />
+                            </span>
+                        </div>
+                    )}
+                    <Card variant="tight" className={TIGHT_CARD}>
+                        {filteredTransactions.length === 0 ? (
+                            <div className="px-4 py-3 text-sm text-white">{emptyFilterMessage}</div>
+                        ) : (
+                            <BlockHistoryGrid rows={visible} showComputeUnits={showComputeUnits} onSort={pushSort} />
+                        )}
+                        {hasMore && (
+                            <div className="border-t border-solid border-white/10 px-3 py-4 md:px-4">
+                                <Button
+                                    ui="dashkit"
+                                    variant="primary"
+                                    className="w-full"
+                                    onClick={() => setNumDisplayed(displayed => displayed + PAGE_SIZE)}
+                                >
+                                    Load More
+                                </Button>
+                            </div>
+                        )}
+                    </Card>
+                </div>
+            </CollapsibleSection>
+        );
     }
 
     return (
@@ -388,6 +476,156 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
                 </CardFooter>
             )}
         </Card>
+    );
+}
+
+// Domain status → badge label/variant. Mirrors the default table's inline mapping.
+const HISTORY_STATUS = {
+    failed: { label: 'Failed', variant: 'warning' },
+    success: { label: 'Success', variant: 'success' },
+} as const;
+
+const numberFmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
+
+// Domains-card style — a CSS grid on lg+, stacked labelled rows below lg. Sortable numeric headers push
+// the sort through `onSort` (same URL-param mechanism as the default table).
+function BlockHistoryGrid({
+    rows,
+    showComputeUnits,
+    onSort,
+}: {
+    rows: TransactionWithInvocations[];
+    showComputeUnits: boolean;
+    onSort: (sortKey?: string) => void;
+}) {
+    // Signature takes the slack; the rest are capped. Inline (not a `grid-cols-[…]` class) so the
+    // Storybook JIT can't purge it. The Compute column only exists when compute data is available.
+    // Following the transaction-history card, Result (badge) sits inline with the signature and the
+    // invoked programs stack beneath it — so neither gets its own column.
+    const gridStyle: React.CSSProperties = {
+        gridTemplateColumns: `minmax(auto,1.25rem) minmax(0,1fr) minmax(auto,7rem) minmax(auto,8rem) ${
+            showComputeUnits ? 'minmax(auto,8rem) ' : ''
+        }minmax(auto,7rem)`,
+    };
+
+    const headers: { label: string; numeric?: boolean; onClick?: () => void }[] = [
+        { label: '#', onClick: () => onSort() },
+        { label: 'Transaction Signature' },
+        { label: 'Fee', numeric: true, onClick: () => onSort('fee') },
+        { label: 'Reserved CUs', numeric: true, onClick: () => onSort('reservedCUs') },
+        ...(showComputeUnits ? [{ label: 'Compute', numeric: true, onClick: () => onSort('compute') }] : []),
+        { label: 'Txn Cost', numeric: true, onClick: () => onSort('txnCost') },
+    ];
+
+    return (
+        <div className="text-sm text-white">
+            <div
+                style={gridStyle}
+                className="hidden gap-4 border-b border-solid border-white/10 px-4 py-2.5 text-xs uppercase text-outer-space-300 lg:grid"
+            >
+                {headers.map(header => (
+                    <div
+                        key={header.label}
+                        className={cn(header.numeric && 'text-right', header.onClick && 'cursor-pointer select-none')}
+                        onClick={header.onClick}
+                    >
+                        {header.label}
+                    </div>
+                ))}
+            </div>
+            {rows.map((tx, i) => (
+                <BlockHistoryGridRow key={i} tx={tx} showComputeUnits={showComputeUnits} gridStyle={gridStyle} />
+            ))}
+        </div>
+    );
+}
+
+function BlockHistoryGridRow({
+    tx,
+    showComputeUnits,
+    gridStyle,
+}: {
+    tx: TransactionWithInvocations;
+    showComputeUnits: boolean;
+    gridStyle: React.CSSProperties;
+}) {
+    const failed = Boolean(tx.meta?.err) || !tx.signature;
+    const status = failed ? HISTORY_STATUS.failed : HISTORY_STATUS.success;
+    const badge = (
+        <Badge ui="dashkit" variant={status.variant}>
+            {status.label}
+        </Badge>
+    );
+    const signatureNode = tx.signature ? <Signature signature={tx.signature} link /> : '-';
+    const feeNode = tx.meta !== null ? <SolBalance lamports={tx.meta.fee} /> : 'Unknown';
+    const reserved = tx.reservedComputeUnits !== undefined ? numberFmt(tx.reservedComputeUnits) : 'Unknown';
+    const compute = `${tx.logTruncated ? '>' : ''}${tx.computeUnits !== undefined ? numberFmt(tx.computeUnits) : 'Unknown'}`;
+    const txnCost = tx.costUnits !== undefined ? numberFmt(tx.costUnits) : 'Unknown';
+    const entries = Array.from(tx.invocations.entries());
+    entries.sort();
+    const invokedNode =
+        entries.length === 0 ? (
+            'NA'
+        ) : (
+            // Two-column grid so the "N ×" counters share one right-aligned column (any width) and every
+            // program name lines up in the next — stays aligned no matter how large the count grows.
+            // `tabular-nums` keeps multi-digit counts from jittering. Inline grid template so the
+            // Storybook JIT can't purge it.
+            <div className="grid items-center gap-x-1.5 gap-y-0.5" style={{ gridTemplateColumns: 'auto 1fr' }}>
+                {entries.map(([programId, count]) => (
+                    <React.Fragment key={programId}>
+                        <span className="text-right tabular-nums text-outer-space-300">{count} ×</span>
+                        <Address pubkey={new PublicKey(programId)} link />
+                    </React.Fragment>
+                ))}
+            </div>
+        );
+
+    // Signature block: signature with the Result badge to its right, invoked programs stacked beneath —
+    // mirroring the transaction-history card (signature + status inline, instructions below).
+    const signatureBlock = (
+        <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+                <span className="min-w-0">{signatureNode}</span>
+                {badge}
+            </div>
+            <div className="mt-1">{invokedNode}</div>
+        </div>
+    );
+
+    return (
+        <div className="border-b border-solid border-white/10 last:border-b-0">
+            {/* Mobile / tablet — stacked, labelled rows. */}
+            <div className="flex flex-col gap-1.5 px-4 py-3 lg:hidden">
+                <div className="flex items-start gap-2">
+                    <span className="shrink-0 text-outer-space-300">#{tx.index + 1}</span>
+                    {signatureBlock}
+                </div>
+                <BlockHistoryMobileField label="Fee">{feeNode}</BlockHistoryMobileField>
+                <BlockHistoryMobileField label="Reserved CUs">{reserved}</BlockHistoryMobileField>
+                {showComputeUnits && <BlockHistoryMobileField label="Compute">{compute}</BlockHistoryMobileField>}
+                <BlockHistoryMobileField label="Txn Cost">{txnCost}</BlockHistoryMobileField>
+            </div>
+
+            {/* Desktop grid row. */}
+            <div style={gridStyle} className="hidden items-start gap-4 px-4 py-3 lg:grid">
+                <div className="text-outer-space-300">{tx.index + 1}</div>
+                {signatureBlock}
+                <div className="text-right">{feeNode}</div>
+                <div className="text-right">{reserved}</div>
+                {showComputeUnits && <div className="text-right">{compute}</div>}
+                <div className="text-right">{txnCost}</div>
+            </div>
+        </div>
+    );
+}
+
+function BlockHistoryMobileField({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex items-center gap-2">
+            <span className="w-32 shrink-0 text-outer-space-300">{label}</span>
+            <span className="min-w-0">{children}</span>
+        </div>
     );
 }
 

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -98,16 +98,19 @@ export function BlockHistoryCard({
     const { cluster } = useCluster();
 
     // Sort is driven by a URL param; the grid variant's sortable headers push through here. Passing no
-    // key clears the sort (the "#" header's reset behaviour).
+    // key clears the sort (the "#" header's reset back to index order). We build the URL from a copy of the
+    // current params so a `delete` actually drops `sort` — `pickClusterParams` only ever adds/overrides
+    // keys, so routing the reset through it would leave the stale `sort` in place.
     const pushSort = React.useCallback(
         (sortKey?: string) => {
-            const additionalParams = new URLSearchParams(currentSearchParams?.toString());
+            const nextParams = new URLSearchParams(currentSearchParams?.toString());
             if (sortKey) {
-                additionalParams.set('sort', sortKey);
+                nextParams.set('sort', sortKey);
             } else {
-                additionalParams.delete('sort');
+                nextParams.delete('sort');
             }
-            router.push(pickClusterParams(currentPathname, currentSearchParams, additionalParams));
+            const queryString = nextParams.toString();
+            router.push(`${currentPathname}${queryString ? `?${queryString}` : ''}`);
         },
         [currentPathname, currentSearchParams, router],
     );
@@ -321,16 +324,7 @@ export function BlockHistoryCard({
                 <BaseTable ui="dashkit" variant="card" nowrap>
                     <BaseTable.Head>
                         <BaseTable.Row>
-                            <BaseTable.HeaderCell
-                                className="cursor-pointer text-dk-gray-700"
-                                onClick={() => {
-                                    const additionalParams = new URLSearchParams(currentSearchParams?.toString());
-                                    additionalParams.delete('sort');
-                                    router.push(
-                                        pickClusterParams(currentPathname, currentSearchParams, additionalParams),
-                                    );
-                                }}
-                            >
+                            <BaseTable.HeaderCell className="cursor-pointer text-dk-gray-700" onClick={() => pushSort()}>
                                 #
                             </BaseTable.HeaderCell>
                             <BaseTable.HeaderCell className="text-dk-gray-700">Result</BaseTable.HeaderCell>
@@ -359,7 +353,7 @@ export function BlockHistoryCard({
                                     );
                                 }}
                             >
-                                Reserved CUs
+                                CUs Reserved
                             </BaseTable.HeaderCell>
                             {showComputeUnits && (
                                 <BaseTable.HeaderCell
@@ -372,7 +366,7 @@ export function BlockHistoryCard({
                                         );
                                     }}
                                 >
-                                    Compute
+                                    CUs Consumed
                                 </BaseTable.HeaderCell>
                             )}
                             <BaseTable.HeaderCell
@@ -503,18 +497,18 @@ function BlockHistoryGrid({
     // exists when compute data is available. Following the transaction-history card, Result (badge) sits
     // inline with the signature and the invoked programs stack beneath it — so neither gets its own column.
     const gridStyle: React.CSSProperties = {
-        gridTemplateColumns: `minmax(auto,1.25rem) minmax(0,1fr) minmax(auto,6rem) minmax(auto,6rem) ${
-            showComputeUnits ? 'minmax(auto,4rem) ' : ''
+        gridTemplateColumns: `minmax(auto,2.5rem) minmax(0,1fr) minmax(auto,7rem) minmax(auto,6rem) ${
+            showComputeUnits ? 'minmax(auto,6rem) ' : ''
         }minmax(auto,4rem)`,
     };
 
     const headers: { label: string; numeric?: boolean; onClick?: () => void }[] = [
         { label: '#', onClick: () => onSort() },
-        { label: 'Transaction Signature' },
+        { label: 'Signature / Programs' },
         { label: 'Fee', numeric: true, onClick: () => onSort('fee') },
-        { label: 'Reserved CUs', numeric: true, onClick: () => onSort('reservedCUs') },
-        ...(showComputeUnits ? [{ label: 'Compute', numeric: true, onClick: () => onSort('compute') }] : []),
-        { label: 'Txn Cost', numeric: true, onClick: () => onSort('txnCost') },
+        { label: 'CUs Reserved', numeric: true, onClick: () => onSort('reservedCUs') },
+        ...(showComputeUnits ? [{ label: 'CUs Consumed', numeric: true, onClick: () => onSort('compute') }] : []),
+        { label: 'Cost', numeric: true, onClick: () => onSort('txnCost') },
     ];
 
     return (
@@ -585,7 +579,7 @@ function BlockHistoryGridRow({
     // invoked programs stack directly beneath it (`signatureBlock`); on mobile they move to their own
     // labelled "Programs" field, so here the header stays on its own.
     const signatureHeader = (
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
             <span className="min-w-0">{signatureNode}</span>
             {badge}
         </div>
@@ -608,9 +602,9 @@ function BlockHistoryGridRow({
                     <div className="pr-10">{signatureHeader}</div>
                 </BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Fee">{feeNode}</BlockHistoryMobileField>
-                <BlockHistoryMobileField label="Reserved CUs">{reserved}</BlockHistoryMobileField>
-                {showComputeUnits && <BlockHistoryMobileField label="Compute">{compute}</BlockHistoryMobileField>}
-                <BlockHistoryMobileField label="Txn Cost">{txnCost}</BlockHistoryMobileField>
+                <BlockHistoryMobileField label="CUs Reserved">{reserved}</BlockHistoryMobileField>
+                {showComputeUnits && <BlockHistoryMobileField label="CUs Consumed">{compute}</BlockHistoryMobileField>}
+                <BlockHistoryMobileField label="Cost">{txnCost}</BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Programs" align="start">
                     {invokedNode}
                 </BlockHistoryMobileField>
@@ -712,7 +706,7 @@ const FilterDropdown = ({ filter, invokedPrograms, totalTransactionCount }: Filt
                     {currentFilterOption.name} <ChevronDown className="align-text-top" size={13} />
                 </Button>
             </DropdownToggle>
-            <DropdownMenu align="end" className="max-h-80 overflow-y-auto">
+            <DropdownMenu align="end" className="max-h-80 overflow-y-auto !border-white/20">
                 {filterOptions.map(({ name, programId, transactionCount }) => (
                     <FilterLink
                         currentFilter={filter}
@@ -752,7 +746,15 @@ function FilterLink({
     }, [currentPathname, currentSearchParams, name, programId]);
     return (
         <DropdownItem asChild className={cn(programId === currentFilter && 'active')} key={programId}>
-            <Link href={href}>{`${name} (${transactionCount})`}</Link>
+            <Link href={href} className="relative">
+                {programId === currentFilter && (
+                    <span
+                        aria-hidden
+                        className="absolute left-2.5 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-current"
+                    />
+                )}
+                {`${name} (${transactionCount})`}
+            </Link>
         </DropdownItem>
     );
 }

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -34,7 +34,7 @@ const PAGE_SIZE = 25;
 //   - 'default'     — the original Dashkit table.
 //   - 'collapsible' — the domains-card treatment (PR #115): the title lifted out above a collapsible
 //                     section (filter dropdown kept as its action), list on a `tight` card surface,
-//                     CSS-grid body on `lg+` and a stacked, labelled layout below `lg`. Sorting and
+//                     CSS-grid body on `md+` and a stacked, labelled layout below `md`. Sorting and
 //                     "Load More" are preserved.
 export type BlockHistoryVariant = 'default' | 'collapsible';
 
@@ -487,7 +487,7 @@ const HISTORY_STATUS = {
 
 const numberFmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
 
-// Domains-card style — a CSS grid on lg+, stacked labelled rows below lg. Sortable numeric headers push
+// Domains-card style — a CSS grid on md+, stacked labelled rows below md. Sortable numeric headers push
 // the sort through `onSort` (same URL-param mechanism as the default table).
 function BlockHistoryGrid({
     rows,
@@ -498,14 +498,14 @@ function BlockHistoryGrid({
     showComputeUnits: boolean;
     onSort: (sortKey?: string) => void;
 }) {
-    // Signature takes the slack; the rest are capped. Inline (not a `grid-cols-[…]` class) so the
-    // Storybook JIT can't purge it. The Compute column only exists when compute data is available.
-    // Following the transaction-history card, Result (badge) sits inline with the signature and the
-    // invoked programs stack beneath it — so neither gets its own column.
+    // Signature takes the slack; the numeric columns are capped tight (≈ content + ~1rem of headroom).
+    // Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it. The Compute column only
+    // exists when compute data is available. Following the transaction-history card, Result (badge) sits
+    // inline with the signature and the invoked programs stack beneath it — so neither gets its own column.
     const gridStyle: React.CSSProperties = {
-        gridTemplateColumns: `minmax(auto,1.25rem) minmax(0,1fr) minmax(auto,7rem) minmax(auto,8rem) ${
-            showComputeUnits ? 'minmax(auto,8rem) ' : ''
-        }minmax(auto,7rem)`,
+        gridTemplateColumns: `minmax(auto,1.25rem) minmax(0,1fr) minmax(auto,6rem) minmax(auto,6rem) ${
+            showComputeUnits ? 'minmax(auto,4rem) ' : ''
+        }minmax(auto,4rem)`,
     };
 
     const headers: { label: string; numeric?: boolean; onClick?: () => void }[] = [
@@ -521,7 +521,7 @@ function BlockHistoryGrid({
         <div className="text-sm text-white">
             <div
                 style={gridStyle}
-                className="hidden gap-4 border-b border-solid border-white/10 px-4 py-2.5 text-xs uppercase text-outer-space-300 lg:grid"
+                className="hidden gap-4 border-b border-solid border-white/10 px-4 py-2.5 text-xs uppercase text-outer-space-300 md:grid"
             >
                 {headers.map(header => (
                     <div
@@ -574,41 +574,50 @@ function BlockHistoryGridRow({
             <div className="grid items-center gap-x-1.5 gap-y-0.5" style={{ gridTemplateColumns: 'auto 1fr' }}>
                 {entries.map(([programId, count]) => (
                     <React.Fragment key={programId}>
-                        <span className="text-right tabular-nums text-outer-space-300">{count} ×</span>
+                        <span className="whitespace-nowrap text-right tabular-nums text-outer-space-300">{count} ×</span>
                         <Address pubkey={new PublicKey(programId)} link />
                     </React.Fragment>
                 ))}
             </div>
         );
 
-    // Signature block: signature with the Result badge to its right, invoked programs stacked beneath —
-    // mirroring the transaction-history card (signature + status inline, instructions below).
+    // Signature with the Result badge to its right — mirroring the transaction-history card. On desktop the
+    // invoked programs stack directly beneath it (`signatureBlock`); on mobile they move to their own
+    // labelled "Programs" field, so here the header stays on its own.
+    const signatureHeader = (
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <span className="min-w-0">{signatureNode}</span>
+            {badge}
+        </div>
+    );
     const signatureBlock = (
         <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-                <span className="min-w-0">{signatureNode}</span>
-                {badge}
-            </div>
+            {signatureHeader}
             <div className="mt-1">{invokedNode}</div>
         </div>
     );
 
     return (
         <div className="border-b border-solid border-white/10 last:border-b-0">
-            {/* Mobile / tablet — stacked, labelled rows. */}
-            <div className="flex flex-col gap-1.5 px-4 py-3 lg:hidden">
-                <div className="flex items-start gap-2">
-                    <span className="shrink-0 text-outer-space-300">#{tx.index + 1}</span>
-                    {signatureBlock}
-                </div>
+            {/* Mobile — stacked, labelled rows matching the Overview card's key/value grid; the index sits
+                in the top-right corner (like the transaction-page account card) and the invoked programs
+                get their own labelled field. */}
+            <div className="relative flex flex-col gap-1.5 px-4 py-3 md:hidden">
+                <span className="absolute right-4 top-3 text-outer-space-300">#{tx.index + 1}</span>
+                <BlockHistoryMobileField label="Signature">
+                    <div className="pr-10">{signatureHeader}</div>
+                </BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Fee">{feeNode}</BlockHistoryMobileField>
                 <BlockHistoryMobileField label="Reserved CUs">{reserved}</BlockHistoryMobileField>
                 {showComputeUnits && <BlockHistoryMobileField label="Compute">{compute}</BlockHistoryMobileField>}
                 <BlockHistoryMobileField label="Txn Cost">{txnCost}</BlockHistoryMobileField>
+                <BlockHistoryMobileField label="Programs" align="start">
+                    {invokedNode}
+                </BlockHistoryMobileField>
             </div>
 
             {/* Desktop grid row. */}
-            <div style={gridStyle} className="hidden items-start gap-4 px-4 py-3 lg:grid">
+            <div style={gridStyle} className="hidden items-start gap-4 px-4 py-3 md:grid">
                 <div className="text-outer-space-300">{tx.index + 1}</div>
                 {signatureBlock}
                 <div className="text-right">{feeNode}</div>
@@ -620,10 +629,24 @@ function BlockHistoryGridRow({
     );
 }
 
-function BlockHistoryMobileField({ label, children }: { label: string; children: React.ReactNode }) {
+function BlockHistoryMobileField({
+    label,
+    children,
+    align = 'baseline',
+}: {
+    label: string;
+    children: React.ReactNode;
+    align?: 'baseline' | 'start';
+}) {
+    // Label column width mirrors the Overview card's key/value grid so the two cards line up.
     return (
-        <div className="flex items-center gap-2">
-            <span className="w-32 shrink-0 text-outer-space-300">{label}</span>
+        <div
+            className={cn(
+                'grid grid-cols-[clamp(100px,25%,200px)_1fr] gap-2',
+                align === 'start' ? 'items-start' : 'items-baseline',
+            )}
+        >
+            <span className="text-outer-space-300">{label}</span>
             <span className="min-w-0">{children}</span>
         </div>
     );

--- a/app/components/block/BlockOverviewCard.tsx
+++ b/app/components/block/BlockOverviewCard.tsx
@@ -216,15 +216,19 @@ export function BlockOverviewCard({
                 <Row divider>
                     <Label>Transaction Cost Utilization</Label>
                     <Value mono={false} breakAll={false}>
-                        {totalCostUnits.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
-                        {Math.round((totalCostUnits / maxComputeUnits) * 100)}%)
+                        {totalCostUnits.toLocaleString()} / {maxComputeUnits.toLocaleString()}{' '}
+                        <span className="text-outer-space-300">
+                            ({Math.round((totalCostUnits / maxComputeUnits) * 100)}%)
+                        </span>
                     </Value>
                 </Row>
                 <Row>
                     <Label>Reserved Compute Units</Label>
                     <Value mono={false} breakAll={false}>
-                        {totalRequestedCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
-                        {Math.round((totalRequestedCUs / maxComputeUnits) * 100)}%)
+                        {totalRequestedCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()}{' '}
+                        <span className="text-outer-space-300">
+                            ({Math.round((totalRequestedCUs / maxComputeUnits) * 100)}%)
+                        </span>
                     </Value>
                 </Row>
             </Card>

--- a/app/components/block/BlockOverviewCard.tsx
+++ b/app/components/block/BlockOverviewCard.tsx
@@ -193,28 +193,28 @@ export function BlockOverviewCard({
                 )}
                 <Row divider>
                     <Label>Processed Transactions</Label>
-                    <Value>{block.transactions.length}</Value>
+                    <Value mono={false}>{block.transactions.length}</Value>
                 </Row>
                 {showSuccessfulCount && (
                     <Row divider>
                         <Label>Successful Transactions</Label>
-                        <Value>{successfulTxs.length}</Value>
+                        <Value mono={false}>{successfulTxs.length}</Value>
                     </Row>
                 )}
                 <Row divider>
                     <Label>Total CUs Consumed</Label>
-                    <Value>{totalCUs.toLocaleString()}</Value>
+                    <Value mono={false}>{totalCUs.toLocaleString()}</Value>
                 </Row>
                 <Row divider>
                     <Label>Transaction Cost Utilization</Label>
-                    <Value>
+                    <Value mono={false}>
                         {totalCostUnits.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
                         {Math.round((totalCostUnits / maxComputeUnits) * 100)}%)
                     </Value>
                 </Row>
                 <Row>
                     <Label>Reserved Compute Units</Label>
-                    <Value>
+                    <Value mono={false}>
                         {totalRequestedCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
                         {Math.round((totalRequestedCUs / maxComputeUnits) * 100)}%)
                     </Value>

--- a/app/components/block/BlockOverviewCard.tsx
+++ b/app/components/block/BlockOverviewCard.tsx
@@ -72,6 +72,7 @@ type BlockOverviewCardProps = {
     childSlot?: number;
     childLeader?: PublicKey;
     parentLeader?: PublicKey;
+    className?: string;
 };
 
 export function BlockOverviewCard({
@@ -82,6 +83,7 @@ export function BlockOverviewCard({
     childSlot,
     childLeader,
     parentLeader,
+    className,
 }: BlockOverviewCardProps) {
     const { cluster } = useCluster();
 
@@ -99,7 +101,7 @@ export function BlockOverviewCard({
     const maxComputeUnits = getMaxComputeUnitsInBlock({ cluster, epoch });
 
     return (
-        <section className="flex flex-col gap-3">
+        <section className={cn('flex flex-col gap-3', className)}>
             <div className="flex items-center justify-between">
                 <h2 className="m-0 text-lg font-normal text-white">Overview</h2>
                 {IBRL_EXPLORER_URL && (

--- a/app/components/block/BlockOverviewCard.tsx
+++ b/app/components/block/BlockOverviewCard.tsx
@@ -1,0 +1,225 @@
+import { Address } from '@components/common/Address';
+import { Copyable } from '@components/common/Copyable';
+import { Epoch } from '@components/common/Epoch';
+import { ExternalLinkWarning } from '@components/common/ExternalLinkWarning';
+import { Slot } from '@components/common/Slot';
+import { cn } from '@components/shared/utils';
+import { estimateRequestedComputeUnits } from '@entities/compute-unit';
+import { useCluster } from '@providers/cluster';
+import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+import { displayTimestamp, displayTimestampUtc } from '@utils/date';
+import { IBRL_EXPLORER_URL } from '@utils/env';
+import React from 'react';
+import { ExternalLink } from 'react-feather';
+
+import { Card } from '@/app/shared/ui/Card';
+import { getMaxComputeUnitsInBlock } from '@/app/utils/epoch-schedule';
+
+// Grid-based key/value row, mirroring the transaction SummaryCard so overview cards stay consistent
+// across pages. The `1fr` value column lets long mono values wrap (`break-all`) instead of forcing
+// the whole card into horizontal scroll on narrow screens.
+type RowProps = React.HTMLAttributes<HTMLDivElement> & { divider?: boolean };
+function Row({ children, className, divider, ...props }: RowProps) {
+    return (
+        <div
+            className={cn(
+                'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
+                divider && 'border-1 border-b border-white/10 [border-bottom-style:solid]',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+}
+
+function Label({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn('flex flex-wrap items-center gap-1 overflow-hidden text-sm text-outer-space-300', className)}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+}
+
+// `mono` toggles the monospace face — on for hashes/addresses/numbers, off for prose like dates.
+// (cn is plain clsx here, so an added `font-sans` wouldn't reliably beat a hardcoded `font-mono`;
+// omitting `font-mono` and inheriting the sans default is the robust way to opt out.)
+function Value({ children, className, mono = true, ...props }: React.HTMLAttributes<HTMLDivElement> & { mono?: boolean }) {
+    return (
+        <div className={cn('break-all text-sm text-white', mono && 'font-mono', className)} {...props}>
+            {children}
+        </div>
+    );
+}
+
+type BlockOverviewCardProps = {
+    block: VersionedBlockResponse;
+    slot: number;
+    epoch: bigint | undefined;
+    blockLeader?: PublicKey;
+    childSlot?: number;
+    childLeader?: PublicKey;
+    parentLeader?: PublicKey;
+};
+
+export function BlockOverviewCard({
+    block,
+    slot,
+    epoch,
+    blockLeader,
+    childSlot,
+    childLeader,
+    parentLeader,
+}: BlockOverviewCardProps) {
+    const { cluster } = useCluster();
+
+    let totalCUs = 0;
+    let totalRequestedCUs = 0;
+    let totalCostUnits = 0;
+    for (const tx of block.transactions) {
+        totalRequestedCUs += estimateRequestedComputeUnits(tx, epoch, cluster);
+        totalCUs += tx.meta?.computeUnitsConsumed ?? 0;
+        totalCostUnits += tx.meta?.costUnits ?? 0;
+    }
+
+    const showSuccessfulCount = block.transactions.every(tx => tx.meta !== null);
+    const successfulTxs = block.transactions.filter(tx => tx.meta?.err === null);
+    const maxComputeUnits = getMaxComputeUnitsInBlock({ cluster, epoch });
+
+    return (
+        <section className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+                <h2 className="m-0 text-lg font-normal text-white">Overview</h2>
+                {IBRL_EXPLORER_URL && (
+                    <ExternalLinkWarning href={`${IBRL_EXPLORER_URL}/block/${slot}`}>
+                        <>
+                            <ExternalLink className="me-2 align-text-top" size={13} />
+                            IBRL Explorer
+                        </>
+                    </ExternalLinkWarning>
+                )}
+            </div>
+            <Card ui="dashkit">
+                <Row divider>
+                    <Label>Blockhash</Label>
+                    <Value className="flex w-full min-w-0 items-baseline">
+                        <Copyable text={block.blockhash}>
+                            <span className="min-w-0 break-all">{block.blockhash}</span>
+                        </Copyable>
+                    </Value>
+                </Row>
+                <Row divider>
+                    <Label>Slot</Label>
+                    <Value className="flex w-full min-w-0 items-baseline">
+                        <Copyable text={String(slot)}>
+                            <Slot slot={slot} />
+                        </Copyable>
+                    </Value>
+                </Row>
+                {blockLeader !== undefined && (
+                    <Row divider>
+                        <Label>Slot Leader</Label>
+                        <Value>
+                            <Address pubkey={blockLeader} link noTruncate />
+                        </Value>
+                    </Row>
+                )}
+                {block.blockTime ? (
+                    <>
+                        <Row divider>
+                            <Label>Timestamp (Local)</Label>
+                            <Value mono={false}>{displayTimestamp(block.blockTime * 1000, true)}</Value>
+                        </Row>
+                        <Row divider>
+                            <Label>Timestamp (UTC)</Label>
+                            <Value mono={false}>{displayTimestampUtc(block.blockTime * 1000, true)}</Value>
+                        </Row>
+                    </>
+                ) : (
+                    <Row divider>
+                        <Label>Timestamp</Label>
+                        <Value>Unavailable</Value>
+                    </Row>
+                )}
+                {epoch !== undefined && (
+                    <Row divider>
+                        <Label>Epoch</Label>
+                        <Value>
+                            <Epoch epoch={epoch} link />
+                        </Value>
+                    </Row>
+                )}
+                <Row divider>
+                    <Label>Parent Blockhash</Label>
+                    <Value className="flex w-full min-w-0 items-baseline">
+                        <Copyable text={block.previousBlockhash}>
+                            <span className="min-w-0 break-all">{block.previousBlockhash}</span>
+                        </Copyable>
+                    </Value>
+                </Row>
+                <Row divider>
+                    <Label>Parent Slot</Label>
+                    <Value>
+                        <Slot slot={block.parentSlot} link />
+                    </Value>
+                </Row>
+                {parentLeader !== undefined && (
+                    <Row divider>
+                        <Label>Parent Slot Leader</Label>
+                        <Value>
+                            <Address pubkey={parentLeader} link noTruncate />
+                        </Value>
+                    </Row>
+                )}
+                {childSlot !== undefined && (
+                    <Row divider>
+                        <Label>Child Slot</Label>
+                        <Value>
+                            <Slot slot={childSlot} link />
+                        </Value>
+                    </Row>
+                )}
+                {childLeader !== undefined && (
+                    <Row divider>
+                        <Label>Child Slot Leader</Label>
+                        <Value>
+                            <Address pubkey={childLeader} link noTruncate />
+                        </Value>
+                    </Row>
+                )}
+                <Row divider>
+                    <Label>Processed Transactions</Label>
+                    <Value>{block.transactions.length}</Value>
+                </Row>
+                {showSuccessfulCount && (
+                    <Row divider>
+                        <Label>Successful Transactions</Label>
+                        <Value>{successfulTxs.length}</Value>
+                    </Row>
+                )}
+                <Row divider>
+                    <Label>Total Compute Units Consumed</Label>
+                    <Value>{totalCUs.toLocaleString()}</Value>
+                </Row>
+                <Row divider>
+                    <Label>Transaction Cost Utilization</Label>
+                    <Value>
+                        {totalCostUnits.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
+                        {Math.round((totalCostUnits / maxComputeUnits) * 100)}%)
+                    </Value>
+                </Row>
+                <Row>
+                    <Label>Reserved Compute Units</Label>
+                    <Value>
+                        {totalRequestedCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
+                        {Math.round((totalRequestedCUs / maxComputeUnits) * 100)}%)
+                    </Value>
+                </Row>
+            </Card>
+        </section>
+    );
+}

--- a/app/components/block/BlockOverviewCard.tsx
+++ b/app/components/block/BlockOverviewCard.tsx
@@ -48,9 +48,17 @@ function Label({ children, className, ...props }: React.HTMLAttributes<HTMLDivEl
 // `mono` toggles the monospace face — on for hashes/addresses/numbers, off for prose like dates.
 // (cn is plain clsx here, so an added `font-sans` wouldn't reliably beat a hardcoded `font-mono`;
 // omitting `font-mono` and inheriting the sans default is the robust way to opt out.)
-function Value({ children, className, mono = true, ...props }: React.HTMLAttributes<HTMLDivElement> & { mono?: boolean }) {
+// `breakAll` lets a long unbreakable token (a hash) wrap anywhere instead of forcing horizontal
+// scroll; turn it off for space-separated prose/numbers so words wrap whole, only at the spaces.
+function Value({
+    children,
+    className,
+    mono = true,
+    breakAll = true,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement> & { mono?: boolean; breakAll?: boolean }) {
     return (
-        <div className={cn('break-all text-sm text-white', mono && 'font-mono', className)} {...props}>
+        <div className={cn('text-sm text-white', breakAll && 'break-all', mono && 'font-mono', className)} {...props}>
             {children}
         </div>
     );
@@ -207,14 +215,14 @@ export function BlockOverviewCard({
                 </Row>
                 <Row divider>
                     <Label>Transaction Cost Utilization</Label>
-                    <Value mono={false}>
+                    <Value mono={false} breakAll={false}>
                         {totalCostUnits.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
                         {Math.round((totalCostUnits / maxComputeUnits) * 100)}%)
                     </Value>
                 </Row>
                 <Row>
                     <Label>Reserved Compute Units</Label>
-                    <Value mono={false}>
+                    <Value mono={false} breakAll={false}>
                         {totalRequestedCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
                         {Math.round((totalRequestedCUs / maxComputeUnits) * 100)}%)
                     </Value>

--- a/app/components/block/BlockOverviewCard.tsx
+++ b/app/components/block/BlockOverviewCard.tsx
@@ -202,7 +202,7 @@ export function BlockOverviewCard({
                     </Row>
                 )}
                 <Row divider>
-                    <Label>Total Compute Units Consumed</Label>
+                    <Label>Total CUs Consumed</Label>
                     <Value>{totalCUs.toLocaleString()}</Value>
                 </Row>
                 <Row divider>

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -20,7 +20,8 @@ import { BaseTable } from '@/app/shared/ui/Table';
 export type BlockProgramsVariant = 'default' | 'collapsible';
 
 // Surface matched to the transaction tables (see BaseDomainsCard) — set on a `variant="tight"` Card.
-const TIGHT_CARD = 'overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900';
+// `!rounded-lg` (8px) forces the radius over the tw base's `rounded-xl` (12px) — see BlockHistoryCard.
+const TIGHT_CARD = 'overflow-hidden !rounded-lg border-outer-space-800 bg-outer-space-900';
 
 type ProgramStats = {
     ixFrequency: Map<string, number>;
@@ -347,9 +348,7 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                         const successes = txSuccesses.get(programId) || 0;
                         const txPct = `${((100 * txFreq) / totalTransactions).toFixed(2)}%`;
                         const ixPct = `${((100 * ixFreq) / totalInstructions).toFixed(2)}%`;
-                        const successRate = showSuccessRate
-                            ? `${((100 * successes) / txFreq).toFixed(0)}%`
-                            : undefined;
+                        const successRate = showSuccessRate ? `${((100 * successes) / txFreq).toFixed(0)}%` : undefined;
                         const fields: { count: string; label: string; pct?: string }[] = [
                             { count: `${txFreq}`, label: 'Transactions', pct: txPct },
                             { count: `${ixFreq}`, label: 'Instructions', pct: ixPct },
@@ -358,10 +357,7 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                             fields.push({ count: successRate, label: bracketed ? 'Success' : 'Success Rate' });
                         }
                         return (
-                            <div
-                                key={programId}
-                                className="border-b border-solid border-white/10 last:border-b-0"
-                            >
+                            <div key={programId} className="border-b border-solid border-white/10 last:border-b-0">
                                 {/* Mobile / tablet — stacked, labelled rows. Label column uses the same
                                     clamp(100px,25%,200px) ratio as the Overview section (ProgramStatsCollapsible). */}
                                 <div className="flex flex-col gap-1 px-3 py-3 md:hidden">
@@ -386,7 +382,10 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                                                 ) : bracketed ? (
                                                     <>
                                                         {f.count}
-                                                        <span className="text-outer-space-300"> ({f.pct} of Total)</span>
+                                                        <span className="text-outer-space-300">
+                                                            {' '}
+                                                            ({f.pct} of Total)
+                                                        </span>
                                                     </>
                                                 ) : (
                                                     <>
@@ -400,10 +399,7 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                                 </div>
 
                                 {/* Desktop grid row. */}
-                                <div
-                                    style={gridStyle}
-                                    className="hidden items-start gap-5 px-3 py-2.5 md:grid md:px-4"
-                                >
+                                <div style={gridStyle} className="hidden items-start gap-5 px-3 py-2.5 md:grid md:px-4">
                                     <div className="min-w-0">
                                         <Address pubkey={new PublicKey(programId)} link />
                                     </div>

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -7,7 +7,6 @@ import { HelpCircle } from 'react-feather';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/app/components/shared/ui/tooltip';
 import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
-import { Chip } from '@/app/features/transaction/ui/ProgramLogSection';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -93,16 +92,9 @@ function computeProgramStats(block: VersionedBlockResponse): ProgramStats {
 export function BlockProgramsCard({
     block,
     variant = 'default',
-    programsVariant = '1',
 }: {
     block: VersionedBlockResponse;
     variant?: BlockProgramsVariant;
-    /**
-     * Initial design variant for the collapsible "Block Programs" table ('1' | '2' | '2a'). Switchable
-     * live on the page via the chip toggle in the section header; this only seeds the starting selection.
-     * Distinct from `variant`, which picks the overall layout (Dashkit vs. domains-card).
-     */
-    programsVariant?: string;
 }) {
     const stats = computeProgramStats(block);
 
@@ -112,7 +104,7 @@ export function BlockProgramsCard({
         return (
             <div className="flex flex-col gap-6">
                 <ProgramStatsCollapsible stats={stats} />
-                <ProgramsCollapsible stats={stats} initialVariant={programsVariant} />
+                <ProgramsCollapsible stats={stats} />
             </div>
         );
     }
@@ -240,92 +232,45 @@ export function HeaderLabel({ label, help }: { label: string; help?: string }) {
     );
 }
 
-// A merged numeric cell: a count and (optionally) its percentage as two fixed-width mono parts. The
-// count holds 6 characters; the percentage holds 7 (enough for `100.00%`), so figures line up
-// regardless of magnitude.
-function MergedFigure({ count, percent }: { count: string; percent?: string }) {
-    return (
-        <div className="flex justify-end gap-1 tabular-nums">
-            <span className="text-right" style={{ width: '6ch' }}>
-                {count}
-            </span>
-            {percent !== undefined && (
-                <span className="text-right text-outer-space-300" style={{ width: '7ch' }}>
-                    {percent}
-                </span>
-            )}
-        </div>
-    );
+// A single right-aligned mono figure (the Success column). `tabular-nums` keeps digits aligned across rows.
+function MergedFigure({ count }: { count: string }) {
+    return <div className="text-right tabular-nums">{count}</div>;
 }
 
-// Design variants for the "Block Programs" table, surfaced as on-page chips (1, 2, …) in the section
-// header — the slot where the collapse toggle normally sits.
-const PROGRAMS_VARIANT_IDS = ['1', '2', '2a'] as const;
-
-// Bracketed figure for variants 2 / 2a — a count and its percentage on one right-aligned mono line.
-//   - Variant 2  (swapped=false): bright count, muted "(percent)" ("of total" dropped on desktop).
-//   - Variant 2a (swapped=true):  bright "percent", muted "(count)" — the two are swapped and the
-//                                  emphasis flips onto the percentage ("of total" dropped on desktop).
-function BracketedFigure({ count, percent, swapped }: { count: string; percent: string; swapped?: boolean }) {
+// A count with its percentage in parentheses on one right-aligned mono line: "count (percent)".
+function BracketedFigure({ count, percent }: { count: string; percent: string }) {
     return (
         <div className="text-right tabular-nums">
-            {swapped ? (
-                <>
-                    {percent}
-                    <span className="text-outer-space-300"> ({count})</span>
-                </>
-            ) : (
-                <>
-                    {count}
-                    <span className="text-outer-space-300"> ({percent})</span>
-                </>
-            )}
+            {count}
+            <span className="text-outer-space-300"> ({percent})</span>
         </div>
     );
 }
 
-// Domains-card style — "Block Programs" as a CSS grid on lg+, stacked labelled rows below lg.
-function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; initialVariant: string }) {
+// Domains-card style: "Block Programs" as a CSS grid on lg+, stacked labelled rows below lg. Each figure
+// shows its count with the percentage in parentheses ("count (percent)").
+function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
     const { ixFrequency, programEntries, showSuccessRate, totalInstructions, totalTransactions, txSuccesses } = stats;
-    const [pv, setPv] = React.useState(initialVariant);
-
-    // Variants 2 / 2a fold each percentage into its count via parentheses (BracketedFigure), so the
-    // header sheds the ", % of total" suffix; the Success Rate column stays, but its header drops "Rate".
-    // Variant 2a additionally swaps count/percentage and flips the emphasis onto the percentage.
-    const bracketed = pv === '2' || pv === '2a';
-    const swapped = pv === '2a';
 
     // Program takes the slack; the count+percentage columns are a fixed 8.5rem track wide enough for a
-    // merged pair (see MergedFigure), while the single-value Success Rate column is narrower (5rem).
-    // Fixed (not `auto`) so the header and each row — which are separate grids — resolve identical
-    // track widths, keeping the right edges of the headers and values on the same vertical. Header +
-    // rows share this template. Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it.
+    // "count (percent)" pair, while the single-value Success column is narrower (5rem). Fixed (not `auto`)
+    // so the header and each row (separate grids) resolve identical track widths, keeping right edges
+    // aligned. Inline (not a `grid-cols-[...]` class) so the Storybook JIT cannot purge it.
     const gridStyle: React.CSSProperties = {
         gridTemplateColumns: `minmax(0,1fr) 8.5rem 8.5rem${showSuccessRate ? ' 5rem' : ''}`,
     };
-    const figureHeader = (base: string) => (bracketed ? base : `${base}, % of total`);
-    // Denominators shown in the page's top block — surfaced here in the header hover explanations.
     const txPctHelp = `Share of the block's ${totalTransactions.toLocaleString('en-US')} processed transactions that invoked this program.`;
     const ixPctHelp = `Share of the block's ${totalInstructions.toLocaleString('en-US')} total instructions that invoked this program.`;
     const successHelp = "Share of this program's transactions that succeeded (no error).";
     const headers: { label: string; help?: string }[] = [
         { label: 'Program' },
-        { help: txPctHelp, label: figureHeader('Transactions') },
-        { help: ixPctHelp, label: figureHeader('Instructions') },
+        { help: txPctHelp, label: 'Transactions' },
+        { help: ixPctHelp, label: 'Instructions' },
     ];
-    if (showSuccessRate) headers.push({ help: successHelp, label: bracketed ? 'Success' : 'Success Rate' });
+    if (showSuccessRate) headers.push({ help: successHelp, label: 'Success' });
 
     return (
-        <CollapsibleSection
-            title="Block Programs"
-            collapsible={false}
-            className=""
-            actions={PROGRAMS_VARIANT_IDS.map(v => (
-                <Chip key={v} active={pv === v} onClick={() => setPv(v)}>
-                    {v}
-                </Chip>
-            ))}
-        >
+        <CollapsibleSection title="Block Programs" collapsible={false} className="">
             <Card variant="tight" className={TIGHT_CARD}>
                 <div className="text-sm text-white">
                     <div
@@ -354,12 +299,11 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                             { count: `${ixFreq}`, label: 'Instructions', pct: ixPct },
                         ];
                         if (successRate !== undefined) {
-                            fields.push({ count: successRate, label: bracketed ? 'Success' : 'Success Rate' });
+                            fields.push({ count: successRate, label: 'Success' });
                         }
                         return (
                             <div key={programId} className="border-b border-solid border-white/10 last:border-b-0">
-                                {/* Mobile / tablet — stacked, labelled rows. Label column uses the same
-                                    clamp(100px,25%,200px) ratio as the Overview section (ProgramStatsCollapsible). */}
+                                {/* Mobile / tablet: stacked, labelled rows. */}
                                 <div className="flex flex-col gap-1 px-3 py-3 md:hidden">
                                     <div className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-center gap-2">
                                         <span className="text-outer-space-300">Program</span>
@@ -374,23 +318,13 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                                             <span>
                                                 {f.pct === undefined ? (
                                                     f.count
-                                                ) : swapped ? (
-                                                    <>
-                                                        {f.pct}
-                                                        <span className="text-outer-space-300"> ({f.count})</span>
-                                                    </>
-                                                ) : bracketed ? (
+                                                ) : (
                                                     <>
                                                         {f.count}
                                                         <span className="text-outer-space-300">
                                                             {' '}
                                                             ({f.pct} of Total)
                                                         </span>
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        {f.count}
-                                                        <span className="text-outer-space-300"> {f.pct} of Total</span>
                                                     </>
                                                 )}
                                             </span>
@@ -403,19 +337,9 @@ function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; i
                                     <div className="min-w-0">
                                         <Address pubkey={new PublicKey(programId)} link />
                                     </div>
-                                    {bracketed ? (
-                                        <>
-                                            <BracketedFigure count={`${txFreq}`} percent={txPct} swapped={swapped} />
-                                            <BracketedFigure count={`${ixFreq}`} percent={ixPct} swapped={swapped} />
-                                            {successRate !== undefined && <MergedFigure count={successRate} />}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <MergedFigure count={`${txFreq}`} percent={txPct} />
-                                            <MergedFigure count={`${ixFreq}`} percent={ixPct} />
-                                            {successRate !== undefined && <MergedFigure count={successRate} />}
-                                        </>
-                                    )}
+                                    <BracketedFigure count={`${txFreq}`} percent={txPct} />
+                                    <BracketedFigure count={`${ixFreq}`} percent={ixPct} />
+                                    {successRate !== undefined && <MergedFigure count={successRate} />}
                                 </div>
                             </div>
                         );

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -3,8 +3,11 @@ import { TableCardBody } from '@components/common/TableCardBody';
 import { cn } from '@components/shared/utils';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import React from 'react';
+import { HelpCircle } from 'react-feather';
 
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/app/components/shared/ui/tooltip';
 import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
+import { Chip } from '@/app/features/transaction/ui/ProgramLogSection';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -89,9 +92,16 @@ function computeProgramStats(block: VersionedBlockResponse): ProgramStats {
 export function BlockProgramsCard({
     block,
     variant = 'default',
+    programsVariant = '1',
 }: {
     block: VersionedBlockResponse;
     variant?: BlockProgramsVariant;
+    /**
+     * Initial design variant for the collapsible "Block Programs" table ('1' | '2' | '2a'). Switchable
+     * live on the page via the chip toggle in the section header; this only seeds the starting selection.
+     * Distinct from `variant`, which picks the overall layout (Dashkit vs. domains-card).
+     */
+    programsVariant?: string;
 }) {
     const stats = computeProgramStats(block);
 
@@ -101,7 +111,7 @@ export function BlockProgramsCard({
         return (
             <div className="flex flex-col gap-6">
                 <ProgramStatsCollapsible stats={stats} />
-                <ProgramsCollapsible stats={stats} />
+                <ProgramsCollapsible stats={stats} initialVariant={programsVariant} />
             </div>
         );
     }
@@ -123,11 +133,11 @@ function ProgramsDefault({ stats }: { stats: ProgramStats }) {
                 <TableCardBody>
                     <BaseTable.Row>
                         <BaseTable.Cell className="w-full">Unique Programs Count</BaseTable.Cell>
-                        <BaseTable.Cell className="text-right font-mono">{programEntries.length}</BaseTable.Cell>
+                        <BaseTable.Cell className="text-right tabular-nums">{programEntries.length}</BaseTable.Cell>
                     </BaseTable.Row>
                     <BaseTable.Row>
                         <BaseTable.Cell className="w-full">Total Instructions</BaseTable.Cell>
-                        <BaseTable.Cell className="text-right font-mono">{totalInstructions}</BaseTable.Cell>
+                        <BaseTable.Cell className="text-right tabular-nums">{totalInstructions}</BaseTable.Cell>
                     </BaseTable.Row>
                 </TableCardBody>
             </Card>
@@ -198,7 +208,7 @@ function ProgramStatsCollapsible({ stats }: { stats: ProgramStats }) {
                         <div className="flex flex-wrap items-center gap-1 overflow-hidden text-sm text-outer-space-300">
                             {label}
                         </div>
-                        <div className="break-all font-mono text-sm text-white">{value}</div>
+                        <div className="break-all text-sm text-white">{value}</div>
                     </div>
                 ))}
             </Card>
@@ -209,12 +219,32 @@ function ProgramStatsCollapsible({ stats }: { stats: ProgramStats }) {
 // Muted uppercase header cell + body cell, matching the transaction tables / BaseDomainsCard grid.
 const GRID_HEADER_CELL = 'text-xs uppercase text-outer-space-300';
 
+// Column header label; when `help` is set it carries a help icon and a hover explanation. The icon is
+// inline (not a flex item) so a long label like "Transactions, % of total" wraps naturally and the icon
+// trails the last word ("total") instead of being pushed onto its own line.
+export function HeaderLabel({ label, help }: { label: string; help?: string }) {
+    if (!help) {
+        return <>{label}</>;
+    }
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span className="cursor-help">
+                    {label}
+                    <HelpCircle size={14} className="ml-1 inline align-text-bottom" />
+                </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-72 normal-case">{help}</TooltipContent>
+        </Tooltip>
+    );
+}
+
 // A merged numeric cell: a count and (optionally) its percentage as two fixed-width mono parts. The
 // count holds 6 characters; the percentage holds 7 (enough for `100.00%`), so figures line up
 // regardless of magnitude.
 function MergedFigure({ count, percent }: { count: string; percent?: string }) {
     return (
-        <div className="flex justify-end gap-3 font-mono">
+        <div className="flex justify-end gap-1 tabular-nums">
             <span className="text-right" style={{ width: '6ch' }}>
                 {count}
             </span>
@@ -227,9 +257,42 @@ function MergedFigure({ count, percent }: { count: string; percent?: string }) {
     );
 }
 
+// Design variants for the "Block Programs" table, surfaced as on-page chips (1, 2, …) in the section
+// header — the slot where the collapse toggle normally sits.
+const PROGRAMS_VARIANT_IDS = ['1', '2', '2a'] as const;
+
+// Bracketed figure for variants 2 / 2a — a count and its percentage on one right-aligned mono line.
+//   - Variant 2  (swapped=false): bright count, muted "(percent)" ("of total" dropped on desktop).
+//   - Variant 2a (swapped=true):  bright "percent", muted "(count)" — the two are swapped and the
+//                                  emphasis flips onto the percentage ("of total" dropped on desktop).
+function BracketedFigure({ count, percent, swapped }: { count: string; percent: string; swapped?: boolean }) {
+    return (
+        <div className="text-right tabular-nums">
+            {swapped ? (
+                <>
+                    {percent}
+                    <span className="text-outer-space-300"> ({count})</span>
+                </>
+            ) : (
+                <>
+                    {count}
+                    <span className="text-outer-space-300"> ({percent})</span>
+                </>
+            )}
+        </div>
+    );
+}
+
 // Domains-card style — "Block Programs" as a CSS grid on lg+, stacked labelled rows below lg.
-function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
+function ProgramsCollapsible({ stats, initialVariant }: { stats: ProgramStats; initialVariant: string }) {
     const { ixFrequency, programEntries, showSuccessRate, totalInstructions, totalTransactions, txSuccesses } = stats;
+    const [pv, setPv] = React.useState(initialVariant);
+
+    // Variants 2 / 2a fold each percentage into its count via parentheses (BracketedFigure), so the
+    // header sheds the ", % of total" suffix; the Success Rate column stays, but its header drops "Rate".
+    // Variant 2a additionally swaps count/percentage and flips the emphasis onto the percentage.
+    const bracketed = pv === '2' || pv === '2a';
+    const swapped = pv === '2a';
 
     // Program takes the slack; the count+percentage columns are a fixed 8.5rem track wide enough for a
     // merged pair (see MergedFigure), while the single-value Success Rate column is narrower (5rem).
@@ -239,11 +302,29 @@ function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
     const gridStyle: React.CSSProperties = {
         gridTemplateColumns: `minmax(0,1fr) 8.5rem 8.5rem${showSuccessRate ? ' 5rem' : ''}`,
     };
-    const headers = ['Program', 'Transactions, % of total', 'Instructions, % of total'];
-    if (showSuccessRate) headers.push('Success Rate');
+    const figureHeader = (base: string) => (bracketed ? base : `${base}, % of total`);
+    // Denominators shown in the page's top block — surfaced here in the header hover explanations.
+    const txPctHelp = `Share of the block's ${totalTransactions.toLocaleString('en-US')} processed transactions that invoked this program.`;
+    const ixPctHelp = `Share of the block's ${totalInstructions.toLocaleString('en-US')} total instructions that invoked this program.`;
+    const successHelp = "Share of this program's transactions that succeeded (no error).";
+    const headers: { label: string; help?: string }[] = [
+        { label: 'Program' },
+        { help: txPctHelp, label: figureHeader('Transactions') },
+        { help: ixPctHelp, label: figureHeader('Instructions') },
+    ];
+    if (showSuccessRate) headers.push({ help: successHelp, label: bracketed ? 'Success' : 'Success Rate' });
 
     return (
-        <CollapsibleSection title="Block Programs" collapsible={false} className="">
+        <CollapsibleSection
+            title="Block Programs"
+            collapsible={false}
+            className=""
+            actions={PROGRAMS_VARIANT_IDS.map(v => (
+                <Chip key={v} active={pv === v} onClick={() => setPv(v)}>
+                    {v}
+                </Chip>
+            ))}
+        >
             <Card variant="tight" className={TIGHT_CARD}>
                 <div className="text-sm text-white">
                     <div
@@ -254,9 +335,9 @@ function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
                             GRID_HEADER_CELL,
                         )}
                     >
-                        {headers.map((label, i) => (
+                        {headers.map((h, i) => (
                             <div key={i} className={cn(i > 0 && 'text-right')}>
-                                {label}
+                                <HeaderLabel help={h.help} label={h.label} />
                             </div>
                         ))}
                     </div>
@@ -266,13 +347,15 @@ function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
                         const successes = txSuccesses.get(programId) || 0;
                         const txPct = `${((100 * txFreq) / totalTransactions).toFixed(2)}%`;
                         const ixPct = `${((100 * ixFreq) / totalInstructions).toFixed(2)}%`;
-                        const successRate = showSuccessRate ? `${((100 * successes) / txFreq).toFixed(0)}%` : undefined;
+                        const successRate = showSuccessRate
+                            ? `${((100 * successes) / txFreq).toFixed(0)}%`
+                            : undefined;
                         const fields: { count: string; label: string; pct?: string }[] = [
                             { count: `${txFreq}`, label: 'Transactions', pct: txPct },
                             { count: `${ixFreq}`, label: 'Instructions', pct: ixPct },
                         ];
                         if (successRate !== undefined) {
-                            fields.push({ count: successRate, label: 'Success Rate' });
+                            fields.push({ count: successRate, label: bracketed ? 'Success' : 'Success Rate' });
                         }
                         return (
                             <div
@@ -293,9 +376,23 @@ function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
                                         >
                                             <span className="text-outer-space-300">{f.label}</span>
                                             <span>
-                                                {f.count}
-                                                {f.pct !== undefined && (
-                                                    <span className="text-outer-space-300"> {f.pct} of Total</span>
+                                                {f.pct === undefined ? (
+                                                    f.count
+                                                ) : swapped ? (
+                                                    <>
+                                                        {f.pct}
+                                                        <span className="text-outer-space-300"> ({f.count})</span>
+                                                    </>
+                                                ) : bracketed ? (
+                                                    <>
+                                                        {f.count}
+                                                        <span className="text-outer-space-300"> ({f.pct} of Total)</span>
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        {f.count}
+                                                        <span className="text-outer-space-300"> {f.pct} of Total</span>
+                                                    </>
                                                 )}
                                             </span>
                                         </div>
@@ -310,9 +407,19 @@ function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
                                     <div className="min-w-0">
                                         <Address pubkey={new PublicKey(programId)} link />
                                     </div>
-                                    <MergedFigure count={`${txFreq}`} percent={txPct} />
-                                    <MergedFigure count={`${ixFreq}`} percent={ixPct} />
-                                    {successRate !== undefined && <MergedFigure count={successRate} />}
+                                    {bracketed ? (
+                                        <>
+                                            <BracketedFigure count={`${txFreq}`} percent={txPct} swapped={swapped} />
+                                            <BracketedFigure count={`${ixFreq}`} percent={ixPct} swapped={swapped} />
+                                            {successRate !== undefined && <MergedFigure count={successRate} />}
+                                        </>
+                                    ) : (
+                                        <>
+                                            <MergedFigure count={`${txFreq}`} percent={txPct} />
+                                            <MergedFigure count={`${ixFreq}`} percent={ixPct} />
+                                            {successRate !== undefined && <MergedFigure count={successRate} />}
+                                        </>
+                                    )}
                                 </div>
                             </div>
                         );

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -1,13 +1,36 @@
 import { Address } from '@components/common/Address';
 import { TableCardBody } from '@components/common/TableCardBody';
+import { cn } from '@components/shared/utils';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import React from 'react';
 
+import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
-export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) {
+// Design variant, switchable via prop (see BlockRewardsCard for the same pattern):
+//   - 'default'     — the original Dashkit cards + table.
+//   - 'collapsible' — the domains-card treatment (PR #115): each heading lifted out above a collapsible
+//                     section, list on a `tight` card surface, CSS-grid body on `lg+` and a stacked,
+//                     labelled layout below `lg`.
+export type BlockProgramsVariant = 'default' | 'collapsible';
+
+// Surface matched to the transaction tables (see BaseDomainsCard) — set on a `variant="tight"` Card.
+const TIGHT_CARD = 'overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900';
+
+type ProgramStats = {
+    ixFrequency: Map<string, number>;
+    programEntries: [string, number][];
+    showSuccessRate: boolean;
+    totalInstructions: number;
+    totalTransactions: number;
+    txSuccesses: Map<string, number>;
+};
+
+// Aggregates program usage across a block's transactions. Unchanged from the original inline body —
+// only lifted into a helper so both variants render from the same numbers.
+function computeProgramStats(block: VersionedBlockResponse): ProgramStats {
     const totalTransactions = block.transactions.length;
     const txSuccesses = new Map<string, number>();
     const txFrequency = new Map<string, number>();
@@ -60,6 +83,35 @@ export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) 
     });
 
     const showSuccessRate = block.transactions.every(tx => tx.meta !== null);
+    return { ixFrequency, programEntries, showSuccessRate, totalInstructions, totalTransactions, txSuccesses };
+}
+
+export function BlockProgramsCard({
+    block,
+    variant = 'default',
+}: {
+    block: VersionedBlockResponse;
+    variant?: BlockProgramsVariant;
+}) {
+    const stats = computeProgramStats(block);
+
+    if (variant === 'collapsible') {
+        // gap-6 (24px) between the two sections matches the spacing between instruction blocks on the
+        // transaction page (each is a dashkit `CollapsibleCard` carrying the default `mb-6`).
+        return (
+            <div className="flex flex-col gap-6">
+                <ProgramStatsCollapsible stats={stats} />
+                <ProgramsCollapsible stats={stats} />
+            </div>
+        );
+    }
+
+    return <ProgramsDefault stats={stats} />;
+}
+
+// Original design — two Dashkit cards.
+function ProgramsDefault({ stats }: { stats: ProgramStats }) {
+    const { ixFrequency, programEntries, showSuccessRate, totalInstructions, totalTransactions, txSuccesses } = stats;
     return (
         <>
             <Card ui="dashkit">
@@ -121,5 +173,152 @@ export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) 
                 </BaseTable>
             </Card>
         </>
+    );
+}
+
+// Domains-card style — "Block Program Stats" as label/value rows on a tight surface. Rows use the
+// same grid key/value shape as BlockOverviewCard (fixed `clamp(100px,25%,200px)` label column, `1fr`
+// mono value that wraps) so the block page's overview-style rows stay consistent.
+function ProgramStatsCollapsible({ stats }: { stats: ProgramStats }) {
+    const rows: [string, number][] = [
+        ['Unique Programs', stats.programEntries.length],
+        ['Total Instructions', stats.totalInstructions],
+    ];
+    return (
+        <CollapsibleSection title="Block Program Stats" collapsible={false} className="">
+            <Card variant="tight" className={TIGHT_CARD}>
+                {rows.map(([label, value], i) => (
+                    <div
+                        key={label}
+                        className={cn(
+                            'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
+                            i < rows.length - 1 && 'border-1 border-b border-white/10 [border-bottom-style:solid]',
+                        )}
+                    >
+                        <div className="flex flex-wrap items-center gap-1 overflow-hidden text-sm text-outer-space-300">
+                            {label}
+                        </div>
+                        <div className="break-all font-mono text-sm text-white">{value}</div>
+                    </div>
+                ))}
+            </Card>
+        </CollapsibleSection>
+    );
+}
+
+// Muted uppercase header cell + body cell, matching the transaction tables / BaseDomainsCard grid.
+const GRID_HEADER_CELL = 'text-xs uppercase text-outer-space-300';
+
+// A merged numeric cell: a count and (optionally) its percentage as two fixed-width mono parts. The
+// count holds 6 characters; the percentage holds 7 (enough for `100.00%`), so figures line up
+// regardless of magnitude.
+function MergedFigure({ count, percent }: { count: string; percent?: string }) {
+    return (
+        <div className="flex justify-end gap-3 font-mono">
+            <span className="text-right" style={{ width: '6ch' }}>
+                {count}
+            </span>
+            {percent !== undefined && (
+                <span className="text-right text-outer-space-300" style={{ width: '7ch' }}>
+                    {percent}
+                </span>
+            )}
+        </div>
+    );
+}
+
+// Domains-card style — "Block Programs" as a CSS grid on lg+, stacked labelled rows below lg.
+function ProgramsCollapsible({ stats }: { stats: ProgramStats }) {
+    const { ixFrequency, programEntries, showSuccessRate, totalInstructions, totalTransactions, txSuccesses } = stats;
+
+    // Program takes the slack; the count+percentage columns are a fixed 8.5rem track wide enough for a
+    // merged pair (see MergedFigure), while the single-value Success Rate column is narrower (5rem).
+    // Fixed (not `auto`) so the header and each row — which are separate grids — resolve identical
+    // track widths, keeping the right edges of the headers and values on the same vertical. Header +
+    // rows share this template. Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it.
+    const gridStyle: React.CSSProperties = {
+        gridTemplateColumns: `minmax(0,1fr) 8.5rem 8.5rem${showSuccessRate ? ' 5rem' : ''}`,
+    };
+    const headers = ['Program', 'Transactions, % of total', 'Instructions, % of total'];
+    if (showSuccessRate) headers.push('Success Rate');
+
+    return (
+        <CollapsibleSection title="Block Programs" collapsible={false} className="">
+            <Card variant="tight" className={TIGHT_CARD}>
+                <div className="text-sm text-white">
+                    <div
+                        style={gridStyle}
+                        className={cn(
+                            'hidden gap-5 px-3 py-2.5 md:grid md:px-4',
+                            'border-b border-solid border-white/10',
+                            GRID_HEADER_CELL,
+                        )}
+                    >
+                        {headers.map((label, i) => (
+                            <div key={i} className={cn(i > 0 && 'text-right')}>
+                                {label}
+                            </div>
+                        ))}
+                    </div>
+
+                    {programEntries.map(([programId, txFreq]) => {
+                        const ixFreq = ixFrequency.get(programId) as number;
+                        const successes = txSuccesses.get(programId) || 0;
+                        const txPct = `${((100 * txFreq) / totalTransactions).toFixed(2)}%`;
+                        const ixPct = `${((100 * ixFreq) / totalInstructions).toFixed(2)}%`;
+                        const successRate = showSuccessRate ? `${((100 * successes) / txFreq).toFixed(0)}%` : undefined;
+                        const fields: { count: string; label: string; pct?: string }[] = [
+                            { count: `${txFreq}`, label: 'Transactions', pct: txPct },
+                            { count: `${ixFreq}`, label: 'Instructions', pct: ixPct },
+                        ];
+                        if (successRate !== undefined) {
+                            fields.push({ count: successRate, label: 'Success Rate' });
+                        }
+                        return (
+                            <div
+                                key={programId}
+                                className="border-b border-solid border-white/10 last:border-b-0"
+                            >
+                                {/* Mobile / tablet — stacked, labelled rows. Label column uses the same
+                                    clamp(100px,25%,200px) ratio as the Overview section (ProgramStatsCollapsible). */}
+                                <div className="flex flex-col gap-1 px-3 py-3 md:hidden">
+                                    <div className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-center gap-2">
+                                        <span className="text-outer-space-300">Program</span>
+                                        <Address pubkey={new PublicKey(programId)} link />
+                                    </div>
+                                    {fields.map((f, i) => (
+                                        <div
+                                            key={i}
+                                            className="grid grid-cols-[clamp(100px,25%,200px)_1fr] items-center gap-2"
+                                        >
+                                            <span className="text-outer-space-300">{f.label}</span>
+                                            <span>
+                                                {f.count}
+                                                {f.pct !== undefined && (
+                                                    <span className="text-outer-space-300"> {f.pct} of Total</span>
+                                                )}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+
+                                {/* Desktop grid row. */}
+                                <div
+                                    style={gridStyle}
+                                    className="hidden items-start gap-5 px-3 py-2.5 md:grid md:px-4"
+                                >
+                                    <div className="min-w-0">
+                                        <Address pubkey={new PublicKey(programId)} link />
+                                    </div>
+                                    <MergedFigure count={`${txFreq}`} percent={txPct} />
+                                    <MergedFigure count={`${ixFreq}`} percent={ixPct} />
+                                    {successRate !== undefined && <MergedFigure count={successRate} />}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </Card>
+        </CollapsibleSection>
     );
 }

--- a/app/components/block/BlockRewardsCard.tsx
+++ b/app/components/block/BlockRewardsCard.tsx
@@ -1,20 +1,53 @@
 import { Address } from '@components/common/Address';
 import { SolBalance } from '@components/common/SolBalance';
+import { cn } from '@components/shared/utils';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import React from 'react';
 
 import { Button } from '@/app/components/shared/ui/button';
+import { CollapsibleSection } from '@/app/features/transaction/ui/CollapsibleSection';
 import { Card, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 const PAGE_SIZE = 10;
 
-export function BlockRewardsCard({ block }: { block: VersionedBlockResponse }) {
-    const [rewardsDisplayed, setRewardsDisplayed] = React.useState(PAGE_SIZE);
+// Design variant, switchable via prop so the block page (and Storybook) can flip layouts without
+// swapping components:
+//   - 'default'     — the original Dashkit table.
+//   - 'collapsible' — the domains-card treatment (PR #115): heading lifted out above a collapsible
+//                     section, list on a `tight` card surface toned to match the transaction tables,
+//                     a CSS-grid body on `lg+` and a stacked, labelled layout below `lg`.
+export type BlockRewardsVariant = 'default' | 'collapsible';
 
+type Reward = NonNullable<VersionedBlockResponse['rewards']>[number];
+
+export function BlockRewardsCard({
+    block,
+    variant = 'default',
+}: {
+    block: VersionedBlockResponse;
+    variant?: BlockRewardsVariant;
+}) {
     if (!block.rewards || block.rewards.length < 1) {
         return null;
     }
+
+    if (variant === 'collapsible') {
+        return (
+            <CollapsibleSection title="Block Rewards" className="">
+                <Card variant="tight" className="overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900">
+                    <RewardsGrid rewards={block.rewards} />
+                </Card>
+            </CollapsibleSection>
+        );
+    }
+
+    return <DashkitRewards rewards={block.rewards} />;
+}
+
+// Original design — Dashkit card + table.
+function DashkitRewards({ rewards }: { rewards: Reward[] }) {
+    const [rewardsDisplayed, setRewardsDisplayed] = React.useState(PAGE_SIZE);
 
     return (
         <Card ui="dashkit">
@@ -34,18 +67,12 @@ export function BlockRewardsCard({ block }: { block: VersionedBlockResponse }) {
                     </BaseTable.Row>
                 </BaseTable.Head>
                 <BaseTable.Body>
-                    {block.rewards.map((reward, index) => {
+                    {rewards.map((reward, index) => {
                         if (index >= rewardsDisplayed - 1) {
                             return null;
                         }
 
-                        let percentChange;
-                        if (reward.postBalance !== null && reward.postBalance !== 0) {
-                            percentChange = (
-                                (Math.abs(reward.lamports) / (reward.postBalance - reward.lamports)) *
-                                100
-                            ).toFixed(9);
-                        }
+                        const pct = percentChange(reward);
                         return (
                             <BaseTable.Row key={reward.pubkey + reward.rewardType}>
                                 <BaseTable.Cell>
@@ -58,14 +85,14 @@ export function BlockRewardsCard({ block }: { block: VersionedBlockResponse }) {
                                 <BaseTable.Cell>
                                     {reward.postBalance ? <SolBalance lamports={reward.postBalance} /> : '-'}
                                 </BaseTable.Cell>
-                                <BaseTable.Cell>{percentChange ? `${percentChange}%` : '-'}</BaseTable.Cell>
+                                <BaseTable.Cell>{pct ?? '-'}</BaseTable.Cell>
                             </BaseTable.Row>
                         );
                     })}
                 </BaseTable.Body>
             </BaseTable>
 
-            {block.rewards.length > rewardsDisplayed && (
+            {rewards.length > rewardsDisplayed && (
                 <CardFooter ui="dashkit">
                     <Button
                         ui="dashkit"
@@ -78,5 +105,119 @@ export function BlockRewardsCard({ block }: { block: VersionedBlockResponse }) {
                 </CardFooter>
             )}
         </Card>
+    );
+}
+
+// Column labels, kept in one place so the desktop header and the mobile row labels can't drift.
+const COLUMNS = ['Address', 'Type', 'Amount', 'New Balance', '% Change'] as const;
+
+// Address takes the slack (`1fr`); the numeric columns are capped so long balances don't push the
+// address column to nothing. Header and every row share this template so columns stay aligned.
+// Set as an inline style (not a `grid-cols-[…]` arbitrary class) because the Storybook Tailwind JIT
+// doesn't always emit a brand-new arbitrary grid template picked up from a fresh file — the class
+// silently no-ops and every column collapses into one. Inline `gridTemplateColumns` can't be purged.
+const GRID_TEMPLATE: React.CSSProperties = {
+    gridTemplateColumns: 'minmax(0,1fr) minmax(auto,4rem) minmax(auto,6.5rem) minmax(auto,7.5rem) minmax(auto,7.5rem)',
+};
+
+// Mirrors the original card's math: share of the pre-reward balance that this reward moved.
+function percentChange(reward: Reward): string | undefined {
+    if (!reward.postBalance) {
+        return undefined;
+    }
+    const pct = (Math.abs(reward.lamports) / (reward.postBalance - reward.lamports)) * 100;
+    return `${pct.toFixed(9)}%`;
+}
+
+// Shared body for the 'card' and 'collapsible' variants — a pure-Tailwind CSS grid on `lg+` plus a
+// stacked, labelled layout below `lg` (the pattern from the transaction Token Balances card).
+function RewardsGrid({ rewards }: { rewards: Reward[] }) {
+    const [displayed, setDisplayed] = React.useState(PAGE_SIZE);
+    const visible = rewards.slice(0, displayed);
+
+    return (
+        <div className="text-sm text-white">
+            {/* Desktop grid header — muted uppercase labels, matching the transaction tables. */}
+            <div
+                style={GRID_TEMPLATE}
+                className={cn(
+                    'hidden gap-5 px-3 py-2.5 md:px-4 md:grid',
+                    'text-xs uppercase text-outer-space-300',
+                    'border-b border-solid border-white/10',
+                )}
+            >
+                {COLUMNS.map((label, i) => (
+                    <div key={label} className={cn(i > 1 && 'text-right')}>
+                        {label}
+                    </div>
+                ))}
+            </div>
+
+            {visible.map(reward => {
+                const pct = percentChange(reward);
+                const pubkey = new PublicKey(reward.pubkey);
+                return (
+                    <div
+                        key={reward.pubkey + reward.rewardType}
+                        className="border-b border-solid border-white/10 last:border-b-0"
+                    >
+                        {/* Mobile / tablet — stacked, labelled rows (block page has to fit five columns). */}
+                        <div className="flex flex-col gap-1 px-3 py-3 md:px-4 md:hidden">
+                            <div className="flex items-center gap-2">
+                                <span className="w-28 shrink-0 text-outer-space-300">Address</span>
+                                <Address pubkey={pubkey} link />
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="w-28 shrink-0 text-outer-space-300">Type</span>
+                                <span>{reward.rewardType}</span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="w-28 shrink-0 text-outer-space-300">Amount</span>
+                                <SolBalance lamports={reward.lamports} />
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="w-28 shrink-0 text-outer-space-300">New Balance</span>
+                                {reward.postBalance ? <SolBalance lamports={reward.postBalance} /> : <span>-</span>}
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="w-28 shrink-0 text-outer-space-300">% Change</span>
+                                <span>{pct ?? '-'}</span>
+                            </div>
+                        </div>
+
+                        {/* Desktop grid row. */}
+                        <div
+                            style={GRID_TEMPLATE}
+                            className="hidden items-start gap-5 px-3 py-2.5 md:px-4 md:grid"
+                        >
+                            <div className="min-w-0">
+                                <Address pubkey={pubkey} link />
+                            </div>
+                            <div>{reward.rewardType}</div>
+                            <div className="text-right">
+                                <SolBalance lamports={reward.lamports} />
+                            </div>
+                            <div className="text-right">
+                                {reward.postBalance ? <SolBalance lamports={reward.postBalance} /> : '-'}
+                            </div>
+                            <div className="break-all text-right">{pct ?? '-'}</div>
+                        </div>
+                    </div>
+                );
+            })}
+
+            {rewards.length > displayed && (
+                <div className="border-t border-solid border-white/10 px-3 py-4 md:px-4">
+                    <Button
+                        ui="dashkit"
+                        variant="primary"
+                        className="w-full"
+                        onClick={() => setDisplayed(d => d + PAGE_SIZE)}
+                    >
+                        Load More
+                    </Button>
+                </div>
+            )}
+        </div>
     );
 }

--- a/app/components/block/BlockRewardsCard.tsx
+++ b/app/components/block/BlockRewardsCard.tsx
@@ -62,7 +62,7 @@ function DashkitRewards({ rewards }: { rewards: Reward[] }) {
                         <BaseTable.HeaderCell className="text-dk-gray-700">Address</BaseTable.HeaderCell>
                         <BaseTable.HeaderCell className="text-dk-gray-700">Type</BaseTable.HeaderCell>
                         <BaseTable.HeaderCell className="text-dk-gray-700">Amount</BaseTable.HeaderCell>
-                        <BaseTable.HeaderCell className="text-dk-gray-700">New Balance</BaseTable.HeaderCell>
+                        <BaseTable.HeaderCell className="text-dk-gray-700">Post Balance</BaseTable.HeaderCell>
                         <BaseTable.HeaderCell className="text-dk-gray-700">Percent Change</BaseTable.HeaderCell>
                     </BaseTable.Row>
                 </BaseTable.Head>
@@ -109,7 +109,7 @@ function DashkitRewards({ rewards }: { rewards: Reward[] }) {
 }
 
 // Column labels, kept in one place so the desktop header and the mobile row labels can't drift.
-const COLUMNS = ['Address', 'Type', 'Amount', 'New Balance', '% Change'] as const;
+const COLUMNS = ['Address', 'Type', 'Amount', 'Post Balance', '% Change'] as const;
 
 // Address takes the slack (`1fr`); the numeric columns are capped so long balances don't push the
 // address column to nothing. Header and every row share this template so columns stay aligned.
@@ -117,7 +117,7 @@ const COLUMNS = ['Address', 'Type', 'Amount', 'New Balance', '% Change'] as cons
 // doesn't always emit a brand-new arbitrary grid template picked up from a fresh file — the class
 // silently no-ops and every column collapses into one. Inline `gridTemplateColumns` can't be purged.
 const GRID_TEMPLATE: React.CSSProperties = {
-    gridTemplateColumns: 'minmax(0,1fr) minmax(auto,4rem) minmax(auto,6.5rem) minmax(auto,7.5rem) minmax(auto,7.5rem)',
+    gridTemplateColumns: 'minmax(0,1fr) minmax(auto,4rem) minmax(auto,6.5rem) minmax(auto,8.5rem) minmax(auto,7.5rem)',
 };
 
 // Mirrors the original card's math: share of the pre-reward balance that this reward moved.
@@ -176,7 +176,7 @@ function RewardsGrid({ rewards }: { rewards: Reward[] }) {
                                 <SolBalance lamports={reward.lamports} />
                             </div>
                             <div className="flex items-center gap-2">
-                                <span className="w-28 shrink-0 text-outer-space-300">New Balance</span>
+                                <span className="w-28 shrink-0 text-outer-space-300">Post Balance</span>
                                 {reward.postBalance ? <SolBalance lamports={reward.postBalance} /> : <span>-</span>}
                             </div>
                             <div className="flex items-center gap-2">

--- a/app/components/block/BlockRewardsCard.tsx
+++ b/app/components/block/BlockRewardsCard.tsx
@@ -35,7 +35,7 @@ export function BlockRewardsCard({
     if (variant === 'collapsible') {
         return (
             <CollapsibleSection title="Block Rewards" className="">
-                <Card variant="tight" className="overflow-hidden rounded-lg border-outer-space-800 bg-outer-space-900">
+                <Card variant="tight" className="overflow-hidden !rounded-lg border-outer-space-800 bg-outer-space-900">
                     <RewardsGrid rewards={block.rewards} />
                 </Card>
             </CollapsibleSection>
@@ -141,7 +141,7 @@ function RewardsGrid({ rewards }: { rewards: Reward[] }) {
             <div
                 style={GRID_TEMPLATE}
                 className={cn(
-                    'hidden gap-5 px-3 py-2.5 md:px-4 md:grid',
+                    'hidden gap-5 px-3 py-2.5 md:grid md:px-4',
                     'text-xs uppercase text-outer-space-300',
                     'border-b border-solid border-white/10',
                 )}
@@ -162,7 +162,7 @@ function RewardsGrid({ rewards }: { rewards: Reward[] }) {
                         className="border-b border-solid border-white/10 last:border-b-0"
                     >
                         {/* Mobile / tablet — stacked, labelled rows (block page has to fit five columns). */}
-                        <div className="flex flex-col gap-1 px-3 py-3 md:px-4 md:hidden">
+                        <div className="flex flex-col gap-1 px-3 py-3 md:hidden md:px-4">
                             <div className="flex items-center gap-2">
                                 <span className="w-28 shrink-0 text-outer-space-300">Address</span>
                                 <Address pubkey={pubkey} link />
@@ -186,10 +186,7 @@ function RewardsGrid({ rewards }: { rewards: Reward[] }) {
                         </div>
 
                         {/* Desktop grid row. */}
-                        <div
-                            style={GRID_TEMPLATE}
-                            className="hidden items-start gap-5 px-3 py-2.5 md:px-4 md:grid"
-                        >
+                        <div style={GRID_TEMPLATE} className="hidden items-start gap-5 px-3 py-2.5 md:grid md:px-4">
                             <div className="min-w-0">
                                 <Address pubkey={pubkey} link />
                             </div>

--- a/app/components/block/__stories__/BlockAccountsCard.stories.tsx
+++ b/app/components/block/__stories__/BlockAccountsCard.stories.tsx
@@ -1,11 +1,20 @@
-import { nextjsParameters, withCluster } from '@storybook-config/decorators';
+import { PublicKey } from '@solana/web3.js';
+import { nextjsParameters, withCluster, withTokenInfoBatch } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
 
 import { BlockAccountsCard } from '../BlockAccountsCard';
 
 const meta: Meta<typeof BlockAccountsCard> = {
+    argTypes: {
+        variant: {
+            control: 'inline-radio',
+            description:
+                "'default' — original Dashkit table; 'collapsible' — domains-card style (heading lifted out above a collapsible section, tight card surface, CSS-grid body).",
+            options: ['default', 'collapsible'],
+        },
+    },
     component: BlockAccountsCard,
-    decorators: [withCluster],
+    decorators: [withCluster, withTokenInfoBatch],
     parameters: nextjsParameters,
     tags: ['autodocs', 'test'],
     title: 'Components/Block/BlockAccountsCard',
@@ -13,6 +22,60 @@ const meta: Meta<typeof BlockAccountsCard> = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// Account addresses used by the synthetic block below (valid base58 — no 0, O, I, l). 13 entries so
+// the list exceeds the initial 10 rows and the "Load More" control shows.
+const ACCOUNT_IDS = [
+    '11111111111111111111111111111111',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+    'So11111111111111111111111111111111111111112',
+    'SysvarRent111111111111111111111111111111111',
+    'SysvarC1ock11111111111111111111111111111111',
+    'Stake11111111111111111111111111111111111111',
+    'Vote111111111111111111111111111111111111111',
+    'BPFLoaderUpgradeab1e11111111111111111111111',
+    'ComputeBudget111111111111111111111111111111',
+    'AddressLookupTab1e1111111111111111111111111',
+    'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+    'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+];
+
+// Minimal stand-in for a VersionedBlockResponse — just the shape BlockAccountsCard reads. Account j
+// is referenced in every (j+1)-th transaction (descending usage); every 3rd account is writable, so
+// the read-write / read-only split varies across rows.
+function makeBlock(txCount: number) {
+    const keys = ACCOUNT_IDS.map(id => new PublicKey(id));
+    const accountKeys = { get: (i: number) => keys[i], length: keys.length };
+    const transactions = Array.from({ length: txCount }, (_, k) => {
+        const accountKeyIndexes = ACCOUNT_IDS.map((_, j) => j).filter(j => k % (j + 1) === 0);
+        const message = {
+            compiledInstructions: [{ accountKeyIndexes }],
+            getAccountKeys: () => accountKeys,
+            isAccountWritable: (i: number) => i % 3 === 0,
+        };
+        return { meta: { loadedAddresses: undefined }, transaction: { message } };
+    });
+    return { transactions } as any;
+}
+
+// Original Dashkit table.
+export const WithData: Story = {
+    args: {
+        block: makeBlock(20),
+        blockSlot: 312_456_789,
+    },
+};
+
+// Domains-card style (PR #115): heading lifted out above a collapsible section, tight card surface,
+// CSS-grid body on lg+ and a stacked, labelled layout below lg.
+export const Collapsible: Story = {
+    args: {
+        block: makeBlock(20),
+        blockSlot: 312_456_789,
+        variant: 'collapsible',
+    },
+};
 
 // Empty block — wrapper-only story for visual-regression coverage of the outer card.
 export const EmptyBlock: Story = {

--- a/app/components/block/__stories__/BlockHistoryCard.stories.tsx
+++ b/app/components/block/__stories__/BlockHistoryCard.stories.tsx
@@ -32,10 +32,27 @@ const VOTE_INDEX = 3;
 // base58-decode, so these render as `Sig0…0000` style links.
 const signatureFor = (i: number) => `Sig${i}HistoryCardStoryPlaceholderSignatureForStorybookRendering0000000000000${i}`;
 
+// Standard-shaped program logs so `parseProgramLogs` can extract compute units. Each invocation emits the
+// runtime's invoke / consumed / success triplet; the consumed amount varies per program and position so
+// per-row Compute totals differ. A failed tx ends its last instruction with an error line instead of
+// success. Only when *every* rendered tx yields compute units does the optional Compute column appear.
+function logsForTx(programIdxs: number[], failed: boolean): string[] {
+    const logs: string[] = [];
+    programIdxs.forEach((idx, n) => {
+        const id = PROGRAM_IDS[idx];
+        const consumed = 450 + (((idx + 1) * (n + 1) * 175) % 4_000);
+        const isLast = n === programIdxs.length - 1;
+        logs.push(`Program ${id} invoke [1]`);
+        logs.push(`Program ${id} consumed ${consumed} of 200000 compute units`);
+        logs.push(failed && isLast ? `Program ${id} failed: custom program error: 0x1` : `Program ${id} success`);
+    });
+    return logs;
+}
+
 // Minimal stand-in for a VersionedBlockResponse — only the shape BlockHistoryCard reads. Every 4th tx
 // fails; each invokes a rotating primary program, and every 3rd also invokes a second one, so the
-// filter dropdown and the "Invoked Programs" column show a realistic spread. Logs are omitted, so the
-// optional Compute column stays hidden (its data comes from parsed program logs).
+// filter dropdown and the "Invoked Programs" column show a realistic spread. Each tx also carries program
+// logs so the optional Compute column (its data comes from parsed program logs) is populated.
 function makeBlock(txCount: number): VersionedBlockResponse {
     const keys = PROGRAM_IDS.map(id => new PublicKey(id));
     const accountKeys = {
@@ -60,7 +77,7 @@ function makeBlock(txCount: number): VersionedBlockResponse {
                 err: failed ? { InstructionError: [0, 'Custom'] } : null,
                 fee: 5_000,
                 innerInstructions: [],
-                logMessages: [],
+                logMessages: logsForTx(programIdxs, failed),
             },
             transaction: {
                 message: {
@@ -105,7 +122,7 @@ export const ManyTransactions: Story = {
 };
 
 // Domains-card style (PR #115): title lifted out above a collapsible section (filter kept as its
-// action), tight card surface, CSS-grid body on lg+ and a stacked, labelled layout below lg.
+// action), tight card surface, CSS-grid body on md+ and a stacked, labelled layout below md.
 export const Collapsible: Story = {
     args: { block: makeBlock(8), epoch: 500n, variant: 'collapsible' },
 };

--- a/app/components/block/__stories__/BlockHistoryCard.stories.tsx
+++ b/app/components/block/__stories__/BlockHistoryCard.stories.tsx
@@ -1,5 +1,5 @@
-import type { VersionedBlockResponse } from '@solana/web3.js';
-import { nextjsParameters, withCluster } from '@storybook-config/decorators';
+import { PublicKey, type VersionedBlockResponse } from '@solana/web3.js';
+import { nextjsParameters, withCluster, withTokenInfoBatch } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
 
 import { BlockHistoryCard } from '../BlockHistoryCard';
@@ -15,9 +15,77 @@ const emptyBlock = {
     transactions: [],
 } as unknown as VersionedBlockResponse;
 
+// Programs the synthetic transactions invoke. Deliberately excludes the Compute Budget program so
+// `estimateRequestedComputeUnits` never tries to parse the (empty) instruction data — it just adds the
+// per-program reserved units, which is enough to populate the "Reserved CUs" column. Vote is last so it
+// can be added only as a *secondary* program (never alone) — otherwise the card's default "All Except
+// Votes" filter would hide those rows and the counts would look off.
+const PROGRAM_IDS = [
+    '11111111111111111111111111111111',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    'Stake11111111111111111111111111111111111111',
+    'Vote111111111111111111111111111111111111111',
+];
+const VOTE_INDEX = 3;
+
+// Distinct placeholder signature per row — the Signature cell only truncates for display, it doesn't
+// base58-decode, so these render as `Sig0…0000` style links.
+const signatureFor = (i: number) => `Sig${i}HistoryCardStoryPlaceholderSignatureForStorybookRendering0000000000000${i}`;
+
+// Minimal stand-in for a VersionedBlockResponse — only the shape BlockHistoryCard reads. Every 4th tx
+// fails; each invokes a rotating primary program, and every 3rd also invokes a second one, so the
+// filter dropdown and the "Invoked Programs" column show a realistic spread. Logs are omitted, so the
+// optional Compute column stays hidden (its data comes from parsed program logs).
+function makeBlock(txCount: number): VersionedBlockResponse {
+    const keys = PROGRAM_IDS.map(id => new PublicKey(id));
+    const accountKeys = {
+        get: (i: number) => keys[i],
+        keySegments: () => [keys],
+        length: keys.length,
+    };
+    const transactions = Array.from({ length: txCount }, (_, k) => {
+        const failed = k % 4 === 0;
+        // Primary rotates over the non-vote programs and is invoked a varying number of times (1..12) so
+        // the "N ×" counter exercises single- and double-digit widths; every other tx also invokes Vote
+        // once as a secondary.
+        const primary = k % VOTE_INDEX;
+        const primaryCount = 1 + (k % 12);
+        const programIdxs = [
+            ...Array.from({ length: primaryCount }, () => primary),
+            ...(k % 2 === 0 ? [VOTE_INDEX] : []),
+        ];
+        return {
+            meta: {
+                costUnits: 1_000 + (k % 7) * 350,
+                err: failed ? { InstructionError: [0, 'Custom'] } : null,
+                fee: 5_000,
+                innerInstructions: [],
+                logMessages: [],
+            },
+            transaction: {
+                message: {
+                    compiledInstructions: programIdxs.map(idx => ({ data: new Uint8Array(), programIdIndex: idx })),
+                    getAccountKeys: () => accountKeys,
+                    staticAccountKeys: keys,
+                },
+                signatures: [signatureFor(k)],
+            },
+        };
+    });
+    return { transactions } as unknown as VersionedBlockResponse;
+}
+
 const meta = {
+    argTypes: {
+        variant: {
+            control: 'inline-radio',
+            description:
+                "'default' — original Dashkit table; 'collapsible' — domains-card style (title lifted out above a collapsible section with the filter as its action, tight card surface, CSS-grid body).",
+            options: ['default', 'collapsible'],
+        },
+    },
     component: BlockHistoryCard,
-    decorators: [withCluster],
+    decorators: [withCluster, withTokenInfoBatch],
     parameters: nextjsParameters,
     tags: ['autodocs', 'test'],
     title: 'Components/Block/BlockHistoryCard',
@@ -26,6 +94,28 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// A handful of transactions — populated table with a mix of Success / Failed rows and invoked programs.
+export const WithTransactions: Story = {
+    args: { block: makeBlock(8), epoch: 500n },
+};
+
+// More than one page (PAGE_SIZE = 25) so the green "Load More" footer shows.
+export const ManyTransactions: Story = {
+    args: { block: makeBlock(30), epoch: 500n },
+};
+
+// Domains-card style (PR #115): title lifted out above a collapsible section (filter kept as its
+// action), tight card surface, CSS-grid body on lg+ and a stacked, labelled layout below lg.
+export const Collapsible: Story = {
+    args: { block: makeBlock(8), epoch: 500n, variant: 'collapsible' },
+};
+
+// Collapsible variant with more than one page → the green "Load More" footer shows.
+export const CollapsibleManyTransactions: Story = {
+    args: { block: makeBlock(30), epoch: 500n, variant: 'collapsible' },
+};
+
+// No transactions → the "This block has no transactions" ErrorCard fallback.
 export const EmptyBlock: Story = {
     args: { block: emptyBlock, epoch: 500n },
 };

--- a/app/components/block/__stories__/BlockOverviewCard.stories.tsx
+++ b/app/components/block/__stories__/BlockOverviewCard.stories.tsx
@@ -1,0 +1,58 @@
+import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { BlockOverviewCard } from '../BlockOverviewCard';
+
+// Real block decoding needs a fully-formed VersionedBlockResponse with compiled instructions and
+// meta (heavy fixture work), but the Overview only reads block-level fields plus tx meta totals, so
+// an empty `transactions` list renders every always-on row (compute totals resolve to 0).
+const baseBlock = {
+    blockTime: 1_700_000_000,
+    blockhash: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+    parentSlot: 426014006,
+    previousBlockhash: 'GfR1o2b8mVCg1KYp2f8vXbNqvY9dQyv2n8VnQyJc5Uab',
+    transactions: [],
+} as unknown as VersionedBlockResponse;
+
+const LEADER = new PublicKey('So11111111111111111111111111111111111111112');
+const PARENT_LEADER = new PublicKey('Vote111111111111111111111111111111111111111');
+const CHILD_LEADER = new PublicKey('Stake11111111111111111111111111111111111111');
+
+const meta = {
+    component: BlockOverviewCard,
+    decorators: [withClusterAccountsAndTokenInfo],
+    parameters: nextjsParameters,
+    tags: ['autodocs', 'test'],
+    title: 'Components/Block/BlockOverviewCard',
+} satisfies Meta<typeof BlockOverviewCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        block: baseBlock,
+        blockLeader: LEADER,
+        childLeader: CHILD_LEADER,
+        childSlot: 426014008,
+        epoch: 500n,
+        parentLeader: PARENT_LEADER,
+        slot: 426014007,
+    },
+};
+
+export const NoTimestamp: Story = {
+    args: {
+        ...Default.args,
+        block: { ...baseBlock, blockTime: null } as unknown as VersionedBlockResponse,
+    },
+};
+
+export const MinimalNoLeaders: Story = {
+    args: {
+        block: baseBlock,
+        epoch: 500n,
+        slot: 426014007,
+    },
+};

--- a/app/components/block/__stories__/BlockProgramsCard.stories.tsx
+++ b/app/components/block/__stories__/BlockProgramsCard.stories.tsx
@@ -1,11 +1,20 @@
-import { nextjsParameters, withCluster } from '@storybook-config/decorators';
+import { PublicKey } from '@solana/web3.js';
+import { nextjsParameters, withCluster, withTokenInfoBatch } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
 
 import { BlockProgramsCard } from '../BlockProgramsCard';
 
 const meta: Meta<typeof BlockProgramsCard> = {
+    argTypes: {
+        variant: {
+            control: 'inline-radio',
+            description:
+                "'default' — original Dashkit cards + table; 'collapsible' — domains-card style (heading lifted out above a collapsible section, tight card surface, CSS-grid body).",
+            options: ['default', 'collapsible'],
+        },
+    },
     component: BlockProgramsCard,
-    decorators: [withCluster],
+    decorators: [withCluster, withTokenInfoBatch],
     parameters: nextjsParameters,
     tags: ['autodocs', 'test'],
     title: 'Components/Block/BlockProgramsCard',
@@ -13,6 +22,50 @@ const meta: Meta<typeof BlockProgramsCard> = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// Program ids used by the synthetic block below (valid base58 — no 0, O, I, l).
+const PROGRAM_IDS = [
+    'Vote111111111111111111111111111111111111111',
+    'ComputeBudget111111111111111111111111111111',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    '11111111111111111111111111111111',
+    'So11111111111111111111111111111111111111112',
+];
+
+// Minimal stand-in for a VersionedBlockResponse — just the shape BlockProgramsCard reads. Program j
+// appears in every (j+1)-th transaction, giving a descending usage distribution; every 5th tx is
+// marked failed (`err`) so Success Rate lands below 100%. All txs carry `meta`, so the Success Rate
+// column shows.
+function makeBlock(txCount: number) {
+    const keys = PROGRAM_IDS.map(id => new PublicKey(id));
+    const accountKeys = { get: (i: number) => keys[i], length: keys.length };
+    const transactions = Array.from({ length: txCount }, (_, k) => {
+        const compiledInstructions = PROGRAM_IDS.map((_, j) => j)
+            .filter(j => k % (j + 1) === 0)
+            .map(j => ({ programIdIndex: j }));
+        return {
+            meta: { err: k % 5 === 0 ? { InstructionError: [0, 'Custom'] } : null, innerInstructions: [] },
+            transaction: { message: { compiledInstructions, getAccountKeys: () => accountKeys } },
+        };
+    });
+    return { transactions } as any;
+}
+
+// Original Dashkit cards.
+export const WithData: Story = {
+    args: {
+        block: makeBlock(12),
+    },
+};
+
+// Domains-card style (PR #115): headings lifted out above collapsible sections, tight card surfaces,
+// CSS-grid bodies on lg+ and stacked, labelled layouts below lg.
+export const Collapsible: Story = {
+    args: {
+        block: makeBlock(12),
+        variant: 'collapsible',
+    },
+};
 
 // Empty block exercises the wrapper without a full VersionedBlockResponse fixture.
 export const EmptyBlock: Story = {

--- a/app/components/block/__stories__/BlockProgramsCard.stories.tsx
+++ b/app/components/block/__stories__/BlockProgramsCard.stories.tsx
@@ -6,12 +6,6 @@ import { BlockProgramsCard } from '../BlockProgramsCard';
 
 const meta: Meta<typeof BlockProgramsCard> = {
     argTypes: {
-        programsVariant: {
-            control: 'inline-radio',
-            description:
-                'Initial design variant for the collapsible "Block Programs" table (also switchable on-page via the chips): \'1\' — count + percentage as aligned columns; \'2\' — count with "(percentage of total)" in parentheses, no "% of total" header suffix, Success Rate header shortened to "Success"; \'2a\' — like 2 but count and percentage swapped, with the percentage bright and the count muted.',
-            options: ['1', '2', '2a'],
-        },
         variant: {
             control: 'inline-radio',
             description:

--- a/app/components/block/__stories__/BlockProgramsCard.stories.tsx
+++ b/app/components/block/__stories__/BlockProgramsCard.stories.tsx
@@ -6,6 +6,12 @@ import { BlockProgramsCard } from '../BlockProgramsCard';
 
 const meta: Meta<typeof BlockProgramsCard> = {
     argTypes: {
+        programsVariant: {
+            control: 'inline-radio',
+            description:
+                'Initial design variant for the collapsible "Block Programs" table (also switchable on-page via the chips): \'1\' — count + percentage as aligned columns; \'2\' — count with "(percentage of total)" in parentheses, no "% of total" header suffix, Success Rate header shortened to "Success"; \'2a\' — like 2 but count and percentage swapped, with the percentage bright and the count muted.',
+            options: ['1', '2', '2a'],
+        },
         variant: {
             control: 'inline-radio',
             description:

--- a/app/components/block/__stories__/BlockRewardsCard.stories.tsx
+++ b/app/components/block/__stories__/BlockRewardsCard.stories.tsx
@@ -4,6 +4,14 @@ import type { Meta, StoryObj } from '@storybook-config/types';
 import { BlockRewardsCard } from '../BlockRewardsCard';
 
 const meta: Meta<typeof BlockRewardsCard> = {
+    argTypes: {
+        variant: {
+            control: 'inline-radio',
+            description:
+                "'default' — original Dashkit table; 'collapsible' — domains-card style (heading lifted out above a collapsible section, tight card surface, CSS-grid body).",
+            options: ['default', 'collapsible'],
+        },
+    },
     component: BlockRewardsCard,
     decorators: [withCluster, withTokenInfoBatch],
     parameters: nextjsParameters,
@@ -39,14 +47,33 @@ const sampleReward = (i: number) => ({
     rewardType: i % 2 === 0 ? 'Staking' : 'Voting',
 });
 
+const rewards = (n: number) => ({ rewards: Array.from({ length: n }, (_, i) => sampleReward(i)) }) as any;
+
+// Original Dashkit table.
 export const WithRewards: Story = {
     args: {
-        block: { rewards: Array.from({ length: 8 }, (_, i) => sampleReward(i)) } as any,
+        block: rewards(8),
     },
 };
 
 export const WithManyRewards: Story = {
     args: {
-        block: { rewards: Array.from({ length: 25 }, (_, i) => sampleReward(i)) } as any,
+        block: rewards(25),
+    },
+};
+
+// Domains-card style (PR #115): heading lifted out above a collapsible section, tight card surface,
+// CSS-grid body on lg+ and a stacked, labelled layout below lg.
+export const Collapsible: Story = {
+    args: {
+        block: rewards(8),
+        variant: 'collapsible',
+    },
+};
+
+export const CollapsibleWithManyRewards: Story = {
+    args: {
+        block: rewards(25),
+        variant: 'collapsible',
     },
 };

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -166,7 +166,7 @@ export function Address({
     );
 
     return (
-        <span ref={visibilityRef} className="block w-full">
+        <span ref={visibilityRef} className="block w-full min-w-0">
             <div ref={rowRef} className={rowVariants({ alignRight: Boolean(alignRight) })} aria-label={ariaLabel}>
                 {/* Hidden span for measuring the natural text width — absolutely positioned so it doesn't affect layout */}
                 {isMidTruncateCandidate && (

--- a/app/features/transaction-history/ui/BaseTransactionHistoryCard.tsx
+++ b/app/features/transaction-history/ui/BaseTransactionHistoryCard.tsx
@@ -2,14 +2,22 @@
 
 import { Signature } from '@components/common/Signature';
 import { Slot } from '@components/common/Slot';
+import { cn } from '@components/shared/utils';
 import { HistoryCardFooter, HistoryCardHeader } from '@shared/ui/HistoryCard';
 import { displayTimestampUtc, unixTimestampToMs } from '@utils/date';
-import { type ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
 import { Badge } from '@/app/components/shared/ui/badge';
 import { RelativeTime } from '@/app/shared/RelativeTime';
 import { Card } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
+
+// Design variant, switchable via prop:
+//   - 'default' — the original Dashkit table (Signature / Block / Age / Timestamp / Result / Raw Data).
+//   - 'grid'    — the rearranged CSS-grid layout: the Result badge moves inline next to the signature
+//                 (instructions below), Age + Timestamp collapse into one "Time" column, and Block /
+//                 Size keep their own columns. Every field from the row model still gets a column.
+export type TransactionHistoryVariant = 'default' | 'grid';
 
 export type TransactionHistoryRowView = {
     signature: string;
@@ -30,6 +38,7 @@ export type BaseTransactionHistoryCardProps = {
     onLoadMore: () => void;
     headerActions?: ReactNode;
     headerSubRow?: ReactNode;
+    variant?: TransactionHistoryVariant;
 };
 
 export function BaseTransactionHistoryCard({
@@ -40,6 +49,7 @@ export function BaseTransactionHistoryCard({
     onLoadMore,
     headerActions,
     headerSubRow,
+    variant = 'default',
 }: BaseTransactionHistoryCardProps) {
     const hasTimestamps = rows.some(row => row.blockTime);
 
@@ -53,6 +63,9 @@ export function BaseTransactionHistoryCard({
                 actions={headerActions}
                 subHeader={headerSubRow}
             />
+            {variant === 'grid' ? (
+                <TransactionGrid rows={rows} />
+            ) : (
             <BaseTable ui="dashkit" variant="card" nowrap>
                 <BaseTable.Head>
                     <BaseTable.Row>
@@ -76,6 +89,7 @@ export function BaseTransactionHistoryCard({
                     ))}
                 </BaseTable.Body>
             </BaseTable>
+            )}
             <HistoryCardFooter fetching={fetching} foundOldest={foundOldest} loadMore={onLoadMore} />
         </Card>
     );
@@ -124,5 +138,80 @@ function TransactionRow({
             </BaseTable.Cell>
             <BaseTable.Cell>{rawDataCell}</BaseTable.Cell>
         </BaseTable.Row>
+    );
+}
+
+// Signature takes the slack; Time / Block / Size are capped. Header + rows share this template so
+// columns stay aligned. Inline (not a `grid-cols-[…]` class) so the Storybook JIT can't purge it.
+const GRID_TEMPLATE: React.CSSProperties = {
+    gridTemplateColumns: 'minmax(240px,1fr) minmax(auto,17rem) minmax(auto,11rem) minmax(auto,7rem)',
+};
+const GRID_HEADERS = ['Transaction Signature', 'Time', 'Block', 'Size (Bytes)'] as const;
+
+// 'grid' variant — the screenshot layout. Header and every row are separate CSS grids sharing the same
+// inline column template, stacked in a fixed-min-width track that scrolls horizontally on narrow
+// screens — so the columns stay aligned like a table (same approach as the block grid cards).
+function TransactionGrid({ rows }: { rows: TransactionHistoryRowView[] }) {
+    return (
+        <div className="overflow-x-auto text-sm text-white">
+            <div style={{ minWidth: '760px' }}>
+                <div
+                    style={GRID_TEMPLATE}
+                    className="grid gap-5 border-0 border-b border-solid border-dark-border px-4 py-2.5 text-xs uppercase text-dk-gray-700"
+                >
+                    {GRID_HEADERS.map(label => (
+                        <div key={label}>{label}</div>
+                    ))}
+                </div>
+                {rows.map(row => (
+                    <TransactionGridRow key={row.signature} row={row} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function TransactionGridRow({
+    row: { signature, slot, blockTime, status, instructionsCell, rawDataCell },
+}: {
+    row: TransactionHistoryRowView;
+}) {
+    return (
+        <div
+            style={GRID_TEMPLATE}
+            className={cn(
+                'grid items-start gap-5 px-4 py-3',
+                'border-0 border-b border-solid border-dark-border last:border-b-0',
+            )}
+        >
+            <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                    <Signature signature={signature} link />
+                    <Badge ui="dashkit" variant={STATUS_BADGE[status].variant}>
+                        {STATUS_BADGE[status].label}
+                    </Badge>
+                </div>
+                {instructionsCell}
+            </div>
+
+            <div className="min-w-0">
+                {blockTime ? (
+                    <div className="flex flex-col">
+                        <span>{displayTimestampUtc(unixTimestampToMs(blockTime), true)}</span>
+                        <span className="text-dk-gray-700">
+                            <RelativeTime date={unixTimestampToMs(blockTime)} />
+                        </span>
+                    </div>
+                ) : (
+                    '---'
+                )}
+            </div>
+
+            <div className="min-w-0">
+                <Slot slot={slot} link />
+            </div>
+
+            <div className="min-w-0">{rawDataCell}</div>
+        </div>
     );
 }

--- a/app/features/transaction-history/ui/BaseTransactionHistoryCard.tsx
+++ b/app/features/transaction-history/ui/BaseTransactionHistoryCard.tsx
@@ -66,29 +66,31 @@ export function BaseTransactionHistoryCard({
             {variant === 'grid' ? (
                 <TransactionGrid rows={rows} />
             ) : (
-            <BaseTable ui="dashkit" variant="card" nowrap>
-                <BaseTable.Head>
-                    <BaseTable.Row>
-                        <BaseTable.HeaderCell className="w-px text-dk-gray-700">
-                            Transaction Signature
-                        </BaseTable.HeaderCell>
-                        <BaseTable.HeaderCell className="w-px text-dk-gray-700">Block</BaseTable.HeaderCell>
-                        {hasTimestamps && (
-                            <>
-                                <BaseTable.HeaderCell className="w-px text-dk-gray-700">Age</BaseTable.HeaderCell>
-                                <BaseTable.HeaderCell className="w-px text-dk-gray-700">Timestamp</BaseTable.HeaderCell>
-                            </>
-                        )}
-                        <BaseTable.HeaderCell className="text-dk-gray-700">Result</BaseTable.HeaderCell>
-                        <BaseTable.HeaderCell className="text-dk-gray-700">Raw Data</BaseTable.HeaderCell>
-                    </BaseTable.Row>
-                </BaseTable.Head>
-                <BaseTable.Body>
-                    {rows.map(row => (
-                        <TransactionRow key={row.signature} row={row} hasTimestamps={hasTimestamps} />
-                    ))}
-                </BaseTable.Body>
-            </BaseTable>
+                <BaseTable ui="dashkit" variant="card" nowrap>
+                    <BaseTable.Head>
+                        <BaseTable.Row>
+                            <BaseTable.HeaderCell className="w-px text-dk-gray-700">
+                                Transaction Signature
+                            </BaseTable.HeaderCell>
+                            <BaseTable.HeaderCell className="w-px text-dk-gray-700">Block</BaseTable.HeaderCell>
+                            {hasTimestamps && (
+                                <>
+                                    <BaseTable.HeaderCell className="w-px text-dk-gray-700">Age</BaseTable.HeaderCell>
+                                    <BaseTable.HeaderCell className="w-px text-dk-gray-700">
+                                        Timestamp
+                                    </BaseTable.HeaderCell>
+                                </>
+                            )}
+                            <BaseTable.HeaderCell className="text-dk-gray-700">Result</BaseTable.HeaderCell>
+                            <BaseTable.HeaderCell className="text-dk-gray-700">Raw Data</BaseTable.HeaderCell>
+                        </BaseTable.Row>
+                    </BaseTable.Head>
+                    <BaseTable.Body>
+                        {rows.map(row => (
+                            <TransactionRow key={row.signature} row={row} hasTimestamps={hasTimestamps} />
+                        ))}
+                    </BaseTable.Body>
+                </BaseTable>
             )}
             <HistoryCardFooter fetching={fetching} foundOldest={foundOldest} loadMore={onLoadMore} />
         </Card>

--- a/app/features/transaction-history/ui/__stories__/BaseTransactionHistoryCard.stories.tsx
+++ b/app/features/transaction-history/ui/__stories__/BaseTransactionHistoryCard.stories.tsx
@@ -1,5 +1,6 @@
 import { createNextjsParameters, withCluster } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
+import { Code } from 'react-feather';
 
 import { BaseTransactionHistoryCard, type TransactionHistoryRowView } from '../BaseTransactionHistoryCard';
 import { InstructionList } from '../InstructionList';
@@ -26,7 +27,26 @@ function makeRow(
     };
 }
 
+// Stand-in for the raw-data cell in the 'grid' variant's "Size (Bytes)" column — the `<>` control plus
+// a byte count, mirroring the design. In production this cell is the lazily-fetched raw-data control.
+function sizeCell(bytes: number) {
+    return (
+        <span className="flex items-center gap-1.5 font-mono">
+            <Code size={13} className="text-dk-gray-700" />
+            {bytes}
+        </span>
+    );
+}
+
 const meta = {
+    argTypes: {
+        variant: {
+            control: 'inline-radio',
+            description:
+                "'default' — original Dashkit table; 'grid' — rearranged CSS-grid layout (Result badge inline with the signature, Age + Timestamp combined into one Time column).",
+            options: ['default', 'grid'],
+        },
+    },
     component: BaseTransactionHistoryCard,
     decorators: [withCluster],
     parameters: createNextjsParameters(),
@@ -83,5 +103,48 @@ export const Fetching: Story = {
         onLoadMore: () => {},
         onRefresh: () => {},
         rows: [makeRow({ signature: SIGNATURES.first })],
+    },
+};
+
+// 'grid' variant — the rearranged layout: badge inline with the signature (instructions below), Age +
+// Timestamp merged into one Time column, Block and Size (Bytes) as their own columns.
+export const Grid: Story = {
+    args: {
+        fetching: false,
+        foundOldest: false,
+        onLoadMore: () => {},
+        onRefresh: () => {},
+        rows: [
+            makeRow({
+                blockTime: 1_718_000_000,
+                instructionsCell: <InstructionList instructions={[{ name: 'Transfer', program: 'System' }]} />,
+                rawDataCell: sizeCell(215),
+                signature: SIGNATURES.first,
+                slot: 312_456_789,
+            }),
+            makeRow({
+                blockTime: 1_717_999_880,
+                instructionsCell: (
+                    <InstructionList
+                        instructions={[
+                            { name: 'Mint To', program: 'Token' },
+                            { name: 'Transfer', program: 'Token' },
+                        ]}
+                    />
+                ),
+                rawDataCell: sizeCell(388),
+                signature: SIGNATURES.third,
+                slot: 312_456_790,
+            }),
+            makeRow({
+                blockTime: 1_717_999_700,
+                instructionsCell: <InstructionList instructions={[{ name: 'Transfer', program: 'System' }]} />,
+                rawDataCell: sizeCell(164),
+                signature: SIGNATURES.failed,
+                slot: 312_456_791,
+                status: 'failed',
+            }),
+        ],
+        variant: 'grid',
     },
 };

--- a/app/features/transaction/ui/CollapsibleSection.tsx
+++ b/app/features/transaction/ui/CollapsibleSection.tsx
@@ -11,6 +11,8 @@ type CollapsibleSectionProps = {
     actions?: ReactNode;
     children: ReactNode;
     defaultExpanded?: boolean;
+    /** When false, the collapse toggle is hidden and the body is always shown. Defaults to true. */
+    collapsible?: boolean;
     className?: string;
     titleClassName?: string;
     sectionClassName?: string;
@@ -22,6 +24,7 @@ export function CollapsibleSection({
     actions,
     children,
     defaultExpanded = true,
+    collapsible = true,
     className = baseCardVariants({ ui: 'dashkit' }),
     titleClassName,
     sectionClassName,
@@ -29,38 +32,45 @@ export function CollapsibleSection({
     const [expanded, setExpanded] = useState(defaultExpanded);
     const headingId = useId();
 
+    // When not collapsible, the body is always shown regardless of the (unused) toggle state.
+    const isOpen = !collapsible || expanded;
+
     return (
         <section id={id} aria-labelledby={headingId} className={cn('flex flex-col gap-3', sectionClassName)}>
             <div data-section-title className={cn('flex items-center justify-between', titleClassName)}>
                 <h2 id={headingId} className="m-0 text-lg font-normal text-white">
                     {title}
                 </h2>
-                <div className="flex items-center gap-1">
-                    {actions && <div className="flex shrink-0 gap-1">{actions}</div>}
-                    <Button
-                        className="md:min-w-[86px]"
-                        variant="outline"
-                        aria-expanded={expanded}
-                        size="sm"
-                        aria-label={expanded ? 'Collapse' : 'Expand'}
-                        onClick={() => setExpanded(v => !v)}
-                    >
-                        <ChevronDown
-                            size={12}
-                            className={cn(
-                                'transition-transform duration-200 ease-in-out',
-                                // keep this writing. this is working in case parent has trasform translate
-                                expanded && '[transform:rotate(180deg)]',
-                            )}
-                        />
-                        <span className="hidden md:inline-block">{expanded ? 'Collapse' : 'Expand'}</span>
-                    </Button>
-                </div>
+                {(collapsible || actions) && (
+                    <div className="flex items-center gap-1">
+                        {actions && <div className="flex shrink-0 gap-1">{actions}</div>}
+                        {collapsible && (
+                            <Button
+                                className="md:min-w-[86px]"
+                                variant="outline"
+                                aria-expanded={expanded}
+                                size="sm"
+                                aria-label={expanded ? 'Collapse' : 'Expand'}
+                                onClick={() => setExpanded(v => !v)}
+                            >
+                                <ChevronDown
+                                    size={12}
+                                    className={cn(
+                                        'transition-transform duration-200 ease-in-out',
+                                        // keep this writing. this is working in case parent has trasform translate
+                                        expanded && '[transform:rotate(180deg)]',
+                                    )}
+                                />
+                                <span className="hidden md:inline-block">{expanded ? 'Collapse' : 'Expand'}</span>
+                            </Button>
+                        )}
+                    </div>
+                )}
             </div>
             <div
                 className={cn(
                     'grid transition-[grid-template-rows] duration-200 ease-in-out',
-                    expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+                    isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
                 )}
             >
                 <div className="overflow-hidden">

--- a/app/features/transaction/ui/CollapsibleSection.tsx
+++ b/app/features/transaction/ui/CollapsibleSection.tsx
@@ -9,6 +9,8 @@ type CollapsibleSectionProps = {
     id?: string;
     title: ReactNode;
     actions?: ReactNode;
+    /** Full-width content stacked under the title row, inside the same (always-visible) title group. */
+    belowTitle?: ReactNode;
     children: ReactNode;
     defaultExpanded?: boolean;
     /** When false, the collapse toggle is hidden and the body is always shown. Defaults to true. */
@@ -22,6 +24,7 @@ export function CollapsibleSection({
     id,
     title,
     actions,
+    belowTitle,
     children,
     defaultExpanded = true,
     collapsible = true,
@@ -37,12 +40,24 @@ export function CollapsibleSection({
 
     return (
         <section id={id} aria-labelledby={headingId} className={cn('flex flex-col gap-3', sectionClassName)}>
+            {/* Header block: the title (plus optional `belowTitle`) forms the first column; the actions and
+                collapse toggle form a second column that `titleClassName` can bottom-align (`items-end`).
+                Without `belowTitle` the title stays a direct child so existing sections are untouched. */}
             <div data-section-title className={cn('flex items-center justify-between', titleClassName)}>
-                <h2 id={headingId} className="m-0 text-lg font-normal text-white">
-                    {title}
-                </h2>
+                {belowTitle ? (
+                    <div className="flex min-w-0 flex-col gap-2">
+                        <h2 id={headingId} className="m-0 text-lg font-normal text-white">
+                            {title}
+                        </h2>
+                        {belowTitle}
+                    </div>
+                ) : (
+                    <h2 id={headingId} className="m-0 text-lg font-normal text-white">
+                        {title}
+                    </h2>
+                )}
                 {(collapsible || actions) && (
-                    <div className="flex items-center gap-1">
+                    <div className="flex shrink-0 items-center gap-1">
                         {actions && <div className="flex shrink-0 gap-1">{actions}</div>}
                         {collapsible && (
                             <Button

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,7 +53,7 @@ export const dkColors = {
     'rainbow-5': '#1dd79b',
     'popover-bg': '#1A1A1A',
     'popover-border': 'rgba(255,255,255,0.1)',
-    'card-outline-dark': '#111',
+    'card-outline-dark': 'oklch(33.501% 0.01351 189.14)', // = outer-space-800; matches the tx-inspector card outline
     'input-placeholder-dark': '#ccc',
 };
 


### PR DESCRIPTION
## Description

Adapts the block detail page (`/block/[slot]`) and all its tabs for mobile and tablet. Card headings move outside their cards with collapse/expand behaviour, the data tables become responsive CSS grids that stack into labelled rows on narrow screens, and spacing/padding are reworked so content uses the full width available.

-   **All block tabs (Overview, Transactions, Accounts, Programs, Rewards)** — matched to the transaction page: heading lifted above a collapsible section, tight card surface, grid body from `md` up and a stacked, labelled layout below. All block tables now share the transaction/overview cards' 8px corner radius.
-   **Page heading** — the "Details / Block" title now matches the transaction page's spacing: airy padding with equal 24px gaps above and below, sitting outside the section rhythm so those gaps stay fixed.
-   **Page tabs** — on mobile the sticky full-bleed tab bar sits ~12px under the Overview card, with a balanced 28px band above the labels and 36px below the underline; desktop spacing is unchanged. The tab underline now runs edge-to-edge into the page margins on mobile and tablet and is clipped to the content column on desktop, matching the address/token page tabs.
-   **Transactions card** — CU columns renamed to CUs Reserved / CUs Consumed / Cost and widened to keep headers on one line; header reads "Signature / Programs"; index column fits 4 digits; on mobile the signature is labelled, invoked programs get a "Programs" field and the index sits top-right. Sortable headers show a direction indicator — dim chevrons when clickable, the active column turning white with a bright arrow, re-click reverses (kept in the URL); the "#" header resets to index order. On mobile, where those headers are hidden, a Sort button beside the filter opens the same columns split into "Lowest …" / "Highest …" (ascending / descending). The record count moves into the heading as "N filtered records" / "N records".
-   **Transactions filter** — reworked into a "Filters" button (icon, plus a dot badge when a filter is active) opening a fixed-width menu with a program search; long option names wrap instead of widening it. The active program filter shows under the heading as a removable chip that clears back to all transactions.
-   **Programs card** — count and its share of the block shown together on one line as "count (percent)" with the percentage muted; column headers gained info-icon tooltips citing the block's transaction/instruction totals.
-   **Accounts card** — Total and its share merged into one "count (percent)" column (matching Programs) with an info tooltip; long account addresses now clip and mid-truncate inside the cell instead of forcing horizontal scroll.
-   **Rewards card** — "New Balance" renamed "Post Balance" with a wider column.
-   **Overview** — "Total CUs Consumed" label; key/value rows share one label-column width; long value rows (cost utilization, reserved CUs) wrap at spaces instead of breaking mid-token, and their percentages use the same muted colour as the Programs table.
-   **Number formatting** — block cards use tabular figures on the standard face; monospace kept only for ◎ SOL amounts.

## Type of change

-   [x] Design update

## Screenshots
<img width="1815" height="4480" alt="block_mobile_desktop" src="https://github.com/user-attachments/assets/14f8d4a4-c3bb-4406-9cf6-7e60226bc4a4" />

## Testing

[Block page](https://explorer-git-development-feat-hoo-801-block-page-734362-hoodies.vercel.app/block/440310960)

## Related Issues

https://linear.app/solana-fndn/issue/HOO-801/block-mobile-layout

## Checklist

-   [ ] My code follows the project's style guidelines
-   [ ] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — recommended for UI changes
