### PR TITLE
fix(block): raise max compute units per block to 100M (SIMD-0286)

### DIFF
--- a/app/utils/__tests__/epoch-schedule.test.ts
+++ b/app/utils/__tests__/epoch-schedule.test.ts
@@ -97,6 +97,9 @@ describe('getMaxComputeUnitsForEpoch', () => {
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 821n })).toEqual(50_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 822n })).toEqual(60_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 823n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 1008n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 1009n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 1010n })).toEqual(100_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: undefined })).toEqual(48_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: -1n })).toEqual(48_000_000);
     });
@@ -108,6 +111,9 @@ describe('getMaxComputeUnitsForEpoch', () => {
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 914n })).toEqual(50_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 915n })).toEqual(60_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 916n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 1099n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 1100n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 1101n })).toEqual(100_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: undefined })).toEqual(48_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: -1n })).toEqual(48_000_000);
     });
@@ -119,18 +125,28 @@ describe('getMaxComputeUnitsForEpoch', () => {
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 811n })).toEqual(50_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 812n })).toEqual(60_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 813n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 982n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 983n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 984n })).toEqual(100_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: undefined })).toEqual(48_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: -1n })).toEqual(48_000_000);
     });
 
     it('should return the correct max compute units for an epoch on custom', () => {
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 0n })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 769n })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 770n })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 821n })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 822n })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 823n })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: undefined })).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: -1n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 0n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 769n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 770n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 821n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 822n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 823n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: undefined })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: -1n })).toEqual(100_000_000);
+    });
+
+    // Every config activates at epoch 0 on the Simd296 surfnet, so the latest config must win.
+    it('should return the latest max compute units on simd296', () => {
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Simd296, epoch: 0n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Simd296, epoch: 1009n })).toEqual(100_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Simd296, epoch: undefined })).toEqual(100_000_000);
     });
 });

--- a/app/utils/epoch-schedule.ts
+++ b/app/utils/epoch-schedule.ts
@@ -136,6 +136,17 @@ const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
         maxComputeUnits: 60_000_000,
         simd: '0256',
     },
+    {
+        activations: {
+            [Cluster.MainnetBeta]: 1009,
+            [Cluster.Devnet]: 1100,
+            [Cluster.Testnet]: 983,
+            [Cluster.Simd296]: 0,
+        },
+        featureAccount: 'P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz',
+        maxComputeUnits: 100_000_000,
+        simd: '0286',
+    },
 ];
 
 /**
@@ -157,7 +168,9 @@ export function getMaxComputeUnitsInBlock({ epoch = 0n, cluster }: { epoch?: big
 
     for (const config of COMPUTE_UNIT_CONFIGS) {
         const activationEpoch = config.activations[cluster];
-        if (activationEpoch <= epochNumber && activationEpoch > highestActivationEpoch) {
+        // `>=` so that on clusters where several configs share an activation epoch (e.g. the
+        // Simd296 surfnet, where every config activates at epoch 0) the latest config wins.
+        if (activationEpoch <= epochNumber && activationEpoch >= highestActivationEpoch) {
             applicableConfig = config;
             highestActivationEpoch = activationEpoch;
         }


### PR DESCRIPTION
## Description

SIMD-0286 raised the per-block compute unit limit from 60M to 100M. Explorer still capped its block-level denominator at 60M, so every block after activation reported inflated utilization on `/block/<slot>` — often above 100%.

Adds the SIMD-0286 entry to `COMPUTE_UNIT_CONFIGS` in `app/utils/epoch-schedule.ts`:

| | |
| --- | --- |
| max compute units | `100_000_000` |
| feature account | `P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz` |
| activation | mainnet-beta 1009 · devnet 1100 · testnet 983 |

The activation epochs were taken from the on-chain feature account rather than from the announcement, by decoding `activated_at` on each cluster:

| Cluster | Activation slot | Epoch |
| --- | --- | --- |
| mainnet-beta | 435,888,000 | 1009 |
| devnet | 475,200,000 | 1100 |
| testnet | 419,132,256 | 983 (via the warmup schedule: `14 + (419132256 − 524256) / 432000`) |

Effect on the block from the report, [435888028](https://explorer.solana.com/block/435888028) — 71,915,916 cost units:

| | Transaction Cost Utilization |
| --- | --- |
| before | `71,915,916 / 60,000,000` (**120%**) |
| after | `71,915,916 / 100,000,000` (**72%**) |

### Secondary fix: activation epoch tie-break

`getMaxComputeUnitsInBlock` selected a config with `activationEpoch > highestActivationEpoch`. Every config activates at epoch 0 on the Simd296 surfnet, so the strict comparison made the first config win the tie and that cluster was pinned to 48M — it never picked up 50M, 60M, or 100M. Relaxed to `>=` so the latest config wins a tie.

Activation epochs on mainnet-beta, devnet, and testnet are distinct and increasing, so their resolution is unchanged. `Cluster.Custom` is unaffected too — it reduces over the maximum and so follows to 100M automatically.

## Type of change

-   [x] Bug fix

## Testing

Manual testing on the preview deployment:

-   [Block 435888028 — "Transaction Cost Utilization" should read 71,915,916 / 100,000,000 (72%)](PREVIEW_URL/block/435888028)
-   [Block 435887999 — last block of epoch 1008, denominator should still be 60,000,000](PREVIEW_URL/block/435887999)
-   [Block 435888000 — first block of epoch 1009, denominator should be 100,000,000](PREVIEW_URL/block/435888000)

## Related Issues

Relates to [HOO-950](https://linear.app/solana-fndn/issue/HOO-950/update-explorer-max-compute-units-to-100m)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit`)
-   [x] I have run `build:info` script to update build information (no change to `bench/BUILD.md`)

## Additional Notes

Out of scope here, but worth flagging for whoever reviews that page: the **"Reserved Compute Units"** row on the same card is structurally misleading, and this change does not fix it. On block 435888028 it reads `458,520,088 / 100,000,000 (459%)` — it read 764% against the old 60M denominator.

That row sums *requested* CU limits, while the 100M limit is enforced against settled cost. The leader reserves the requested amount when packing a transaction and releases the unused remainder after it executes, so the reservations in one block can legitimately total several times the block limit. `meta.costUnits` — what the row above uses — reflects actual consumption: across all 1711 transactions in that block, `costUnits − computeUnitsConsumed` is never negative and has a median of just +1,429.

On that block, 909 of 1711 transactions set no explicit CU limit, so the estimate charges 200k per instruction and contributes 301,885,000 of the 458,520,088 total; the remaining 802 transactions reserved 156,635,088 but consumed 48,739,509. The numerator is faithful to the protocol's reservation rule — it is the division by the block limit that has no meaning. Suggest either dropping the `/ max` and percentage from that row or relabelling it as an estimate of reserved demand.
