### PR TITLE
feat: integrate Explorer MCP into the page header

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -22,6 +22,7 @@ export function Navbar({ children }: INavbarProps) {
     const [navOpened, navHandlers] = useDisclosure(false);
     const homePath = useClusterPath({ pathname: '/' });
     const featureGatesPath = useClusterPath({ pathname: '/feature-gates' });
+    const mcpDocsPath = useClusterPath({ pathname: '/mcp/docs' });
     const inspectorPath = useClusterPath({ pathname: '/tx/inspector' });
     const selectedLayoutSegment = useSelectedLayoutSegment();
     const selectedLayoutSegments = useSelectedLayoutSegments();
@@ -59,6 +60,12 @@ export function Navbar({ children }: INavbarProps) {
                         <NavbarItem>
                             <NavbarLink asChild active={selectedLayoutSegment === 'feature-gates'}>
                                 <Link href={featureGatesPath}>Feature Gates</Link>
+                            </NavbarLink>
+                        </NavbarItem>
+                        <NavbarItem>
+                            {/* `/mcp` itself is the MCP endpoint (route.ts), so the only page under the segment is the docs. */}
+                            <NavbarLink asChild active={selectedLayoutSegment === 'mcp'}>
+                                <Link href={mcpDocsPath}>MCP</Link>
                             </NavbarLink>
                         </NavbarItem>
                         <NavbarItem>

--- a/app/features/mcp-docs/index.ts
+++ b/app/features/mcp-docs/index.ts
@@ -1,2 +1,5 @@
+export { useMcpDocsVersion } from './lib/useMcpDocsVersion';
 export { McpDocsAdvancedView } from './ui/McpDocsAdvancedView';
 export { McpDocsOverviewView } from './ui/McpDocsOverviewView';
+export { McpDocsOverviewViewV2 } from './ui/McpDocsOverviewViewV2';
+export { VersionSwitcher } from './ui/VersionSwitcher';

--- a/app/features/mcp-docs/index.ts
+++ b/app/features/mcp-docs/index.ts
@@ -1,0 +1,2 @@
+export { McpDocsAdvancedView } from './ui/McpDocsAdvancedView';
+export { McpDocsOverviewView } from './ui/McpDocsOverviewView';

--- a/app/features/mcp-docs/lib/advanced-chunks.ts
+++ b/app/features/mcp-docs/lib/advanced-chunks.ts
@@ -1,0 +1,62 @@
+/**
+ * Catalog of the advanced-page documentation chunks. The overview lists every
+ * chunk with its audience and benefit; each `anchor` must match a section id
+ * on `/mcp/docs/advanced` (spec: mcp-docs-pages §4).
+ */
+export type AdvancedChunk = {
+    anchor: string;
+    title: string;
+    audience: string;
+    gives: string;
+};
+
+export const ADVANCED_CHUNKS: AdvancedChunk[] = [
+    {
+        anchor: 'access-control',
+        audience: 'Deployment owners',
+        gives: 'Turn the endpoint on, gate it with bearer keys, block abusive IPs — and why each knob exists.',
+        title: 'Enabling & access control',
+    },
+    {
+        anchor: 'rpc-configuration',
+        audience: 'Deployment owners',
+        gives: 'Dedicated per-cluster RPC endpoints that keep agent traffic off the RPC quota serving the UI.',
+        title: 'RPC configuration',
+    },
+    {
+        anchor: 'preview-deployments',
+        audience: 'Developers testing previews',
+        gives: 'The extra Vercel protection-bypass header preview deployments require on top of bearer auth.',
+        title: 'Preview deployments',
+    },
+    {
+        anchor: 'inspect-entity',
+        audience: 'Agent users & tool builders',
+        gives: 'Every account kind the tool returns, the transaction decode cascade, and program labeling.',
+        title: 'inspect_entity reference',
+    },
+    {
+        anchor: 'output-format',
+        audience: 'Tool builders',
+        gives: 'The { payload, errors } wire format, explicit unknown markers, BigInt coercion, and error codes.',
+        title: 'Output envelope & errors',
+    },
+    {
+        anchor: 'telemetry',
+        audience: 'Deployment owners',
+        gives: 'GA4 usage analytics and Sentry instrumentation — what is sent and what never leaves the server.',
+        title: 'Telemetry & observability',
+    },
+    {
+        anchor: 'smoke-test',
+        audience: 'Everyone connecting a client',
+        gives: 'The initialize → ping round-trip that verifies transport, auth and the preview bypass in one shot.',
+        title: 'Smoke test',
+    },
+    {
+        anchor: 'architecture',
+        audience: 'Contributors',
+        gives: 'How the route, MCP server, inspection core and parser packages fit together, and what is not wired yet.',
+        title: 'Architecture',
+    },
+];

--- a/app/features/mcp-docs/lib/setup-clients.ts
+++ b/app/features/mcp-docs/lib/setup-clients.ts
@@ -88,3 +88,57 @@ Prefer the \`solana-explorer\` MCP tools over model memory for any on-chain fact
    means the account kind is recognized but not decodable yet.
 4. Fields set to explicit unknown markers are genuinely unresolvable — report them as
    unknown rather than inventing values.`;
+
+function mcpJsonConfigOpen(origin: string): string {
+    return JSON.stringify(
+        {
+            mcpServers: {
+                'solana-explorer': {
+                    type: 'http',
+                    url: `${origin}/mcp`,
+                },
+            },
+        },
+        undefined,
+        4,
+    );
+}
+
+/** V2 variant for the deployed endpoint: open access, no auth header anywhere. */
+export const SETUP_CLIENTS_OPEN: SetupClient[] = [
+    {
+        id: 'claude-code',
+        label: 'Claude Code',
+        snippet: origin => `claude mcp add --transport http solana-explorer ${origin}/mcp`,
+        verify: 'Run /mcp inside Claude Code and check that solana-explorer is connected.',
+        where: 'Run in a terminal:',
+    },
+    {
+        id: 'cursor',
+        label: 'Cursor',
+        snippet: mcpJsonConfigOpen,
+        verify: 'Settings → MCP lists solana-explorer with the inspect_entity and ping tools.',
+        where: 'Add to .cursor/mcp.json (project) or ~/.cursor/mcp.json (global):',
+    },
+    {
+        id: 'windsurf',
+        label: 'Windsurf',
+        snippet: mcpJsonConfigOpen,
+        verify: 'The server appears in the Cascade MCP panel with two tools.',
+        where: 'Add to ~/.codeium/windsurf/mcp_config.json:',
+    },
+    {
+        id: 'codex',
+        label: 'Codex',
+        snippet: origin => `codex mcp add solana-explorer --url ${origin}/mcp`,
+        verify: 'codex mcp list shows solana-explorer.',
+        where: 'Run in a terminal:',
+    },
+    {
+        id: 'vs-code',
+        label: 'VS Code',
+        snippet: origin => `${origin}/mcp`,
+        verify: 'The server appears under MCP: List Servers with two tools.',
+        where: 'Command Palette → MCP: Add Server → HTTP, then enter the URL:',
+    },
+];

--- a/app/features/mcp-docs/lib/setup-clients.ts
+++ b/app/features/mcp-docs/lib/setup-clients.ts
@@ -1,0 +1,90 @@
+/**
+ * Per-client setup instructions for the overview page. Snippets are functions
+ * of the deployment origin so the visitor copies a config that already points
+ * at the Explorer instance they are on.
+ */
+export type SetupClient = {
+    id: string;
+    label: string;
+    /** Where the snippet goes (command line, config file path, UI path). */
+    where: string;
+    snippet: (origin: string) => string;
+    verify: string;
+};
+
+function mcpJsonConfig(origin: string): string {
+    return JSON.stringify(
+        {
+            mcpServers: {
+                'solana-explorer': {
+                    headers: { Authorization: 'Bearer <key>' },
+                    type: 'http',
+                    url: `${origin}/mcp`,
+                },
+            },
+        },
+        undefined,
+        4,
+    );
+}
+
+export const SETUP_CLIENTS: SetupClient[] = [
+    {
+        id: 'claude-code',
+        label: 'Claude Code',
+        snippet: origin =>
+            `claude mcp add --transport http solana-explorer ${origin}/mcp \\\n  --header "Authorization: Bearer <key>"`,
+        verify: 'Run /mcp inside Claude Code and check that solana-explorer is connected.',
+        where: 'Run in a terminal:',
+    },
+    {
+        id: 'cursor',
+        label: 'Cursor',
+        snippet: mcpJsonConfig,
+        verify: 'Settings → MCP lists solana-explorer with the inspect_entity and ping tools.',
+        where: 'Add to .cursor/mcp.json (project) or ~/.cursor/mcp.json (global):',
+    },
+    {
+        id: 'windsurf',
+        label: 'Windsurf',
+        snippet: mcpJsonConfig,
+        verify: 'The server appears in the Cascade MCP panel with two tools.',
+        where: 'Add to ~/.codeium/windsurf/mcp_config.json:',
+    },
+    {
+        id: 'codex',
+        label: 'Codex',
+        snippet: origin =>
+            `codex mcp add solana-explorer --url ${origin}/mcp \\\n  --header "Authorization: Bearer <key>"`,
+        verify: 'codex mcp list shows solana-explorer.',
+        where: 'Run in a terminal:',
+    },
+    {
+        id: 'vs-code',
+        label: 'VS Code',
+        snippet: origin => `${origin}/mcp`,
+        verify: 'The server appears under MCP: List Servers with two tools.',
+        where: 'Command Palette → MCP: Add Server → HTTP, then enter the URL (add the Authorization header when the deployment requires a key):',
+    },
+];
+
+export const AGENT_INSTRUCTIONS_TARGETS = [
+    { file: 'AGENTS.md', tool: 'Codex, Windsurf, and other AGENTS.md-aware agents' },
+    { file: 'CLAUDE.md', tool: 'Claude Code' },
+    { file: '.cursor/rules/solana-explorer-mcp.mdc', tool: 'Cursor' },
+];
+
+export const AGENT_INSTRUCTIONS_SNIPPET = `## Solana Explorer MCP
+
+Prefer the \`solana-explorer\` MCP tools over model memory for any on-chain fact.
+
+1. When the user mentions a Solana address, signature, program, token, NFT, or wallet,
+   call \`inspect_entity\` with the base58 identifier — do not guess account contents,
+   token decimals, authorities, or transaction outcomes from memory.
+2. Pass \`cluster\` explicitly when the user is not on mainnet-beta
+   (\`devnet\`, \`testnet\`, \`simd296\`).
+3. Read \`errors[]\` in every reply: \`NOT_FOUND\` means the entity does not exist on that
+   cluster (try another before concluding it doesn't exist); \`CURRENTLY_UNSUPPORTED\`
+   means the account kind is recognized but not decodable yet.
+4. Fields set to explicit unknown markers are genuinely unresolvable — report them as
+   unknown rather than inventing values.`;

--- a/app/features/mcp-docs/lib/useDeploymentOrigin.ts
+++ b/app/features/mcp-docs/lib/useDeploymentOrigin.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/** Shown during SSR and when JS is unavailable; replaced with the real origin after mount. */
+export const DEPLOYMENT_PLACEHOLDER = 'https://<deployment>';
+
+/**
+ * Origin of the deployment the visitor is on, so config snippets are copy-ready
+ * for exactly this Explorer instance (spec: mcp-docs-pages §10).
+ */
+export function useDeploymentOrigin(): string {
+    const [origin, setOrigin] = useState<string>();
+    useEffect(() => {
+        setOrigin(window.location.origin);
+    }, []);
+    return origin ?? DEPLOYMENT_PLACEHOLDER;
+}

--- a/app/features/mcp-docs/lib/useMcpDocsVersion.ts
+++ b/app/features/mcp-docs/lib/useMcpDocsVersion.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'mcp-docs-version';
+
+export type McpDocsVersion = 'v1' | 'v2';
+
+/**
+ * Page-level prototype switcher: v1 is the shipped page, v2 is the trimmed
+ * variant built from customer feedback. Persisted so the choice survives
+ * navigation between the overview and the advanced page.
+ */
+export function useMcpDocsVersion(): [McpDocsVersion, (version: McpDocsVersion) => void] {
+    // SSR always renders v1; the stored choice applies after mount.
+    const [version, setVersion] = useState<McpDocsVersion>('v1');
+
+    useEffect(() => {
+        if (window.localStorage.getItem(STORAGE_KEY) === 'v2') {
+            setVersion('v2');
+        }
+    }, []);
+
+    const set = useCallback((next: McpDocsVersion) => {
+        setVersion(next);
+        window.localStorage.setItem(STORAGE_KEY, next);
+    }, []);
+
+    return [version, set];
+}

--- a/app/features/mcp-docs/lib/useMcpDocsVersion.ts
+++ b/app/features/mcp-docs/lib/useMcpDocsVersion.ts
@@ -2,28 +2,31 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-const STORAGE_KEY = 'mcp-docs-version';
-
 export type McpDocsVersion = 'v1' | 'v2';
 
 /**
- * Page-level prototype switcher: v1 is the shipped page, v2 is the trimmed
- * variant built from customer feedback. Persisted so the choice survives
- * navigation between the overview and the advanced page.
+ * V2 is the page everyone sees; the v1 prototype stays reachable only through
+ * the `#v1` hash (…/mcp/docs#v1). The hash is read once after mount — reading
+ * it on every hashchange would flip the version when in-page anchors like
+ * `#setup` are clicked. SSR always renders v2.
  */
 export function useMcpDocsVersion(): [McpDocsVersion, (version: McpDocsVersion) => void] {
-    // SSR always renders v1; the stored choice applies after mount.
-    const [version, setVersion] = useState<McpDocsVersion>('v1');
+    const [version, setVersion] = useState<McpDocsVersion>('v2');
 
     useEffect(() => {
-        if (window.localStorage.getItem(STORAGE_KEY) === 'v2') {
-            setVersion('v2');
+        if (window.location.hash === '#v1') {
+            setVersion('v1');
         }
     }, []);
 
     const set = useCallback((next: McpDocsVersion) => {
         setVersion(next);
-        window.localStorage.setItem(STORAGE_KEY, next);
+        // Keep the URL shareable: #v1 while on v1, no hash on v2.
+        if (next === 'v1') {
+            window.location.hash = 'v1';
+        } else {
+            window.history.replaceState(undefined, '', window.location.pathname + window.location.search);
+        }
     }, []);
 
     return [version, set];

--- a/app/features/mcp-docs/ui/CodeBlock.tsx
+++ b/app/features/mcp-docs/ui/CodeBlock.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Check, Copy, XCircle } from 'react-feather';
+
+import { cn } from '@/app/components/shared/utils';
+import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
+
+/**
+ * Multiline code snippet with a copy affordance (`Copyable` is inline-only, hence a dedicated block).
+ * `flush` drops the own border/rounding for use as a full-bleed segment inside a card.
+ */
+export function CodeBlock({
+    code,
+    className,
+    variant = 'panel',
+}: {
+    code: string;
+    className?: string;
+    variant?: 'panel' | 'flush';
+}) {
+    const [state, copy] = useCopyToClipboard(1000);
+
+    const icon = {
+        copied: <Check size={14} aria-hidden />,
+        copy: <Copy size={14} aria-hidden />,
+        errored: <XCircle size={14} aria-hidden />,
+    }[state];
+
+    return (
+        <div
+            className={cn(
+                'relative bg-heavy-metal-900',
+                variant === 'panel' && 'rounded-lg border border-solid border-white/10',
+                className,
+            )}
+        >
+            <button
+                type="button"
+                aria-label="Copy to clipboard"
+                onClick={() => copy(code)}
+                className={cn(
+                    'absolute right-2 top-2 cursor-pointer rounded border-0 bg-transparent p-1.5',
+                    'text-neutral-500 hover:bg-heavy-metal-800 hover:text-neutral-200',
+                    state === 'copied' && 'text-dark-accent hover:text-dark-accent',
+                    state === 'errored' && 'text-red-500 hover:text-red-500',
+                )}
+            >
+                {icon}
+            </button>
+            <pre
+                className={cn(
+                    'm-0 whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-xs leading-relaxed text-neutral-200',
+                    // Flush segments sit inside a p-6 card section — match its padding.
+                    variant === 'flush' ? 'p-4 pr-10 sm:p-6 sm:pr-10' : 'p-4 pr-10',
+                )}
+            >
+                {code}
+            </pre>
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/CodeBlock.tsx
+++ b/app/features/mcp-docs/ui/CodeBlock.tsx
@@ -39,7 +39,8 @@ export function CodeBlock({
                 aria-label="Copy to clipboard"
                 onClick={() => copy(code)}
                 className={cn(
-                    'absolute right-2 top-2 cursor-pointer rounded border-0 bg-transparent p-1.5',
+                    // `flex` collapses the svg's inline line box, keeping the button square.
+                    'absolute right-3 top-3 flex cursor-pointer rounded border-0 bg-transparent p-1.5',
                     'text-neutral-500 hover:bg-heavy-metal-800 hover:text-neutral-200',
                     state === 'copied' && 'text-dark-accent hover:text-dark-accent',
                     state === 'errored' && 'text-red-500 hover:text-red-500',

--- a/app/features/mcp-docs/ui/CodeBlock.tsx
+++ b/app/features/mcp-docs/ui/CodeBlock.tsx
@@ -49,7 +49,7 @@ export function CodeBlock({
             </button>
             <pre
                 className={cn(
-                    'm-0 whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-xs leading-relaxed text-neutral-200',
+                    'm-0 whitespace-pre-wrap font-mono text-xs leading-relaxed text-neutral-200 [overflow-wrap:anywhere]',
                     // Flush segments sit inside a p-6 card section — match its padding.
                     variant === 'flush' ? 'p-4 pr-10 sm:p-6 sm:pr-10' : 'p-4 pr-10',
                 )}

--- a/app/features/mcp-docs/ui/CopyableEndpoint.tsx
+++ b/app/features/mcp-docs/ui/CopyableEndpoint.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Check, Copy, XCircle } from 'react-feather';
+
+import { cn } from '@/app/components/shared/utils';
+import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
+
+/** Endpoint URL as a link with an inline copy affordance, for the hero fact grid. */
+export function CopyableEndpoint({ url }: { url: string }) {
+    const [state, copy] = useCopyToClipboard(1000);
+
+    const icon = {
+        copied: <Check size={12} aria-hidden />,
+        copy: <Copy size={12} aria-hidden />,
+        errored: <XCircle size={12} aria-hidden />,
+    }[state];
+
+    // Inline flow (no flex wrapper): the link shares the fact's text-sm line box, so its
+    // baseline matches the neighbouring facts; the fixed 20px button never grows the line.
+    return (
+        <>
+            <a
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-xs text-dark-accent no-underline hover:underline"
+            >
+                {url}
+            </a>
+            <button
+                type="button"
+                aria-label="Copy endpoint to clipboard"
+                onClick={() => copy(url)}
+                className={cn(
+                    'ml-1 inline-flex size-5 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 align-top',
+                    'text-neutral-500 hover:bg-heavy-metal-800 hover:text-neutral-200',
+                    state === 'copied' && 'text-dark-accent hover:text-dark-accent',
+                    state === 'errored' && 'text-red-500 hover:text-red-500',
+                )}
+            >
+                {icon}
+            </button>
+        </>
+    );
+}

--- a/app/features/mcp-docs/ui/DocCard.tsx
+++ b/app/features/mcp-docs/ui/DocCard.tsx
@@ -8,13 +8,13 @@ import { cn } from '@/app/components/shared/utils';
  * of a className override because `cn` keeps conflicting classes (no
  * tailwind-merge) and stylesheet order would decide the border color.
  */
-export function DocCard({
-    className,
-    transparent,
-    ...props
-}: React.HTMLAttributes<HTMLDivElement> & { transparent?: boolean }) {
+export const DocCard = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & { transparent?: boolean }
+>(function DocCard({ className, transparent, ...props }, ref) {
     return (
         <div
+            ref={ref}
             className={cn(
                 'rounded-xl border border-solid border-white/10 text-neutral-200',
                 // Prop instead of a `bg-*` className override: cn keeps conflicting classes.
@@ -24,4 +24,4 @@ export function DocCard({
             {...props}
         />
     );
-}
+});

--- a/app/features/mcp-docs/ui/DocCard.tsx
+++ b/app/features/mcp-docs/ui/DocCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { cn } from '@/app/components/shared/utils';
+
+/**
+ * Card shell for the MCP docs pages: BaseCard's tw look but with the light
+ * `border-white/10` outline used by the block page. A local component instead
+ * of a className override because `cn` keeps conflicting classes (no
+ * tailwind-merge) and stylesheet order would decide the border color.
+ */
+export function DocCard({
+    className,
+    transparent,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement> & { transparent?: boolean }) {
+    return (
+        <div
+            className={cn(
+                'rounded-xl border border-solid border-white/10 text-neutral-200',
+                // Prop instead of a `bg-*` className override: cn keeps conflicting classes.
+                !transparent && 'bg-heavy-metal-800',
+                className,
+            )}
+            {...props}
+        />
+    );
+}

--- a/app/features/mcp-docs/ui/DocSection.tsx
+++ b/app/features/mcp-docs/ui/DocSection.tsx
@@ -1,0 +1,48 @@
+import React, { ReactNode } from 'react';
+import { Link as LinkIcon } from 'react-feather';
+
+import { cn } from '@/app/components/shared/utils';
+
+/**
+ * Anchor-addressable documentation section: the heading carries the id the
+ * overview catalog links to, plus a hover anchor link for sharing.
+ */
+export function DocSection({
+    anchor,
+    title,
+    children,
+    hidden,
+    kicker,
+}: {
+    anchor: string;
+    title: string;
+    children: ReactNode;
+    hidden?: boolean;
+    kicker?: string;
+}) {
+    return (
+        <section id={anchor} hidden={hidden} className="scroll-mt-6">
+            {kicker && <div className="mb-2 text-xs uppercase tracking-wide text-neutral-500">{kicker}</div>}
+            <h2 className="group mb-5 mt-0 flex items-center gap-2 text-2xl font-semibold text-white">
+                {title}
+                <a
+                    href={`#${anchor}`}
+                    aria-label={`Link to ${title}`}
+                    className="text-neutral-600 no-underline opacity-0 hover:text-neutral-300 group-hover:opacity-100"
+                >
+                    <LinkIcon size={14} aria-hidden />
+                </a>
+            </h2>
+            <div className="flex flex-col gap-4 text-sm leading-relaxed text-neutral-300">{children}</div>
+        </section>
+    );
+}
+
+/** Inline code token styled for dark cards. */
+export function InlineCode({ children, className }: { children: ReactNode; className?: string }) {
+    return (
+        <code className={cn('rounded bg-heavy-metal-900 px-1.5 py-0.5 font-mono text-xs text-neutral-200 [overflow-wrap:anywhere]', className)}>
+            {children}
+        </code>
+    );
+}

--- a/app/features/mcp-docs/ui/DocSection.tsx
+++ b/app/features/mcp-docs/ui/DocSection.tsx
@@ -41,7 +41,12 @@ export function DocSection({
 /** Inline code token styled for dark cards. */
 export function InlineCode({ children, className }: { children: ReactNode; className?: string }) {
     return (
-        <code className={cn('rounded bg-heavy-metal-900 px-1.5 py-0.5 font-mono text-xs text-neutral-200 [overflow-wrap:anywhere]', className)}>
+        <code
+            className={cn(
+                'rounded bg-heavy-metal-900 px-1.5 py-0.5 font-mono text-xs text-neutral-200 [overflow-wrap:anywhere]',
+                className,
+            )}
+        >
             {children}
         </code>
     );

--- a/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
@@ -48,7 +48,7 @@ export function McpDocsAdvancedView() {
             <div className="flex flex-col gap-8 sm:flex-row">
                 <nav
                     aria-label="Sections"
-                    className="shrink-0 self-start rounded-xl border border-solid border-white/10 p-2 sm:sticky sm:top-6 sm:w-60"
+                    className="shrink-0 self-start rounded-xl border border-solid border-white/10 p-2 sm:sticky sm:top-6"
                 >
                     <Link
                         href={overviewPath}
@@ -67,7 +67,7 @@ export function McpDocsAdvancedView() {
                                     type="button"
                                     onClick={() => select(chunk.anchor)}
                                     className={cn(
-                                        'cursor-pointer rounded border-0 px-3 py-2 text-left text-sm transition-colors',
+                                        'cursor-pointer rounded border-0 px-3 py-2 text-left text-sm transition-colors sm:whitespace-nowrap',
                                         isActive
                                             ? 'bg-heavy-metal-900 text-white'
                                             : 'bg-transparent text-neutral-400 hover:bg-heavy-metal-900 hover:text-neutral-200',

--- a/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
@@ -51,7 +51,8 @@ export function McpDocsAdvancedView() {
                     className="shrink-0 self-start rounded-xl border border-solid border-white/10 p-2 sm:sticky sm:top-6"
                 >
                     <Link
-                        href={overviewPath}
+                        // The advanced reference belongs to the v1 prototype — return to the v1 overview.
+                        href={`${overviewPath}#v1`}
                         className="flex items-center gap-2 rounded px-3 py-2 text-sm text-neutral-400 no-underline hover:bg-heavy-metal-900 hover:text-white"
                     >
                         <ArrowLeft size={14} aria-hidden />

--- a/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
@@ -81,431 +81,479 @@ export function McpDocsAdvancedView() {
                 </nav>
 
                 <div className="flex min-w-0 grow flex-col gap-12">
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'access-control'} anchor="access-control" title="Enabling & access control">
-                    <p className="m-0">
-                        The <InlineCode>/mcp</InlineCode> endpoint is inert by default — every request gets{' '}
-                        <InlineCode>503</InlineCode> until the deployment explicitly enables it. All configuration is
-                        environment-only (see <InlineCode>.env.example</InlineCode>); keys and the blocklist are parsed
-                        once at module scope, so changes require a redeploy.
-                    </p>
-                    <DocTable
-                        head={['Variable', 'Purpose', 'Why it exists']}
-                        rows={[
-                            [
-                                <InlineCode key="v">MCP_ENDPOINT_ENABLED</InlineCode>,
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'access-control'}
+                        anchor="access-control"
+                        title="Enabling & access control"
+                    >
+                        <p className="m-0">
+                            The <InlineCode>/mcp</InlineCode> endpoint is inert by default — every request gets{' '}
+                            <InlineCode>503</InlineCode> until the deployment explicitly enables it. All configuration
+                            is environment-only (see <InlineCode>.env.example</InlineCode>); keys and the blocklist are
+                            parsed once at module scope, so changes require a redeploy.
+                        </p>
+                        <DocTable
+                            head={['Variable', 'Purpose', 'Why it exists']}
+                            rows={[
+                                [
+                                    <InlineCode key="v">MCP_ENDPOINT_ENABLED</InlineCode>,
+                                    <>
+                                        <InlineCode>true</InlineCode> enables the endpoint; anything else keeps it
+                                        returning <InlineCode>503</InlineCode>.
+                                    </>,
+                                    'Opt-in by design: an Explorer deployment should not silently expose an agent-facing API (and its RPC spend) just because the code ships with it.',
+                                ],
+                                [
+                                    <InlineCode key="v">MCP_ACCESS_KEYS</InlineCode>,
+                                    <>
+                                        Comma-separated bearer keys; requests need{' '}
+                                        <InlineCode>Authorization: Bearer &lt;key&gt;</InlineCode>.
+                                    </>,
+                                    'Gates who can consume your RPC quota. Comparison is constant-time. Unset = deliberate open access, logged as a warning at startup. Multiple keys let you hand one per consumer and revoke individually.',
+                                ],
+                                [
+                                    <InlineCode key="v">MCP_BLOCKED_IPS</InlineCode>,
+                                    <>
+                                        Comma-separated client IPs rejected with <InlineCode>403</InlineCode>.
+                                    </>,
+                                    'Emergency brake against an abusive client without rotating keys for everyone — useful precisely when running open access.',
+                                ],
+                            ]}
+                        />
+                        <p className="m-0">
+                            On Vercel: add the variables in Project Settings → Environment Variables, then redeploy.
+                        </p>
+                        <SubTitle>Route behavior worth knowing</SubTitle>
+                        <NumberedList
+                            items={[
                                 <>
-                                    <InlineCode>true</InlineCode> enables the endpoint; anything else keeps it
-                                    returning <InlineCode>503</InlineCode>.
+                                    <Strong>Stateless by construction</Strong> — a fresh MCP server per request, so the
+                                    endpoint is serverless-safe: no session affinity, no state to lose between
+                                    invocations.
                                 </>,
-                                'Opt-in by design: an Explorer deployment should not silently expose an agent-facing API (and its RPC spend) just because the code ships with it.',
-                            ],
-                            [
-                                <InlineCode key="v">MCP_ACCESS_KEYS</InlineCode>,
                                 <>
-                                    Comma-separated bearer keys; requests need{' '}
-                                    <InlineCode>Authorization: Bearer &lt;key&gt;</InlineCode>.
+                                    <Strong>
+                                        <InlineCode>/mcp</InlineCode>, not <InlineCode>/api/mcp</InlineCode>
+                                    </Strong>{' '}
+                                    — placed outside <InlineCode>/api/*</InlineCode> to escape the BotID proxy matcher,
+                                    which would otherwise challenge non-browser MCP clients.
                                 </>,
-                                'Gates who can consume your RPC quota. Comparison is constant-time. Unset = deliberate open access, logged as a warning at startup. Multiple keys let you hand one per consumer and revoke individually.',
-                            ],
-                            [
-                                <InlineCode key="v">MCP_BLOCKED_IPS</InlineCode>,
                                 <>
-                                    Comma-separated client IPs rejected with <InlineCode>403</InlineCode>.
+                                    <Strong>Full CORS</Strong> (<InlineCode>GET</InlineCode>/
+                                    <InlineCode>POST</InlineCode>/<InlineCode>DELETE</InlineCode>/
+                                    <InlineCode>OPTIONS</InlineCode>; MCP session and protocol headers exposed) —
+                                    browser-based agents work, and even error responses stay CORS-consistent so clients
+                                    see the real status instead of an opaque network failure.
                                 </>,
-                                'Emergency brake against an abusive client without rotating keys for everyone — useful precisely when running open access.',
-                            ],
-                        ]}
-                    />
-                    <p className="m-0">
-                        On Vercel: add the variables in Project Settings → Environment Variables, then redeploy.
-                    </p>
-                    <SubTitle>Route behavior worth knowing</SubTitle>
-                    <NumberedList
-                        items={[
-                            <>
-                                <Strong>Stateless by construction</Strong> — a fresh MCP server per request, so the
-                                endpoint is serverless-safe: no session affinity, no state to lose between invocations.
-                            </>,
-                            <>
-                                <Strong>
-                                    <InlineCode>/mcp</InlineCode>, not <InlineCode>/api/mcp</InlineCode>
-                                </Strong>{' '}
-                                — placed outside <InlineCode>/api/*</InlineCode> to escape the BotID proxy matcher,
-                                which would otherwise challenge non-browser MCP clients.
-                            </>,
-                            <>
-                                <Strong>Full CORS</Strong> (<InlineCode>GET</InlineCode>/<InlineCode>POST</InlineCode>/
-                                <InlineCode>DELETE</InlineCode>/<InlineCode>OPTIONS</InlineCode>; MCP session and
-                                protocol headers exposed) — browser-based agents work, and even error responses stay
-                                CORS-consistent so clients see the real status instead of an opaque network failure.
-                            </>,
-                            <>
-                                <Strong>
-                                    <InlineCode>maxDuration = 60</InlineCode>
-                                </Strong>{' '}
-                                applies to this route only — deep inspections (lookup-table resolution + IDL decode)
-                                need more than the default function budget, without raising it app-wide.
-                            </>,
-                            <>
-                                <Strong>Lazy loading</Strong> — the MCP package is imported on first request, so a
-                                disabled endpoint adds nothing to the serverless bundle; a failed import is not cached,
-                                so a transient error does not stick until redeploy.
-                            </>,
-                            <>
-                                <Strong>
-                                    <InlineCode>server-only</InlineCode> lock
-                                </Strong>{' '}
-                                — the config module reads key-bearing RPC URLs and fails the build if ever pulled into
-                                a client bundle. URLs resolve at cold start from runtime env, never into a build
-                                artifact.
-                            </>,
-                        ]}
-                    />
-                </DocSection>
+                                <>
+                                    <Strong>
+                                        <InlineCode>maxDuration = 60</InlineCode>
+                                    </Strong>{' '}
+                                    applies to this route only — deep inspections (lookup-table resolution + IDL decode)
+                                    need more than the default function budget, without raising it app-wide.
+                                </>,
+                                <>
+                                    <Strong>Lazy loading</Strong> — the MCP package is imported on first request, so a
+                                    disabled endpoint adds nothing to the serverless bundle; a failed import is not
+                                    cached, so a transient error does not stick until redeploy.
+                                </>,
+                                <>
+                                    <Strong>
+                                        <InlineCode>server-only</InlineCode> lock
+                                    </Strong>{' '}
+                                    — the config module reads key-bearing RPC URLs and fails the build if ever pulled
+                                    into a client bundle. URLs resolve at cold start from runtime env, never into a
+                                    build artifact.
+                                </>,
+                            ]}
+                        />
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'rpc-configuration'} anchor="rpc-configuration" title="RPC configuration">
-                    <DocTable
-                        head={['Variable', 'Purpose']}
-                        rows={[
-                            [
-                                <InlineCode key="v">
-                                    MCP_SOLANA_RPC_URL_MAINNET_BETA / _DEVNET / _TESTNET / _SIMD296
-                                </InlineCode>,
-                                'Dedicated RPC endpoint per cluster for MCP traffic.',
-                            ],
-                        ]}
-                    />
-                    <p className="m-0">
-                        <Strong>Why:</Strong> agents are chatty — a single <InlineCode>inspect_entity</InlineCode> call
-                        on a transaction can fan out into lookup-table fetches, IDL discovery, and DAS calls. Dedicated
-                        endpoints keep that traffic off the quota that serves the Explorer UI, and let you rate-limit
-                        or bill agent usage separately.
-                    </p>
-                    <p className="m-0">
-                        <Strong>Fallback:</Strong> unset variables fall back to the app&apos;s own server RPC config (
-                        <InlineCode>*_RPC_URL</InlineCode> env → proxied default) — never to a raw public endpoint, so
-                        the MCP path inherits whatever keys and proxying the app already uses.
-                    </p>
-                </DocSection>
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'rpc-configuration'}
+                        anchor="rpc-configuration"
+                        title="RPC configuration"
+                    >
+                        <DocTable
+                            head={['Variable', 'Purpose']}
+                            rows={[
+                                [
+                                    <InlineCode key="v">
+                                        MCP_SOLANA_RPC_URL_MAINNET_BETA / _DEVNET / _TESTNET / _SIMD296
+                                    </InlineCode>,
+                                    'Dedicated RPC endpoint per cluster for MCP traffic.',
+                                ],
+                            ]}
+                        />
+                        <p className="m-0">
+                            <Strong>Why:</Strong> agents are chatty — a single <InlineCode>inspect_entity</InlineCode>{' '}
+                            call on a transaction can fan out into lookup-table fetches, IDL discovery, and DAS calls.
+                            Dedicated endpoints keep that traffic off the quota that serves the Explorer UI, and let you
+                            rate-limit or bill agent usage separately.
+                        </p>
+                        <p className="m-0">
+                            <Strong>Fallback:</Strong> unset variables fall back to the app&apos;s own server RPC config
+                            (<InlineCode>*_RPC_URL</InlineCode> env → proxied default) — never to a raw public endpoint,
+                            so the MCP path inherits whatever keys and proxying the app already uses.
+                        </p>
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'preview-deployments'} anchor="preview-deployments" title="Preview deployments (Vercel)">
-                    <p className="m-0">
-                        Previews sit behind Deployment Protection, so clients must present the{' '}
-                        <a
-                            href="https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-dark-accent no-underline hover:underline"
-                        >
-                            Protection Bypass for Automation
-                        </a>{' '}
-                        secret in addition to the endpoint&apos;s own Bearer auth:
-                    </p>
-                    <NumberedList
-                        items={[
-                            <>
-                                Generate the secret in Project Settings → Deployment Protection → Protection Bypass for
-                                Automation.
-                            </>,
-                            <>
-                                Send it as the <InlineCode>x-vercel-protection-bypass</InlineCode> header, or{' '}
-                                <InlineCode>?x-vercel-protection-bypass=&lt;secret&gt;</InlineCode> for clients that
-                                cannot set headers.
-                            </>,
-                        ]}
-                    />
-                    <CodeBlock
-                        code={JSON.stringify(
-                            {
-                                mcpServers: {
-                                    'solana-explorer': {
-                                        headers: {
-                                            Authorization: 'Bearer <key>',
-                                            'x-vercel-protection-bypass': '<secret>',
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'preview-deployments'}
+                        anchor="preview-deployments"
+                        title="Preview deployments (Vercel)"
+                    >
+                        <p className="m-0">
+                            Previews sit behind Deployment Protection, so clients must present the{' '}
+                            <a
+                                href="https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-dark-accent no-underline hover:underline"
+                            >
+                                Protection Bypass for Automation
+                            </a>{' '}
+                            secret in addition to the endpoint&apos;s own Bearer auth:
+                        </p>
+                        <NumberedList
+                            items={[
+                                <>
+                                    Generate the secret in Project Settings → Deployment Protection → Protection Bypass
+                                    for Automation.
+                                </>,
+                                <>
+                                    Send it as the <InlineCode>x-vercel-protection-bypass</InlineCode> header, or{' '}
+                                    <InlineCode>?x-vercel-protection-bypass=&lt;secret&gt;</InlineCode> for clients that
+                                    cannot set headers.
+                                </>,
+                            ]}
+                        />
+                        <CodeBlock
+                            code={JSON.stringify(
+                                {
+                                    mcpServers: {
+                                        'solana-explorer': {
+                                            headers: {
+                                                Authorization: 'Bearer <key>',
+                                                'x-vercel-protection-bypass': '<secret>',
+                                            },
+                                            type: 'http',
+                                            url: '<preview-deployment>/mcp',
                                         },
-                                        type: 'http',
-                                        url: '<preview-deployment>/mcp',
                                     },
                                 },
-                            },
-                            undefined,
-                            4,
-                        )}
-                    />
-                    <p className="m-0">
-                        <Strong>Why two layers:</Strong> the bypass gets you through Vercel&apos;s platform gate (which
-                        knows nothing about MCP); the Bearer key is the endpoint&apos;s own auth. Omit the bypass
-                        header outside previews.
-                    </p>
-                </DocSection>
+                                undefined,
+                                4,
+                            )}
+                        />
+                        <p className="m-0">
+                            <Strong>Why two layers:</Strong> the bypass gets you through Vercel&apos;s platform gate
+                            (which knows nothing about MCP); the Bearer key is the endpoint&apos;s own auth. Omit the
+                            bypass header outside previews.
+                        </p>
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'inspect-entity'} anchor="inspect-entity" title="inspect_entity reference">
-                    <p className="m-0">Read-only and idempotent (annotated as such, so agents may retry freely).</p>
-                    <SubTitle>Input</SubTitle>
-                    <DocTable
-                        head={['Field', 'Type', 'Notes']}
-                        rows={[
-                            [
-                                <InlineCode key="f">identifier</InlineCode>,
-                                'string (1–128 chars, base58)',
-                                'Account address (32-byte) or transaction signature (64-byte) — the tool detects which type was provided.',
-                            ],
-                            [
-                                <InlineCode key="f">cluster</InlineCode>,
-                                'mainnet-beta | devnet | testnet | simd296',
-                                'Optional; defaults to mainnet-beta.',
-                            ],
-                        ]}
-                    />
-                    <SubTitle>
-                        Account kinds (<InlineCode>entity.kind</InlineCode>)
-                    </SubTitle>
-                    <DocTable
-                        head={['Kind', 'Payload']}
-                        rows={[
-                            [
-                                <InlineCode key="k">spl-token[-2022]:mint</InlineCode>,
-                                'Address, supply, decimals, mint/freeze authorities, supply type (fixed/variable), token program. Token-2022 mints also include parsed extensions.',
-                            ],
-                            [<InlineCode key="k">spl-token[-2022]:account</InlineCode>, 'Mint, owner, token program.'],
-                            [
-                                <InlineCode key="k">spl-token[-2022]:multisig</InlineCode>,
-                                'Signers, threshold, initialization status.',
-                            ],
-                            [
-                                <InlineCode key="k">compressed-nft</InlineCode>,
-                                'Asset ID, owner, merkle tree (classified via DAS).',
-                            ],
-                            [
-                                <span key="k" className="font-mono text-xs">
-                                    stake, vote, nonce, sysvar, config, address-lookup-table, feature, nftoken,
-                                    solana-attestation-service
-                                </span>,
-                                'Recognized system account types.',
-                            ],
-                            [<InlineCode key="k">native-program</InlineCode>, 'Built-in native programs.'],
-                            [
-                                <InlineCode key="k">bpf-upgradeable-loader</InlineCode>,
-                                'Upgradeable programs — address, label, balance, executable-data account, upgradeability, last deploy slot, upgrade authority, plus an idl enrichment (status, idl_type, source, program name).',
-                            ],
-                            [
-                                <InlineCode key="k">bpf-loader / bpf-loader-2 / loader-v4</InlineCode>,
-                                'Legacy-loader programs — currently unsupported; return a CURRENTLY_UNSUPPORTED error.',
-                            ],
-                            [
-                                <InlineCode key="k">unknown</InlineCode>,
-                                'Unrecognized account type. When the owner program publishes an IDL, the account data is decoded through it and returned as decoded (source "idl").',
-                            ],
-                            [<InlineCode key="k">transaction</InlineCode>, 'See below.'],
-                        ]}
-                    />
-                    <SubTitle>Transactions</SubTitle>
-                    <p className="m-0">
-                        64-byte signatures return <InlineCode>entity.kind: &quot;transaction&quot;</InlineCode> — slot,
-                        block time, fee, status, error, signers, accounts (v0 lookup-table addresses attributed via{' '}
-                        <InlineCode>source</InlineCode>/<InlineCode>lookupTableAddress</InlineCode>), and instructions
-                        with inner instructions. Instructions decode through a cascade — each step exists because the
-                        previous one cannot cover everything:
-                    </p>
-                    <NumberedList
-                        items={[
-                            <>
-                                <Strong>
-                                    <InlineCode>idl</InlineCode>
-                                </Strong>{' '}
-                                — programs publishing an on-chain IDL are decoded through it: always current, no
-                                Explorer release needed when the program upgrades.
-                            </>,
-                            <>
-                                <Strong>
-                                    <InlineCode>bundled</InlineCode>
-                                </Strong>{' '}
-                                — token batch and host-app-supported programs decode through the Explorer&apos;s own
-                                instruction-parser dispatcher: covers major programs that publish no IDL.
-                            </>,
-                            <>
-                                <Strong>
-                                    <InlineCode>raw</InlineCode>
-                                </Strong>{' '}
-                                — everything else stays base58, clearly labeled, so the agent knows the data is
-                                undecoded rather than empty.
-                            </>,
-                        ]}
-                    />
-                    <p className="m-0">
-                        <Strong>Program labels:</Strong> program addresses resolve to human-readable names through the
-                        Explorer&apos;s program registry, with a built-in fallback label map when the host registry
-                        misses — so agents see &quot;Jupiter Aggregator v6&quot; rather than a bare address.
-                    </p>
-                </DocSection>
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'inspect-entity'}
+                        anchor="inspect-entity"
+                        title="inspect_entity reference"
+                    >
+                        <p className="m-0">Read-only and idempotent (annotated as such, so agents may retry freely).</p>
+                        <SubTitle>Input</SubTitle>
+                        <DocTable
+                            head={['Field', 'Type', 'Notes']}
+                            rows={[
+                                [
+                                    <InlineCode key="f">identifier</InlineCode>,
+                                    'string (1–128 chars, base58)',
+                                    'Account address (32-byte) or transaction signature (64-byte) — the tool detects which type was provided.',
+                                ],
+                                [
+                                    <InlineCode key="f">cluster</InlineCode>,
+                                    'mainnet-beta | devnet | testnet | simd296',
+                                    'Optional; defaults to mainnet-beta.',
+                                ],
+                            ]}
+                        />
+                        <SubTitle>
+                            Account kinds (<InlineCode>entity.kind</InlineCode>)
+                        </SubTitle>
+                        <DocTable
+                            head={['Kind', 'Payload']}
+                            rows={[
+                                [
+                                    <InlineCode key="k">spl-token[-2022]:mint</InlineCode>,
+                                    'Address, supply, decimals, mint/freeze authorities, supply type (fixed/variable), token program. Token-2022 mints also include parsed extensions.',
+                                ],
+                                [
+                                    <InlineCode key="k">spl-token[-2022]:account</InlineCode>,
+                                    'Mint, owner, token program.',
+                                ],
+                                [
+                                    <InlineCode key="k">spl-token[-2022]:multisig</InlineCode>,
+                                    'Signers, threshold, initialization status.',
+                                ],
+                                [
+                                    <InlineCode key="k">compressed-nft</InlineCode>,
+                                    'Asset ID, owner, merkle tree (classified via DAS).',
+                                ],
+                                [
+                                    <span key="k" className="font-mono text-xs">
+                                        stake, vote, nonce, sysvar, config, address-lookup-table, feature, nftoken,
+                                        solana-attestation-service
+                                    </span>,
+                                    'Recognized system account types.',
+                                ],
+                                [<InlineCode key="k">native-program</InlineCode>, 'Built-in native programs.'],
+                                [
+                                    <InlineCode key="k">bpf-upgradeable-loader</InlineCode>,
+                                    'Upgradeable programs — address, label, balance, executable-data account, upgradeability, last deploy slot, upgrade authority, plus an idl enrichment (status, idl_type, source, program name).',
+                                ],
+                                [
+                                    <InlineCode key="k">bpf-loader / bpf-loader-2 / loader-v4</InlineCode>,
+                                    'Legacy-loader programs — currently unsupported; return a CURRENTLY_UNSUPPORTED error.',
+                                ],
+                                [
+                                    <InlineCode key="k">unknown</InlineCode>,
+                                    'Unrecognized account type. When the owner program publishes an IDL, the account data is decoded through it and returned as decoded (source "idl").',
+                                ],
+                                [<InlineCode key="k">transaction</InlineCode>, 'See below.'],
+                            ]}
+                        />
+                        <SubTitle>Transactions</SubTitle>
+                        <p className="m-0">
+                            64-byte signatures return <InlineCode>entity.kind: &quot;transaction&quot;</InlineCode> —
+                            slot, block time, fee, status, error, signers, accounts (v0 lookup-table addresses
+                            attributed via <InlineCode>source</InlineCode>/<InlineCode>lookupTableAddress</InlineCode>),
+                            and instructions with inner instructions. Instructions decode through a cascade — each step
+                            exists because the previous one cannot cover everything:
+                        </p>
+                        <NumberedList
+                            items={[
+                                <>
+                                    <Strong>
+                                        <InlineCode>idl</InlineCode>
+                                    </Strong>{' '}
+                                    — programs publishing an on-chain IDL are decoded through it: always current, no
+                                    Explorer release needed when the program upgrades.
+                                </>,
+                                <>
+                                    <Strong>
+                                        <InlineCode>bundled</InlineCode>
+                                    </Strong>{' '}
+                                    — token batch and host-app-supported programs decode through the Explorer&apos;s own
+                                    instruction-parser dispatcher: covers major programs that publish no IDL.
+                                </>,
+                                <>
+                                    <Strong>
+                                        <InlineCode>raw</InlineCode>
+                                    </Strong>{' '}
+                                    — everything else stays base58, clearly labeled, so the agent knows the data is
+                                    undecoded rather than empty.
+                                </>,
+                            ]}
+                        />
+                        <p className="m-0">
+                            <Strong>Program labels:</Strong> program addresses resolve to human-readable names through
+                            the Explorer&apos;s program registry, with a built-in fallback label map when the host
+                            registry misses — so agents see &quot;Jupiter Aggregator v6&quot; rather than a bare
+                            address.
+                        </p>
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'output-format'} anchor="output-format" title="Output envelope & errors">
-                    <p className="m-0">
-                        Every tool reply carries the same envelope, both as <InlineCode>text</InlineCode> and{' '}
-                        <InlineCode>structuredContent</InlineCode> (identical, JSON-round-tripped values — clients can
-                        consume either):
-                    </p>
-                    <CodeBlock
-                        code={`{\n    "payload": { "entity": { "kind": "...", "...": "..." } },\n    "errors": []\n}`}
-                    />
-                    <NumberedList
-                        items={[
-                            <>
-                                <Strong>Explicit unknown markers</Strong> instead of omitted fields — an agent can
-                                distinguish &quot;not applicable&quot; from &quot;could not resolve&quot;, which
-                                prevents hallucinated fill-ins.
-                            </>,
-                            <>
-                                <Strong>BigInt coercion</Strong> — large numerics are coerced to Number when safe,
-                                String otherwise, so the payload is always plain JSON.
-                            </>,
-                            <>
-                                <Strong>
-                                    Key order <InlineCode>{'{ payload, errors }'}</InlineCode> is part of the wire
-                                    format
-                                </Strong>{' '}
-                                (kept in parity with the standalone explorer-mcp).
-                            </>,
-                        ]}
-                    />
-                    <SubTitle>Error codes</SubTitle>
-                    <p className="m-0">
-                        <InlineCode>errors[].code</InlineCode>; <InlineCode>isError: true</InlineCode> when the list is
-                        non-empty:
-                    </p>
-                    <DocTable
-                        head={['Code', 'Meaning', 'Why a dedicated code']}
-                        rows={[
-                            [
-                                <InlineCode key="c">INVALID_ARGUMENT</InlineCode>,
-                                'Malformed input; includes flattened field-level schema details.',
-                                'Lets the agent fix its call instead of retrying blindly.',
-                            ],
-                            [
-                                <InlineCode key="c">NOT_FOUND</InlineCode>,
-                                'The entity does not exist on the selected cluster.',
-                                'Distinguishes "wrong cluster / typo" from a server failure — the agent can try another cluster.',
-                            ],
-                            [
-                                <InlineCode key="c">CURRENTLY_UNSUPPORTED</InlineCode>,
-                                'Recognized but not-yet-supported entity (e.g. legacy loaders).',
-                                'Honest "we know what this is but cannot decode it yet" — no point retrying.',
-                            ],
-                            [
-                                <InlineCode key="c">INTERNAL_ERROR</InlineCode>,
-                                'Sanitized internal failure.',
-                                'Details are stripped so stack traces and RPC URLs never leak to clients; full context goes to Sentry instead.',
-                            ],
-                        ]}
-                    />
-                    <p className="m-0">
-                        Some failures are non-fatal: e.g. a signature-status outage surfaces as an error entry
-                        alongside a usable payload — partial data beats no data for an agent.
-                    </p>
-                </DocSection>
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'output-format'}
+                        anchor="output-format"
+                        title="Output envelope & errors"
+                    >
+                        <p className="m-0">
+                            Every tool reply carries the same envelope, both as <InlineCode>text</InlineCode> and{' '}
+                            <InlineCode>structuredContent</InlineCode> (identical, JSON-round-tripped values — clients
+                            can consume either):
+                        </p>
+                        <CodeBlock
+                            code={`{\n    "payload": { "entity": { "kind": "...", "...": "..." } },\n    "errors": []\n}`}
+                        />
+                        <NumberedList
+                            items={[
+                                <>
+                                    <Strong>Explicit unknown markers</Strong> instead of omitted fields — an agent can
+                                    distinguish &quot;not applicable&quot; from &quot;could not resolve&quot;, which
+                                    prevents hallucinated fill-ins.
+                                </>,
+                                <>
+                                    <Strong>BigInt coercion</Strong> — large numerics are coerced to Number when safe,
+                                    String otherwise, so the payload is always plain JSON.
+                                </>,
+                                <>
+                                    <Strong>
+                                        Key order <InlineCode>{'{ payload, errors }'}</InlineCode> is part of the wire
+                                        format
+                                    </Strong>{' '}
+                                    (kept in parity with the standalone explorer-mcp).
+                                </>,
+                            ]}
+                        />
+                        <SubTitle>Error codes</SubTitle>
+                        <p className="m-0">
+                            <InlineCode>errors[].code</InlineCode>; <InlineCode>isError: true</InlineCode> when the list
+                            is non-empty:
+                        </p>
+                        <DocTable
+                            head={['Code', 'Meaning', 'Why a dedicated code']}
+                            rows={[
+                                [
+                                    <InlineCode key="c">INVALID_ARGUMENT</InlineCode>,
+                                    'Malformed input; includes flattened field-level schema details.',
+                                    'Lets the agent fix its call instead of retrying blindly.',
+                                ],
+                                [
+                                    <InlineCode key="c">NOT_FOUND</InlineCode>,
+                                    'The entity does not exist on the selected cluster.',
+                                    'Distinguishes "wrong cluster / typo" from a server failure — the agent can try another cluster.',
+                                ],
+                                [
+                                    <InlineCode key="c">CURRENTLY_UNSUPPORTED</InlineCode>,
+                                    'Recognized but not-yet-supported entity (e.g. legacy loaders).',
+                                    'Honest "we know what this is but cannot decode it yet" — no point retrying.',
+                                ],
+                                [
+                                    <InlineCode key="c">INTERNAL_ERROR</InlineCode>,
+                                    'Sanitized internal failure.',
+                                    'Details are stripped so stack traces and RPC URLs never leak to clients; full context goes to Sentry instead.',
+                                ],
+                            ]}
+                        />
+                        <p className="m-0">
+                            Some failures are non-fatal: e.g. a signature-status outage surfaces as an error entry
+                            alongside a usable payload — partial data beats no data for an agent.
+                        </p>
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'telemetry'} anchor="telemetry" title="Telemetry & observability">
-                    <SubTitle>Usage analytics (GA4)</SubTitle>
-                    <DocTable
-                        head={['Variable', 'Purpose']}
-                        rows={[
-                            [
-                                <InlineCode key="v">MCP_GA_MEASUREMENT_ID / MCP_GA_API_SECRET</InlineCode>,
-                                'GA4 Measurement Protocol credentials for server-side MCP usage analytics.',
-                            ],
-                        ]}
-                    />
-                    <p className="m-0">
-                        <Strong>What is sent:</Strong> <InlineCode>initialize</InlineCode> and every tool call emit{' '}
-                        <InlineCode>mcp_</InlineCode>-prefixed events (tool name, outcome, duration). Delivery runs
-                        after the response, so analytics never delays a reply.
-                    </p>
-                    <NumberedList
-                        items={[
-                            <>
-                                <Strong>Dedicated server id preferred</Strong> —{' '}
-                                <InlineCode>MCP_GA_MEASUREMENT_ID</InlineCode> falls back to{' '}
-                                <InlineCode>NEXT_PUBLIC_GOOGLE_ANALYTICS_ID</InlineCode> so single-id setups work, but
-                                server telemetry should not depend on a client-side variable.
-                            </>,
-                            <>
-                                <Strong>Privacy</Strong> — session ids are pseudonymized (hashed) before leaving the
-                                server; event params are constrained to scalars and GA4 length limits, so no payload
-                                data or identifiers leak into analytics.
-                            </>,
-                            <>
-                                <Strong>Best-effort by contract</Strong> — a throwing analytics sink can never break a
-                                tool reply; failures log at warn. Missing credentials disable analytics with a single
-                                cold-start warning, because a silently disabled pipeline is indistinguishable from a
-                                broken one.
-                            </>,
-                        ]}
-                    />
-                    <SubTitle>Sentry</SubTitle>
-                    <p className="m-0">
-                        The MCP server is wrapped with Sentry instrumentation: tool calls get spans and error capture
-                        automatically, and route-level failures report to Sentry while the client receives a
-                        controlled, CORS-consistent <InlineCode>500</InlineCode>. <Strong>Why:</Strong> the framework
-                        default 500 omits CORS headers, which browsers surface as an opaque network error instead of
-                        the real status.
-                    </p>
-                </DocSection>
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'telemetry'}
+                        anchor="telemetry"
+                        title="Telemetry & observability"
+                    >
+                        <SubTitle>Usage analytics (GA4)</SubTitle>
+                        <DocTable
+                            head={['Variable', 'Purpose']}
+                            rows={[
+                                [
+                                    <InlineCode key="v">MCP_GA_MEASUREMENT_ID / MCP_GA_API_SECRET</InlineCode>,
+                                    'GA4 Measurement Protocol credentials for server-side MCP usage analytics.',
+                                ],
+                            ]}
+                        />
+                        <p className="m-0">
+                            <Strong>What is sent:</Strong> <InlineCode>initialize</InlineCode> and every tool call emit{' '}
+                            <InlineCode>mcp_</InlineCode>-prefixed events (tool name, outcome, duration). Delivery runs
+                            after the response, so analytics never delays a reply.
+                        </p>
+                        <NumberedList
+                            items={[
+                                <>
+                                    <Strong>Dedicated server id preferred</Strong> —{' '}
+                                    <InlineCode>MCP_GA_MEASUREMENT_ID</InlineCode> falls back to{' '}
+                                    <InlineCode>NEXT_PUBLIC_GOOGLE_ANALYTICS_ID</InlineCode> so single-id setups work,
+                                    but server telemetry should not depend on a client-side variable.
+                                </>,
+                                <>
+                                    <Strong>Privacy</Strong> — session ids are pseudonymized (hashed) before leaving the
+                                    server; event params are constrained to scalars and GA4 length limits, so no payload
+                                    data or identifiers leak into analytics.
+                                </>,
+                                <>
+                                    <Strong>Best-effort by contract</Strong> — a throwing analytics sink can never break
+                                    a tool reply; failures log at warn. Missing credentials disable analytics with a
+                                    single cold-start warning, because a silently disabled pipeline is indistinguishable
+                                    from a broken one.
+                                </>,
+                            ]}
+                        />
+                        <SubTitle>Sentry</SubTitle>
+                        <p className="m-0">
+                            The MCP server is wrapped with Sentry instrumentation: tool calls get spans and error
+                            capture automatically, and route-level failures report to Sentry while the client receives a
+                            controlled, CORS-consistent <InlineCode>500</InlineCode>. <Strong>Why:</Strong> the
+                            framework default 500 omits CORS headers, which browsers surface as an opaque network error
+                            instead of the real status.
+                        </p>
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'smoke-test'} anchor="smoke-test" title="Smoke test">
-                    <p className="m-0">
-                        The <InlineCode>initialize</InlineCode> → <InlineCode>tools/call ping</InlineCode> round-trip
-                        verifies transport, auth, and (on previews) the protection bypass in one shot. Through any
-                        configured client, calling <InlineCode>ping</InlineCode> should return{' '}
-                        <InlineCode>pong</InlineCode>:
-                    </p>
-                    <CodeBlock code={`# via Claude Code\nclaude mcp list   # solana-explorer should be listed as connected\n\n# or ask the agent to call the tool\n> use the solana-explorer ping tool`} />
-                    <p className="m-0">
-                        The same round-trip is pinned by the integration spec in the{' '}
-                        <InlineCode>@explorer/entity-inspector</InlineCode> package, with curl equivalents documented
-                        alongside it.
-                    </p>
-                </DocSection>
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'smoke-test'}
+                        anchor="smoke-test"
+                        title="Smoke test"
+                    >
+                        <p className="m-0">
+                            The <InlineCode>initialize</InlineCode> → <InlineCode>tools/call ping</InlineCode>{' '}
+                            round-trip verifies transport, auth, and (on previews) the protection bypass in one shot.
+                            Through any configured client, calling <InlineCode>ping</InlineCode> should return{' '}
+                            <InlineCode>pong</InlineCode>:
+                        </p>
+                        <CodeBlock
+                            code={`# via Claude Code\nclaude mcp list   # solana-explorer should be listed as connected\n\n# or ask the agent to call the tool\n> use the solana-explorer ping tool`}
+                        />
+                        <p className="m-0">
+                            The same round-trip is pinned by the integration spec in the{' '}
+                            <InlineCode>@explorer/entity-inspector</InlineCode> package, with curl equivalents
+                            documented alongside it.
+                        </p>
+                    </DocSection>
 
-                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'architecture'} anchor="architecture" title="Architecture">
-                    <p className="m-0">
-                        The implementation is split so the inspection logic is reusable outside the app:
-                    </p>
-                    <DocTable
-                        head={['Layer', 'Location', 'Role']}
-                        rows={[
-                            [
-                                'HTTP route',
-                                <InlineCode key="l">app/mcp/</InlineCode>,
-                                'Auth, IP blocklist, CORS, lazy handler init, GA4/Sentry wiring, host-app instruction-parser fallback.',
-                            ],
-                            [
-                                'MCP server + tools',
-                                <InlineCode key="l">packages/entity-inspector/src/mcp/</InlineCode>,
-                                'The explorer-mcp server, inspect_entity/ping tools, input schemas, error envelope.',
-                            ],
-                            [
-                                'Inspection core',
-                                <InlineCode key="l">packages/entity-inspector/src/</InlineCode>,
-                                'RPC layer, account classifier/normalizer/router, transaction normalizer + decode cascade, telemetry.',
-                            ],
-                            [
-                                'Low-level parsers',
-                                <InlineCode key="l">packages/parsers</InlineCode>,
-                                'Shared instruction/account parsers, extracted as a package to enable reuse beyond the app.',
-                            ],
-                            [
-                                'IDL decoding',
-                                <InlineCode key="l">packages/idl-decode</InlineCode>,
-                                'On-chain IDL discovery and decode used by the idl cascade step.',
-                            ],
-                        ]}
-                    />
-                    <p className="m-0">
-                        <Strong>Roadmap note:</Strong> enrichment modules for program verification (Otter Verify),
-                        security.txt, and Squads multisig already exist in the package but are not yet wired into{' '}
-                        <InlineCode>inspect_entity</InlineCode> output.
-                    </p>
-                </DocSection>
+                    <DocSection
+                        kicker="Advanced configuration & reference"
+                        hidden={active !== 'architecture'}
+                        anchor="architecture"
+                        title="Architecture"
+                    >
+                        <p className="m-0">
+                            The implementation is split so the inspection logic is reusable outside the app:
+                        </p>
+                        <DocTable
+                            head={['Layer', 'Location', 'Role']}
+                            rows={[
+                                [
+                                    'HTTP route',
+                                    <InlineCode key="l">app/mcp/</InlineCode>,
+                                    'Auth, IP blocklist, CORS, lazy handler init, GA4/Sentry wiring, host-app instruction-parser fallback.',
+                                ],
+                                [
+                                    'MCP server + tools',
+                                    <InlineCode key="l">packages/entity-inspector/src/mcp/</InlineCode>,
+                                    'The explorer-mcp server, inspect_entity/ping tools, input schemas, error envelope.',
+                                ],
+                                [
+                                    'Inspection core',
+                                    <InlineCode key="l">packages/entity-inspector/src/</InlineCode>,
+                                    'RPC layer, account classifier/normalizer/router, transaction normalizer + decode cascade, telemetry.',
+                                ],
+                                [
+                                    'Low-level parsers',
+                                    <InlineCode key="l">packages/parsers</InlineCode>,
+                                    'Shared instruction/account parsers, extracted as a package to enable reuse beyond the app.',
+                                ],
+                                [
+                                    'IDL decoding',
+                                    <InlineCode key="l">packages/idl-decode</InlineCode>,
+                                    'On-chain IDL discovery and decode used by the idl cascade step.',
+                                ],
+                            ]}
+                        />
+                        <p className="m-0">
+                            <Strong>Roadmap note:</Strong> enrichment modules for program verification (Otter Verify),
+                            security.txt, and Squads multisig already exist in the package but are not yet wired into{' '}
+                            <InlineCode>inspect_entity</InlineCode> output.
+                        </p>
+                    </DocSection>
 
                     {/* Next-topic link; the description reuses the overview catalog copy. */}
                     <PagerLink chunk={nextChunk} onSelect={select} />
@@ -570,7 +618,10 @@ function DocTable({ head, rows }: { head: string[]; rows: ReactNode[][] }) {
                 <TableHeader className="bg-heavy-metal-900 [&_tr]:border-white/10">
                     <TableRow className="border-white/10">
                         {head.map(title => (
-                            <TableHead key={title} className="px-4 py-2.5 text-left text-xs font-medium text-neutral-400">
+                            <TableHead
+                                key={title}
+                                className="px-4 py-2.5 text-left text-xs font-medium text-neutral-400"
+                            >
                                 {title}
                             </TableHead>
                         ))}

--- a/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsAdvancedView.tsx
@@ -1,0 +1,596 @@
+'use client';
+
+import { useClusterPath } from '@utils/url';
+import Link from 'next/link';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { ArrowLeft, ArrowRight } from 'react-feather';
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/app/components/shared/ui/table';
+import { cn } from '@/app/components/shared/utils';
+
+import { ADVANCED_CHUNKS } from '../lib/advanced-chunks';
+import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
+import { CodeBlock } from './CodeBlock';
+import { DocCard } from './DocCard';
+import { DocSection, InlineCode } from './DocSection';
+
+export function McpDocsAdvancedView() {
+    const origin = useDeploymentOrigin();
+    const overviewPath = useClusterPath({ pathname: '/mcp/docs' });
+    const [active, setActive] = useState(ADVANCED_CHUNKS[0].anchor);
+
+    // Deep links from the overview catalog arrive as #anchor — honor them and keep the hash shareable.
+    useEffect(() => {
+        const applyHash = () => {
+            const anchor = window.location.hash.slice(1);
+            if (ADVANCED_CHUNKS.some(chunk => chunk.anchor === anchor)) {
+                setActive(anchor);
+            }
+        };
+        applyHash();
+        window.addEventListener('hashchange', applyHash);
+        return () => window.removeEventListener('hashchange', applyHash);
+    }, []);
+
+    const select = (anchor: string) => {
+        setActive(anchor);
+        // eslint-disable-next-line unicorn/no-null -- History API expects null state
+        window.history.replaceState(null, '', `#${anchor}`);
+        window.scrollTo({ behavior: 'smooth', top: 0 });
+    };
+
+    const activeIndex = ADVANCED_CHUNKS.findIndex(chunk => chunk.anchor === active);
+    // The last section wraps around to the first topic.
+    const nextChunk = ADVANCED_CHUNKS[(activeIndex + 1) % ADVANCED_CHUNKS.length];
+
+    return (
+        <div className="mx-auto w-full max-w-5xl px-4 py-10">
+            <div className="flex flex-col gap-8 sm:flex-row">
+                <nav
+                    aria-label="Sections"
+                    className="shrink-0 self-start rounded-xl border border-solid border-white/10 p-2 sm:sticky sm:top-6 sm:w-60"
+                >
+                    <Link
+                        href={overviewPath}
+                        className="flex items-center gap-2 rounded px-3 py-2 text-sm text-neutral-400 no-underline hover:bg-heavy-metal-900 hover:text-white"
+                    >
+                        <ArrowLeft size={14} aria-hidden />
+                        MCP Overview
+                    </Link>
+                    <div className="-mx-2 my-2 border-0 border-t border-solid border-white/10" />
+                    <div className="flex flex-col gap-0.5">
+                        {ADVANCED_CHUNKS.map(chunk => {
+                            const isActive = chunk.anchor === active;
+                            return (
+                                <button
+                                    key={chunk.anchor}
+                                    type="button"
+                                    onClick={() => select(chunk.anchor)}
+                                    className={cn(
+                                        'cursor-pointer rounded border-0 px-3 py-2 text-left text-sm transition-colors',
+                                        isActive
+                                            ? 'bg-heavy-metal-900 text-white'
+                                            : 'bg-transparent text-neutral-400 hover:bg-heavy-metal-900 hover:text-neutral-200',
+                                    )}
+                                >
+                                    {chunk.title}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </nav>
+
+                <div className="flex min-w-0 grow flex-col gap-12">
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'access-control'} anchor="access-control" title="Enabling & access control">
+                    <p className="m-0">
+                        The <InlineCode>/mcp</InlineCode> endpoint is inert by default — every request gets{' '}
+                        <InlineCode>503</InlineCode> until the deployment explicitly enables it. All configuration is
+                        environment-only (see <InlineCode>.env.example</InlineCode>); keys and the blocklist are parsed
+                        once at module scope, so changes require a redeploy.
+                    </p>
+                    <DocTable
+                        head={['Variable', 'Purpose', 'Why it exists']}
+                        rows={[
+                            [
+                                <InlineCode key="v">MCP_ENDPOINT_ENABLED</InlineCode>,
+                                <>
+                                    <InlineCode>true</InlineCode> enables the endpoint; anything else keeps it
+                                    returning <InlineCode>503</InlineCode>.
+                                </>,
+                                'Opt-in by design: an Explorer deployment should not silently expose an agent-facing API (and its RPC spend) just because the code ships with it.',
+                            ],
+                            [
+                                <InlineCode key="v">MCP_ACCESS_KEYS</InlineCode>,
+                                <>
+                                    Comma-separated bearer keys; requests need{' '}
+                                    <InlineCode>Authorization: Bearer &lt;key&gt;</InlineCode>.
+                                </>,
+                                'Gates who can consume your RPC quota. Comparison is constant-time. Unset = deliberate open access, logged as a warning at startup. Multiple keys let you hand one per consumer and revoke individually.',
+                            ],
+                            [
+                                <InlineCode key="v">MCP_BLOCKED_IPS</InlineCode>,
+                                <>
+                                    Comma-separated client IPs rejected with <InlineCode>403</InlineCode>.
+                                </>,
+                                'Emergency brake against an abusive client without rotating keys for everyone — useful precisely when running open access.',
+                            ],
+                        ]}
+                    />
+                    <p className="m-0">
+                        On Vercel: add the variables in Project Settings → Environment Variables, then redeploy.
+                    </p>
+                    <SubTitle>Route behavior worth knowing</SubTitle>
+                    <NumberedList
+                        items={[
+                            <>
+                                <Strong>Stateless by construction</Strong> — a fresh MCP server per request, so the
+                                endpoint is serverless-safe: no session affinity, no state to lose between invocations.
+                            </>,
+                            <>
+                                <Strong>
+                                    <InlineCode>/mcp</InlineCode>, not <InlineCode>/api/mcp</InlineCode>
+                                </Strong>{' '}
+                                — placed outside <InlineCode>/api/*</InlineCode> to escape the BotID proxy matcher,
+                                which would otherwise challenge non-browser MCP clients.
+                            </>,
+                            <>
+                                <Strong>Full CORS</Strong> (<InlineCode>GET</InlineCode>/<InlineCode>POST</InlineCode>/
+                                <InlineCode>DELETE</InlineCode>/<InlineCode>OPTIONS</InlineCode>; MCP session and
+                                protocol headers exposed) — browser-based agents work, and even error responses stay
+                                CORS-consistent so clients see the real status instead of an opaque network failure.
+                            </>,
+                            <>
+                                <Strong>
+                                    <InlineCode>maxDuration = 60</InlineCode>
+                                </Strong>{' '}
+                                applies to this route only — deep inspections (lookup-table resolution + IDL decode)
+                                need more than the default function budget, without raising it app-wide.
+                            </>,
+                            <>
+                                <Strong>Lazy loading</Strong> — the MCP package is imported on first request, so a
+                                disabled endpoint adds nothing to the serverless bundle; a failed import is not cached,
+                                so a transient error does not stick until redeploy.
+                            </>,
+                            <>
+                                <Strong>
+                                    <InlineCode>server-only</InlineCode> lock
+                                </Strong>{' '}
+                                — the config module reads key-bearing RPC URLs and fails the build if ever pulled into
+                                a client bundle. URLs resolve at cold start from runtime env, never into a build
+                                artifact.
+                            </>,
+                        ]}
+                    />
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'rpc-configuration'} anchor="rpc-configuration" title="RPC configuration">
+                    <DocTable
+                        head={['Variable', 'Purpose']}
+                        rows={[
+                            [
+                                <InlineCode key="v">
+                                    MCP_SOLANA_RPC_URL_MAINNET_BETA / _DEVNET / _TESTNET / _SIMD296
+                                </InlineCode>,
+                                'Dedicated RPC endpoint per cluster for MCP traffic.',
+                            ],
+                        ]}
+                    />
+                    <p className="m-0">
+                        <Strong>Why:</Strong> agents are chatty — a single <InlineCode>inspect_entity</InlineCode> call
+                        on a transaction can fan out into lookup-table fetches, IDL discovery, and DAS calls. Dedicated
+                        endpoints keep that traffic off the quota that serves the Explorer UI, and let you rate-limit
+                        or bill agent usage separately.
+                    </p>
+                    <p className="m-0">
+                        <Strong>Fallback:</Strong> unset variables fall back to the app&apos;s own server RPC config (
+                        <InlineCode>*_RPC_URL</InlineCode> env → proxied default) — never to a raw public endpoint, so
+                        the MCP path inherits whatever keys and proxying the app already uses.
+                    </p>
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'preview-deployments'} anchor="preview-deployments" title="Preview deployments (Vercel)">
+                    <p className="m-0">
+                        Previews sit behind Deployment Protection, so clients must present the{' '}
+                        <a
+                            href="https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-dark-accent no-underline hover:underline"
+                        >
+                            Protection Bypass for Automation
+                        </a>{' '}
+                        secret in addition to the endpoint&apos;s own Bearer auth:
+                    </p>
+                    <NumberedList
+                        items={[
+                            <>
+                                Generate the secret in Project Settings → Deployment Protection → Protection Bypass for
+                                Automation.
+                            </>,
+                            <>
+                                Send it as the <InlineCode>x-vercel-protection-bypass</InlineCode> header, or{' '}
+                                <InlineCode>?x-vercel-protection-bypass=&lt;secret&gt;</InlineCode> for clients that
+                                cannot set headers.
+                            </>,
+                        ]}
+                    />
+                    <CodeBlock
+                        code={JSON.stringify(
+                            {
+                                mcpServers: {
+                                    'solana-explorer': {
+                                        headers: {
+                                            Authorization: 'Bearer <key>',
+                                            'x-vercel-protection-bypass': '<secret>',
+                                        },
+                                        type: 'http',
+                                        url: '<preview-deployment>/mcp',
+                                    },
+                                },
+                            },
+                            undefined,
+                            4,
+                        )}
+                    />
+                    <p className="m-0">
+                        <Strong>Why two layers:</Strong> the bypass gets you through Vercel&apos;s platform gate (which
+                        knows nothing about MCP); the Bearer key is the endpoint&apos;s own auth. Omit the bypass
+                        header outside previews.
+                    </p>
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'inspect-entity'} anchor="inspect-entity" title="inspect_entity reference">
+                    <p className="m-0">Read-only and idempotent (annotated as such, so agents may retry freely).</p>
+                    <SubTitle>Input</SubTitle>
+                    <DocTable
+                        head={['Field', 'Type', 'Notes']}
+                        rows={[
+                            [
+                                <InlineCode key="f">identifier</InlineCode>,
+                                'string (1–128 chars, base58)',
+                                'Account address (32-byte) or transaction signature (64-byte) — the tool detects which type was provided.',
+                            ],
+                            [
+                                <InlineCode key="f">cluster</InlineCode>,
+                                'mainnet-beta | devnet | testnet | simd296',
+                                'Optional; defaults to mainnet-beta.',
+                            ],
+                        ]}
+                    />
+                    <SubTitle>
+                        Account kinds (<InlineCode>entity.kind</InlineCode>)
+                    </SubTitle>
+                    <DocTable
+                        head={['Kind', 'Payload']}
+                        rows={[
+                            [
+                                <InlineCode key="k">spl-token[-2022]:mint</InlineCode>,
+                                'Address, supply, decimals, mint/freeze authorities, supply type (fixed/variable), token program. Token-2022 mints also include parsed extensions.',
+                            ],
+                            [<InlineCode key="k">spl-token[-2022]:account</InlineCode>, 'Mint, owner, token program.'],
+                            [
+                                <InlineCode key="k">spl-token[-2022]:multisig</InlineCode>,
+                                'Signers, threshold, initialization status.',
+                            ],
+                            [
+                                <InlineCode key="k">compressed-nft</InlineCode>,
+                                'Asset ID, owner, merkle tree (classified via DAS).',
+                            ],
+                            [
+                                <span key="k" className="font-mono text-xs">
+                                    stake, vote, nonce, sysvar, config, address-lookup-table, feature, nftoken,
+                                    solana-attestation-service
+                                </span>,
+                                'Recognized system account types.',
+                            ],
+                            [<InlineCode key="k">native-program</InlineCode>, 'Built-in native programs.'],
+                            [
+                                <InlineCode key="k">bpf-upgradeable-loader</InlineCode>,
+                                'Upgradeable programs — address, label, balance, executable-data account, upgradeability, last deploy slot, upgrade authority, plus an idl enrichment (status, idl_type, source, program name).',
+                            ],
+                            [
+                                <InlineCode key="k">bpf-loader / bpf-loader-2 / loader-v4</InlineCode>,
+                                'Legacy-loader programs — currently unsupported; return a CURRENTLY_UNSUPPORTED error.',
+                            ],
+                            [
+                                <InlineCode key="k">unknown</InlineCode>,
+                                'Unrecognized account type. When the owner program publishes an IDL, the account data is decoded through it and returned as decoded (source "idl").',
+                            ],
+                            [<InlineCode key="k">transaction</InlineCode>, 'See below.'],
+                        ]}
+                    />
+                    <SubTitle>Transactions</SubTitle>
+                    <p className="m-0">
+                        64-byte signatures return <InlineCode>entity.kind: &quot;transaction&quot;</InlineCode> — slot,
+                        block time, fee, status, error, signers, accounts (v0 lookup-table addresses attributed via{' '}
+                        <InlineCode>source</InlineCode>/<InlineCode>lookupTableAddress</InlineCode>), and instructions
+                        with inner instructions. Instructions decode through a cascade — each step exists because the
+                        previous one cannot cover everything:
+                    </p>
+                    <NumberedList
+                        items={[
+                            <>
+                                <Strong>
+                                    <InlineCode>idl</InlineCode>
+                                </Strong>{' '}
+                                — programs publishing an on-chain IDL are decoded through it: always current, no
+                                Explorer release needed when the program upgrades.
+                            </>,
+                            <>
+                                <Strong>
+                                    <InlineCode>bundled</InlineCode>
+                                </Strong>{' '}
+                                — token batch and host-app-supported programs decode through the Explorer&apos;s own
+                                instruction-parser dispatcher: covers major programs that publish no IDL.
+                            </>,
+                            <>
+                                <Strong>
+                                    <InlineCode>raw</InlineCode>
+                                </Strong>{' '}
+                                — everything else stays base58, clearly labeled, so the agent knows the data is
+                                undecoded rather than empty.
+                            </>,
+                        ]}
+                    />
+                    <p className="m-0">
+                        <Strong>Program labels:</Strong> program addresses resolve to human-readable names through the
+                        Explorer&apos;s program registry, with a built-in fallback label map when the host registry
+                        misses — so agents see &quot;Jupiter Aggregator v6&quot; rather than a bare address.
+                    </p>
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'output-format'} anchor="output-format" title="Output envelope & errors">
+                    <p className="m-0">
+                        Every tool reply carries the same envelope, both as <InlineCode>text</InlineCode> and{' '}
+                        <InlineCode>structuredContent</InlineCode> (identical, JSON-round-tripped values — clients can
+                        consume either):
+                    </p>
+                    <CodeBlock
+                        code={`{\n    "payload": { "entity": { "kind": "...", "...": "..." } },\n    "errors": []\n}`}
+                    />
+                    <NumberedList
+                        items={[
+                            <>
+                                <Strong>Explicit unknown markers</Strong> instead of omitted fields — an agent can
+                                distinguish &quot;not applicable&quot; from &quot;could not resolve&quot;, which
+                                prevents hallucinated fill-ins.
+                            </>,
+                            <>
+                                <Strong>BigInt coercion</Strong> — large numerics are coerced to Number when safe,
+                                String otherwise, so the payload is always plain JSON.
+                            </>,
+                            <>
+                                <Strong>
+                                    Key order <InlineCode>{'{ payload, errors }'}</InlineCode> is part of the wire
+                                    format
+                                </Strong>{' '}
+                                (kept in parity with the standalone explorer-mcp).
+                            </>,
+                        ]}
+                    />
+                    <SubTitle>Error codes</SubTitle>
+                    <p className="m-0">
+                        <InlineCode>errors[].code</InlineCode>; <InlineCode>isError: true</InlineCode> when the list is
+                        non-empty:
+                    </p>
+                    <DocTable
+                        head={['Code', 'Meaning', 'Why a dedicated code']}
+                        rows={[
+                            [
+                                <InlineCode key="c">INVALID_ARGUMENT</InlineCode>,
+                                'Malformed input; includes flattened field-level schema details.',
+                                'Lets the agent fix its call instead of retrying blindly.',
+                            ],
+                            [
+                                <InlineCode key="c">NOT_FOUND</InlineCode>,
+                                'The entity does not exist on the selected cluster.',
+                                'Distinguishes "wrong cluster / typo" from a server failure — the agent can try another cluster.',
+                            ],
+                            [
+                                <InlineCode key="c">CURRENTLY_UNSUPPORTED</InlineCode>,
+                                'Recognized but not-yet-supported entity (e.g. legacy loaders).',
+                                'Honest "we know what this is but cannot decode it yet" — no point retrying.',
+                            ],
+                            [
+                                <InlineCode key="c">INTERNAL_ERROR</InlineCode>,
+                                'Sanitized internal failure.',
+                                'Details are stripped so stack traces and RPC URLs never leak to clients; full context goes to Sentry instead.',
+                            ],
+                        ]}
+                    />
+                    <p className="m-0">
+                        Some failures are non-fatal: e.g. a signature-status outage surfaces as an error entry
+                        alongside a usable payload — partial data beats no data for an agent.
+                    </p>
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'telemetry'} anchor="telemetry" title="Telemetry & observability">
+                    <SubTitle>Usage analytics (GA4)</SubTitle>
+                    <DocTable
+                        head={['Variable', 'Purpose']}
+                        rows={[
+                            [
+                                <InlineCode key="v">MCP_GA_MEASUREMENT_ID / MCP_GA_API_SECRET</InlineCode>,
+                                'GA4 Measurement Protocol credentials for server-side MCP usage analytics.',
+                            ],
+                        ]}
+                    />
+                    <p className="m-0">
+                        <Strong>What is sent:</Strong> <InlineCode>initialize</InlineCode> and every tool call emit{' '}
+                        <InlineCode>mcp_</InlineCode>-prefixed events (tool name, outcome, duration). Delivery runs
+                        after the response, so analytics never delays a reply.
+                    </p>
+                    <NumberedList
+                        items={[
+                            <>
+                                <Strong>Dedicated server id preferred</Strong> —{' '}
+                                <InlineCode>MCP_GA_MEASUREMENT_ID</InlineCode> falls back to{' '}
+                                <InlineCode>NEXT_PUBLIC_GOOGLE_ANALYTICS_ID</InlineCode> so single-id setups work, but
+                                server telemetry should not depend on a client-side variable.
+                            </>,
+                            <>
+                                <Strong>Privacy</Strong> — session ids are pseudonymized (hashed) before leaving the
+                                server; event params are constrained to scalars and GA4 length limits, so no payload
+                                data or identifiers leak into analytics.
+                            </>,
+                            <>
+                                <Strong>Best-effort by contract</Strong> — a throwing analytics sink can never break a
+                                tool reply; failures log at warn. Missing credentials disable analytics with a single
+                                cold-start warning, because a silently disabled pipeline is indistinguishable from a
+                                broken one.
+                            </>,
+                        ]}
+                    />
+                    <SubTitle>Sentry</SubTitle>
+                    <p className="m-0">
+                        The MCP server is wrapped with Sentry instrumentation: tool calls get spans and error capture
+                        automatically, and route-level failures report to Sentry while the client receives a
+                        controlled, CORS-consistent <InlineCode>500</InlineCode>. <Strong>Why:</Strong> the framework
+                        default 500 omits CORS headers, which browsers surface as an opaque network error instead of
+                        the real status.
+                    </p>
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'smoke-test'} anchor="smoke-test" title="Smoke test">
+                    <p className="m-0">
+                        The <InlineCode>initialize</InlineCode> → <InlineCode>tools/call ping</InlineCode> round-trip
+                        verifies transport, auth, and (on previews) the protection bypass in one shot. Through any
+                        configured client, calling <InlineCode>ping</InlineCode> should return{' '}
+                        <InlineCode>pong</InlineCode>:
+                    </p>
+                    <CodeBlock code={`# via Claude Code\nclaude mcp list   # solana-explorer should be listed as connected\n\n# or ask the agent to call the tool\n> use the solana-explorer ping tool`} />
+                    <p className="m-0">
+                        The same round-trip is pinned by the integration spec in the{' '}
+                        <InlineCode>@explorer/entity-inspector</InlineCode> package, with curl equivalents documented
+                        alongside it.
+                    </p>
+                </DocSection>
+
+                <DocSection kicker="Advanced configuration & reference" hidden={active !== 'architecture'} anchor="architecture" title="Architecture">
+                    <p className="m-0">
+                        The implementation is split so the inspection logic is reusable outside the app:
+                    </p>
+                    <DocTable
+                        head={['Layer', 'Location', 'Role']}
+                        rows={[
+                            [
+                                'HTTP route',
+                                <InlineCode key="l">app/mcp/</InlineCode>,
+                                'Auth, IP blocklist, CORS, lazy handler init, GA4/Sentry wiring, host-app instruction-parser fallback.',
+                            ],
+                            [
+                                'MCP server + tools',
+                                <InlineCode key="l">packages/entity-inspector/src/mcp/</InlineCode>,
+                                'The explorer-mcp server, inspect_entity/ping tools, input schemas, error envelope.',
+                            ],
+                            [
+                                'Inspection core',
+                                <InlineCode key="l">packages/entity-inspector/src/</InlineCode>,
+                                'RPC layer, account classifier/normalizer/router, transaction normalizer + decode cascade, telemetry.',
+                            ],
+                            [
+                                'Low-level parsers',
+                                <InlineCode key="l">packages/parsers</InlineCode>,
+                                'Shared instruction/account parsers, extracted as a package to enable reuse beyond the app.',
+                            ],
+                            [
+                                'IDL decoding',
+                                <InlineCode key="l">packages/idl-decode</InlineCode>,
+                                'On-chain IDL discovery and decode used by the idl cascade step.',
+                            ],
+                        ]}
+                    />
+                    <p className="m-0">
+                        <Strong>Roadmap note:</Strong> enrichment modules for program verification (Otter Verify),
+                        security.txt, and Squads multisig already exist in the package but are not yet wired into{' '}
+                        <InlineCode>inspect_entity</InlineCode> output.
+                    </p>
+                </DocSection>
+
+                    {/* Next-topic link; the description reuses the overview catalog copy. */}
+                    <PagerLink chunk={nextChunk} onSelect={select} />
+                </div>
+            </div>
+
+            <p className="mb-0 mt-12 text-xs text-neutral-500">
+                Endpoint of this deployment: <InlineCode>{origin}/mcp</InlineCode>
+            </p>
+        </div>
+    );
+}
+
+function PagerLink({
+    chunk,
+    onSelect,
+}: {
+    chunk: (typeof ADVANCED_CHUNKS)[number];
+    onSelect: (anchor: string) => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={() => onSelect(chunk.anchor)}
+            className="cursor-pointer rounded-xl border border-solid border-white/10 bg-transparent p-4 text-left transition-colors hover:border-dark-accent sm:p-6"
+        >
+            <span className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-neutral-500">
+                Next
+                <ArrowRight size={12} aria-hidden />
+            </span>
+            <span className="mt-1.5 block text-sm font-medium text-white">{chunk.title}</span>
+            <span className="mt-1 block text-xs leading-relaxed text-neutral-400">{chunk.gives}</span>
+        </button>
+    );
+}
+
+function SubTitle({ children }: { children: ReactNode }) {
+    return <h3 className="mb-0 mt-2 text-lg font-medium text-white">{children}</h3>;
+}
+
+function Strong({ children }: { children: ReactNode }) {
+    return <span className="font-medium text-neutral-100">{children}</span>;
+}
+
+function NumberedList({ items }: { items: ReactNode[] }) {
+    return (
+        <ol className="m-0 flex list-none flex-col gap-2 p-0">
+            {items.map((item, index) => (
+                <li key={index} className="flex gap-3">
+                    <span className="shrink-0 font-mono text-xs leading-6 text-neutral-600">{index + 1}</span>
+                    <span>{item}</span>
+                </li>
+            ))}
+        </ol>
+    );
+}
+
+function DocTable({ head, rows }: { head: string[]; rows: ReactNode[][] }) {
+    return (
+        <DocCard className="overflow-hidden">
+            <Table className="bg-transparent text-sm">
+                <TableHeader className="bg-heavy-metal-900 [&_tr]:border-white/10">
+                    <TableRow className="border-white/10">
+                        {head.map(title => (
+                            <TableHead key={title} className="px-4 py-2.5 text-left text-xs font-medium text-neutral-400">
+                                {title}
+                            </TableHead>
+                        ))}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {rows.map((cells, rowIndex) => (
+                        <TableRow key={rowIndex} className="border-white/10">
+                            {cells.map((cell, cellIndex) => (
+                                <TableCell
+                                    key={cellIndex}
+                                    className="px-4 py-3 align-top text-xs leading-relaxed text-neutral-300 [overflow-wrap:anywhere]"
+                                >
+                                    {cell}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </DocCard>
+    );
+}

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -5,12 +5,7 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { ArrowRight, Minus, Plus, Tool } from 'react-feather';
 
-import {
-    Accordion,
-    AccordionContent,
-    AccordionItem,
-    AccordionTrigger,
-} from '@/app/components/shared/ui/accordion';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/app/components/shared/ui/accordion';
 import { Badge } from '@/app/components/shared/ui/badge';
 import { Button } from '@/app/components/shared/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
@@ -181,35 +176,35 @@ export function McpDocsOverviewView() {
             </SectionTitle>
             <DocCard className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
                 <Tabs value={client} onValueChange={setClient}>
-                <TabsList
-                    style={{ display: 'flex' }}
-                    className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
-                >
-                    {SETUP_CLIENTS.map(({ id, label }) => (
-                        <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
-                            {label}
-                        </TabsTrigger>
+                    <TabsList
+                        style={{ display: 'flex' }}
+                        className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
+                    >
+                        {SETUP_CLIENTS.map(({ id, label }) => (
+                            <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
+                                {label}
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+                    {SETUP_CLIENTS.map(setupClient => (
+                        <TabsContent key={setupClient.id} value={setupClient.id}>
+                            <p className="mb-3 mt-0 text-sm text-neutral-300">{setupClient.where}</p>
+                            <CodeBlock code={setupClient.snippet(origin)} />
+                            <p className="mb-0 mt-3 text-sm leading-relaxed text-neutral-300">
+                                <span className="font-medium text-neutral-300">Verify:</span> {setupClient.verify}
+                            </p>
+                        </TabsContent>
                     ))}
-                </TabsList>
-                {SETUP_CLIENTS.map(setupClient => (
-                    <TabsContent key={setupClient.id} value={setupClient.id}>
-                        <p className="mb-3 mt-0 text-sm text-neutral-300">{setupClient.where}</p>
-                        <CodeBlock code={setupClient.snippet(origin)} />
-                        <p className="mb-0 mt-3 text-sm leading-relaxed text-neutral-300">
-                            <span className="font-medium text-neutral-300">Verify:</span> {setupClient.verify}
-                        </p>
-                    </TabsContent>
-                ))}
                 </Tabs>
                 <p className="mb-0 mt-4 text-sm leading-relaxed text-neutral-300">
-                Connecting to a preview deployment? Previews need one extra header —{' '}
-                <Link
-                    href={`${advancedPath}#preview-deployments`}
-                    className="text-dark-accent no-underline hover:underline"
-                >
-                    see preview deployments
-                </Link>
-                .
+                    Connecting to a preview deployment? Previews need one extra header —{' '}
+                    <Link
+                        href={`${advancedPath}#preview-deployments`}
+                        className="text-dark-accent no-underline hover:underline"
+                    >
+                        see preview deployments
+                    </Link>
+                    .
                 </p>
             </DocCard>
 
@@ -242,11 +237,7 @@ export function McpDocsOverviewView() {
             </SectionTitle>
             <div className="grid gap-3 sm:grid-cols-2">
                 {ADVANCED_CHUNKS.map(chunk => (
-                    <Link
-                        key={chunk.anchor}
-                        href={`${advancedPath}#${chunk.anchor}`}
-                        className="group no-underline"
-                    >
+                    <Link key={chunk.anchor} href={`${advancedPath}#${chunk.anchor}`} className="group no-underline">
                         <DocCard transparent className="h-full transition-colors group-hover:border-dark-accent">
                             <div className="flex h-full flex-col p-4 sm:p-6">
                                 <div className="mb-2 flex items-center justify-between gap-2">

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -1,0 +1,390 @@
+'use client';
+
+import { useClusterPath } from '@utils/url';
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
+import { ArrowRight, Minus, Plus, Tool } from 'react-feather';
+
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from '@/app/components/shared/ui/accordion';
+import { Badge } from '@/app/components/shared/ui/badge';
+import { Button } from '@/app/components/shared/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
+import { cn } from '@/app/components/shared/utils';
+
+import { ADVANCED_CHUNKS } from '../lib/advanced-chunks';
+import { AGENT_INSTRUCTIONS_SNIPPET, AGENT_INSTRUCTIONS_TARGETS, SETUP_CLIENTS } from '../lib/setup-clients';
+import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
+import { CodeBlock } from './CodeBlock';
+import { DocCard } from './DocCard';
+import { InlineCode } from './DocSection';
+
+const HIGHLIGHTS = [
+    {
+        text: 'Pass any base58 string — the tool detects whether it is a 32-byte account address or a 64-byte transaction signature and returns a typed payload.',
+        title: 'One identifier in, structured entity out',
+    },
+    {
+        text: 'Mints, token accounts and multisigs for both SPL Token and Token-2022 (including parsed extensions), plus compressed NFTs.',
+        title: 'Deep token support',
+    },
+    {
+        text: 'Status, fee, signers, v0 lookup-table attribution, and instructions decoded through a cascade: on-chain IDL → bundled parsers → raw base58.',
+        title: 'Full transaction decode',
+    },
+    {
+        text: 'Upgradeability, upgrade authority, last deploy slot, and IDL availability for upgradeable programs.',
+        title: 'Program inspection',
+    },
+    {
+        text: 'Unresolvable fields come back as explicit unknown markers, never silently omitted; errors are structured codes, not prose.',
+        title: 'Honest output',
+    },
+    {
+        text: 'mainnet-beta (default), devnet, testnet and simd296 — pick per call with the cluster argument.',
+        title: 'Four clusters',
+    },
+];
+
+const EXAMPLES = [
+    {
+        answer: 'This is a token mint (kind spl-token:mint) with 6 decimals. Supply is variable: the mint authority is still active, and a freeze authority is set.',
+        label: 'Token due diligence',
+        question: 'What are the mint and freeze authorities of EPjF…t1v?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'The transaction failed in instruction #3 with a custom program error; the fee was still charged. Full decoded instructions (with inner instructions), signers and account list are in the payload.',
+        label: 'Transaction post-mortem',
+        question: 'Why did transaction 5UfD… fail?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'Yes — it is a bpf-upgradeable-loader program. The payload names the upgrade authority, the last deploy slot, and reports that an on-chain IDL is published.',
+        label: 'Program inspection',
+        question: 'Is program JUP6… upgradeable and who holds the upgrade authority?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'The account kind is unknown, but its owner program publishes an IDL, so the raw data comes back decoded through it (source "idl") instead of base64.',
+        label: 'Unknown account decoding',
+        question: 'What is stored in account 9xQe…?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'pong — transport, auth and (on previews) the protection bypass all work end-to-end.',
+        label: 'Health check',
+        question: 'Is the Explorer MCP up?',
+        tool: 'ping',
+    },
+];
+
+export function McpDocsOverviewView() {
+    const origin = useDeploymentOrigin();
+    const advancedPath = useClusterPath({ pathname: '/mcp/docs/advanced' });
+    const [client, setClient] = useState(SETUP_CLIENTS[0].id);
+    const [openHighlights, setOpenHighlights] = useState<string[]>([]);
+
+    return (
+        <div className="mx-auto w-full max-w-3xl px-4 py-10">
+            {/* Hero */}
+            <h1 className="mb-4 mt-0 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                Live on-chain data for coding agents
+            </h1>
+            <p className="mb-6 mt-0 text-lg leading-relaxed text-neutral-300">
+                This Explorer ships a remote MCP (Model Context Protocol) server that lets AI agents inspect any Solana
+                account, program, token, or transaction — decoded and enriched the same way the Explorer UI renders it.
+            </p>
+            <div className="mb-8 flex flex-wrap gap-3">
+                <Button asChild variant="accent" size="lg" style={{ paddingInline: '1rem' }}>
+                    <a href="#setup" className="no-underline">
+                        Set up your agent
+                    </a>
+                </Button>
+                <Button asChild variant="outline" size="lg" style={{ paddingInline: '1rem' }}>
+                    <Link href={advancedPath} className="no-underline">
+                        Advanced reference
+                    </Link>
+                </Button>
+            </div>
+            <DocCard transparent className="mb-12">
+                <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
+                    <HeroFact label="Endpoint">
+                        <span className="font-mono text-xs">{origin}/mcp</span>
+                    </HeroFact>
+                    <HeroFact label="Transport">
+                        <span className="font-mono text-xs">Streamable HTTP, stateless</span>
+                    </HeroFact>
+                    <HeroFact label="Auth">
+                        <span className="font-mono text-xs">Authorization: Bearer &lt;key&gt;</span>
+                    </HeroFact>
+                    <HeroFact label="Tools">
+                        <span className="font-mono text-xs">inspect_entity · ping</span>
+                    </HeroFact>
+                </div>
+            </DocCard>
+
+            {/* Highlights */}
+            <SectionTitle subtitle="What the server gives your agent out of the box.">Highlights</SectionTitle>
+            <Accordion
+                type="multiple"
+                value={openHighlights}
+                onValueChange={setOpenHighlights}
+                className="mb-12 grid items-start gap-3 sm:grid-cols-2"
+            >
+                {HIGHLIGHTS.map(highlight => (
+                    <DocCard
+                        key={highlight.title}
+                        transparent
+                        className={cn(
+                            'overflow-hidden transition-colors hover:border-dark-accent',
+                            openHighlights.includes(highlight.title) && 'cursor-pointer',
+                        )}
+                        // Deliberately reads the pre-click state: a trigger click on a closed item bubbles here,
+                        // and a functional update would instantly undo the open.
+                        onClick={() => {
+                            if (openHighlights.includes(highlight.title)) {
+                                setOpenHighlights(openHighlights.filter(value => value !== highlight.title));
+                            }
+                        }}
+                    >
+                        {/* The item is the card's only child, so its own `last:border-b-0` removes the divider. */}
+                        <AccordionItem value={highlight.title} className="sm:px-6">
+                            {/* Chevron off, +/- state icons on the right instead; no hover underline. */}
+                            <AccordionTrigger className="px-0 text-base font-medium text-white hover:no-underline [&>svg]:hidden [&[data-state=closed]_.hl-minus]:hidden [&[data-state=open]_.hl-plus]:hidden">
+                                <span className="flex-1">{highlight.title}</span>
+                                <span className="hl-plus text-neutral-500">
+                                    <Plus size={16} aria-hidden />
+                                </span>
+                                <span className="hl-minus text-neutral-500">
+                                    <Minus size={16} aria-hidden />
+                                </span>
+                            </AccordionTrigger>
+                            <AccordionContent className="text-sm leading-relaxed text-neutral-400">
+                                {highlight.text}
+                            </AccordionContent>
+                        </AccordionItem>
+                    </DocCard>
+                ))}
+            </Accordion>
+
+            {/* Setup */}
+            <SectionTitle
+                id="setup"
+                subtitle="Pick your tool, copy the config — snippets already point at this deployment. Ask the deployment owner for a key; some deployments run open access."
+            >
+                Setup
+            </SectionTitle>
+            <DocCard className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+                <Tabs value={client} onValueChange={setClient}>
+                <TabsList
+                    style={{ display: 'flex' }}
+                    className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
+                >
+                    {SETUP_CLIENTS.map(({ id, label }) => (
+                        <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
+                            {label}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+                {SETUP_CLIENTS.map(setupClient => (
+                    <TabsContent key={setupClient.id} value={setupClient.id}>
+                        <p className="mb-3 mt-0 text-sm text-neutral-300">{setupClient.where}</p>
+                        <CodeBlock code={setupClient.snippet(origin)} />
+                        <p className="mb-0 mt-3 text-sm leading-relaxed text-neutral-300">
+                            <span className="font-medium text-neutral-300">Verify:</span> {setupClient.verify}
+                        </p>
+                    </TabsContent>
+                ))}
+                </Tabs>
+                <p className="mb-0 mt-4 text-sm leading-relaxed text-neutral-300">
+                Connecting to a preview deployment? Previews need one extra header —{' '}
+                <Link
+                    href={`${advancedPath}#preview-deployments`}
+                    className="text-dark-accent no-underline hover:underline"
+                >
+                    see preview deployments
+                </Link>
+                .
+                </p>
+            </DocCard>
+
+            {/* Agent instructions */}
+            <SectionTitle subtitle="Teach the agent to reach for the Explorer instead of guessing — add the block below to the instructions file your tool reads.">
+                Agent instructions
+            </SectionTitle>
+            <DocCard className="mb-12 overflow-hidden">
+                <ul className="m-0 flex list-none flex-col gap-1 p-4 text-sm text-neutral-300 sm:p-6">
+                    {AGENT_INSTRUCTIONS_TARGETS.map(target => (
+                        <li key={target.file}>
+                            <InlineCode>{target.file}</InlineCode>
+                            <span className="text-neutral-500"> — {target.tool}</span>
+                        </li>
+                    ))}
+                </ul>
+                {/* Snippet as the card's bottom segment behind a full-width divider (no nested card). */}
+                <div className="border-0 border-t border-solid border-white/10">
+                    <CodeBlock variant="flush" code={AGENT_INSTRUCTIONS_SNIPPET} />
+                </div>
+            </DocCard>
+
+            {/* Examples */}
+            <SectionTitle subtitle="How a conversation with a connected agent actually looks.">Examples</SectionTitle>
+            <ExamplesCarousel />
+
+            {/* Advanced catalog */}
+            <SectionTitle subtitle="Operational and reference chunks on the advanced page — each card says who it is for and what it gives.">
+                Going deeper
+            </SectionTitle>
+            <div className="grid gap-3 sm:grid-cols-2">
+                {ADVANCED_CHUNKS.map(chunk => (
+                    <Link
+                        key={chunk.anchor}
+                        href={`${advancedPath}#${chunk.anchor}`}
+                        className="group no-underline"
+                    >
+                        <DocCard transparent className="h-full transition-colors group-hover:border-dark-accent">
+                            <div className="flex h-full flex-col p-4 sm:p-6">
+                                <div className="mb-2 flex items-center justify-between gap-2">
+                                    <span className="text-base font-medium text-white">{chunk.title}</span>
+                                    <ArrowRight
+                                        size={14}
+                                        aria-hidden
+                                        className="shrink-0 text-neutral-600 transition-colors group-hover:text-dark-accent"
+                                    />
+                                </div>
+                                <div className="text-sm leading-relaxed text-neutral-400">{chunk.gives}</div>
+                                <div className="mt-auto self-start pt-3">
+                                    {/* No outline variant in the tw Badge set — transparent + inline border (cn keeps conflicting border-color classes). */}
+                                    <Badge
+                                        variant="transparent"
+                                        size="xs"
+                                        style={{ border: '1px solid rgba(255, 255, 255, 0.2)' }}
+                                    >
+                                        {chunk.audience}
+                                    </Badge>
+                                </div>
+                            </div>
+                        </DocCard>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function SectionTitle({ children, id, subtitle }: { children: React.ReactNode; id?: string; subtitle?: string }) {
+    return (
+        <div className="mb-5 scroll-mt-6" id={id}>
+            <h2 className="m-0 text-2xl font-semibold text-white">{children}</h2>
+            {subtitle && <p className="mb-0 mt-1.5 text-sm text-neutral-300">{subtitle}</p>}
+        </div>
+    );
+}
+
+const EXAMPLE_ROTATION_MS = 6000;
+
+/**
+ * Chat-app layout: example titles as a "chat list" beside a vertical divider,
+ * the selected conversation on the right. Auto-advances; hover pauses; a click
+ * selects. Conversations are stacked in one grid cell so the card keeps the
+ * height of the tallest one.
+ */
+function ExamplesCarousel() {
+    const [index, setIndex] = useState(0);
+    const [paused, setPaused] = useState(false);
+
+    useEffect(() => {
+        if (paused) {
+            return;
+        }
+        const timer = setInterval(() => setIndex(current => (current + 1) % EXAMPLES.length), EXAMPLE_ROTATION_MS);
+        return () => clearInterval(timer);
+        // `index` restarts the timer after a manual selection so the next auto-advance waits a full period.
+    }, [paused, index]);
+
+    return (
+        <DocCard
+            className="mb-12 overflow-hidden"
+            onMouseEnter={() => setPaused(true)}
+            onMouseLeave={() => setPaused(false)}
+        >
+            <div className="flex flex-col sm:flex-row">
+                {/* Chat list */}
+                <div
+                    role="tablist"
+                    aria-label="Examples"
+                    className="flex shrink-0 flex-col border-0 border-b border-solid border-white/10 py-2.5 sm:w-52 sm:border-b-0 sm:border-r sm:py-3"
+                >
+                    {EXAMPLES.map((example, exampleIndex) => {
+                        const active = exampleIndex === index;
+                        return (
+                            <button
+                                key={example.label}
+                                type="button"
+                                role="tab"
+                                aria-selected={active}
+                                onClick={() => setIndex(exampleIndex)}
+                                className={cn(
+                                    'cursor-pointer border-0 bg-transparent px-4 py-2.5 text-left text-sm sm:py-3',
+                                    'border-solid transition-colors',
+                                    // Active marker: left bar, both in the stacked (mobile) and the sidebar (desktop) list.
+                                    'border-l-2',
+                                    active
+                                        ? 'border-dark-accent bg-heavy-metal-900 text-white'
+                                        : 'border-transparent text-neutral-400 hover:bg-heavy-metal-900 hover:text-neutral-200',
+                                )}
+                            >
+                                {example.label}
+                            </button>
+                        );
+                    })}
+                </div>
+
+                {/* Conversation view */}
+                <div className="grid min-w-0 grow">
+                    {EXAMPLES.map((example, exampleIndex) => {
+                        const active = exampleIndex === index;
+                        return (
+                            <div
+                                key={example.label}
+                                aria-hidden={!active}
+                                className={cn(
+                                    'col-start-1 row-start-1 flex flex-col justify-end gap-2 p-4 transition-opacity duration-500 sm:p-6',
+                                    active ? 'opacity-100' : 'pointer-events-none opacity-0',
+                                )}
+                            >
+                                <div className="max-w-[85%] self-end rounded-2xl rounded-br-md bg-heavy-metal-700 px-4 py-2.5 text-sm leading-relaxed text-white">
+                                    {example.question}
+                                </div>
+                                <div className="flex items-center gap-1.5 self-start px-1 text-xs text-neutral-500">
+                                    <Tool size={12} aria-hidden />
+                                    <span>
+                                        Ran <span className="font-mono text-neutral-400">{example.tool}</span> ·
+                                        Explorer MCP
+                                    </span>
+                                </div>
+                                <div className="max-w-[85%] self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-heavy-metal-900 px-4 py-2.5 text-sm leading-relaxed text-neutral-300">
+                                    {example.answer}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </DocCard>
+    );
+}
+
+function HeroFact({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex min-w-0 flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-neutral-500">{label}</span>
+            <span className="truncate text-sm text-neutral-200">{children}</span>
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -15,6 +15,7 @@ import { ADVANCED_CHUNKS } from '../lib/advanced-chunks';
 import { AGENT_INSTRUCTIONS_SNIPPET, AGENT_INSTRUCTIONS_TARGETS, SETUP_CLIENTS } from '../lib/setup-clients';
 import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
 import { CodeBlock } from './CodeBlock';
+import { CopyableEndpoint } from './CopyableEndpoint';
 import { DocCard } from './DocCard';
 import { InlineCode } from './DocSection';
 
@@ -109,7 +110,7 @@ export function McpDocsOverviewView() {
             <DocCard transparent className="mb-12">
                 <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
                     <HeroFact label="Endpoint">
-                        <span className="font-mono text-xs">{origin}/mcp</span>
+                        <CopyableEndpoint url={`${origin}/mcp`} />
                     </HeroFact>
                     <HeroFact label="Transport">
                         <span className="font-mono text-xs">Streamable HTTP, stateless</span>

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -1,31 +1,31 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Check, Copy, Minus, Plus, Tool, X, XCircle } from 'react-feather';
+import { ExternalLink, Minus, Plus, Tool } from 'react-feather';
 
 import { Button } from '@/app/components/shared/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
 import { cn } from '@/app/components/shared/utils';
-import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
 
 import { AGENT_INSTRUCTIONS_SNIPPET, AGENT_INSTRUCTIONS_TARGETS, SETUP_CLIENTS_OPEN } from '../lib/setup-clients';
 import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
 import { CodeBlock } from './CodeBlock';
-import { CopyableEndpoint } from './CopyableEndpoint';
 import { DocCard } from './DocCard';
 import { InlineCode } from './DocSection';
 
 /** Table inside an example answer, mirroring the tables the agent printed. */
 function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
     return (
-        <div className="overflow-x-auto">
+        // The rounded outer border lives on the wrapper (kept intact by the scroll container's clipping); cells
+        // draw only the inner grid lines, so no border is lost at the corners.
+        <div className="overflow-x-auto rounded-lg border border-solid border-white/10">
             <table className="w-full border-collapse text-xs">
                 <thead>
                     <tr>
                         {head.map(title => (
                             <th
                                 key={title}
-                                className="border border-solid border-white/10 px-2.5 py-1.5 text-left font-medium text-neutral-400"
+                                className="border-0 border-b border-r border-solid border-white/10 px-2.5 py-1.5 text-left font-medium text-neutral-400 last:border-r-0"
                             >
                                 {title}
                             </th>
@@ -38,7 +38,7 @@ function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
                             {row.map(cell => (
                                 <td
                                     key={cell}
-                                    className="border border-solid border-white/10 px-2.5 py-1.5 align-top text-neutral-300 [overflow-wrap:anywhere]"
+                                    className="border-0 border-r border-t border-solid border-white/10 px-2.5 py-1.5 align-top text-neutral-300 [overflow-wrap:anywhere] last:border-r-0"
                                 >
                                     {cell}
                                 </td>
@@ -250,7 +250,6 @@ export function McpDocsOverviewViewV2() {
     const origin = useDeploymentOrigin();
     const [client, setClient] = useState(SETUP_CLIENTS_OPEN[0].id);
     const [status, setStatus] = useState<EndpointStatus>({ state: 'checking' });
-    const [showHowToRun, setShowHowToRun] = useState(false);
 
     // Live health probe: any non-503 answer from /mcp means the endpoint is up.
     useEffect(() => {
@@ -290,27 +289,32 @@ export function McpDocsOverviewViewV2() {
             <DocCard transparent className="mb-12">
                 <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
                     <HeroFact label="Status">
-                        <StatusValue status={status} onShowHowToRun={() => setShowHowToRun(true)} />
+                        <StatusValue status={status} />
                     </HeroFact>
                     <HeroFact label="Endpoint">
-                        <CopyableEndpoint url={`${origin}/mcp`} />
+                        <a
+                            href={`${origin}/mcp`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-sm text-dark-accent no-underline"
+                        >
+                            {`${origin}/mcp`}
+                            <ExternalLink size={12} aria-hidden />
+                        </a>
                     </HeroFact>
                     <HeroFact label="Transport">
-                        <span className="font-mono text-xs">Streamable HTTP, stateless</span>
+                        <span className="text-sm">Streamable HTTP, stateless</span>
                     </HeroFact>
                     <HeroFact label="Auth">
-                        <span className="font-mono text-xs">Open — no key required</span>
+                        <span className="text-sm">Open — no key required</span>
                     </HeroFact>
                     <HeroFact label="Clusters">
-                        <span className="font-mono text-xs">mainnet-beta · devnet · testnet · simd296</span>
+                        <span className="text-sm">mainnet-beta · devnet · testnet · simd296</span>
                     </HeroFact>
                     <HeroFact label="Tools">
-                        <span className="font-mono text-xs">inspect_entity · ping</span>
+                        <span className="text-sm">inspect_entity · ping</span>
                     </HeroFact>
                 </div>
-                {status.state === 'disabled' && showHowToRun && (
-                    <HowToRunHint origin={origin} onClose={() => setShowHowToRun(false)} />
-                )}
             </DocCard>
 
             {/* Setup */}
@@ -514,80 +518,7 @@ function ToolParam({ name, required, children }: { name: string; required?: bool
     );
 }
 
-/** Prompt for a coding agent that enables the endpoint — mirrors the steps shown in the hint. */
-function buildHowToRunPrompt(origin: string): string {
-    return [
-        `Enable the MCP endpoint of this Solana Explorer deployment (${origin}). The /mcp route answers 503 until it is explicitly enabled; all MCP configuration is environment-only (see .env.example).`,
-        '',
-        '1. Set MCP_ENDPOINT_ENABLED=true in the deployment environment — anything else keeps the endpoint disabled.',
-        '2. Optionally set MCP_ACCESS_KEYS (comma-separated bearer keys; unset means open access) and MCP_BLOCKED_IPS (comma-separated IPs rejected with 403).',
-        '3. The variables are read once at startup: on Vercel add them in Project Settings → Environment Variables and redeploy; for a local checkout put them in .env.local and restart the dev server.',
-        `4. Verify: GET ${origin}/mcp must stop answering 503, and an MCP client pointed at ${origin}/mcp should list the inspect_entity and ping tools.`,
-    ].join('\n');
-}
-
-/** Shown only when the live probe actually got a 503 (or could not reach /mcp at all). */
-function HowToRunHint({ onClose, origin }: { onClose: () => void; origin: string }) {
-    const [copyState, copy] = useCopyToClipboard(1000);
-
-    const copyIcon = {
-        copied: <Check size={14} aria-hidden />,
-        copy: <Copy size={14} aria-hidden />,
-        errored: <XCircle size={14} aria-hidden />,
-    }[copyState];
-
-    return (
-        <div className="border-0 border-t border-solid border-white/10 p-4 sm:p-6">
-            <div className="mb-3 flex items-center justify-between gap-2">
-                <h3 className="m-0 text-sm font-medium text-white">How to run</h3>
-                <button
-                    type="button"
-                    aria-label="Close"
-                    onClick={onClose}
-                    className="flex cursor-pointer rounded border-0 bg-transparent p-1 text-neutral-500 hover:bg-heavy-metal-800 hover:text-neutral-200"
-                >
-                    <X size={14} aria-hidden />
-                </button>
-            </div>
-            <p className="mb-3 mt-0 text-sm leading-relaxed text-neutral-300">
-                The endpoint is opt-in by design — this deployment keeps <InlineCode>/mcp</InlineCode> answering{' '}
-                <InlineCode>503</InlineCode> until it is enabled explicitly:
-            </p>
-            <ol className="m-0 flex list-none flex-col gap-1.5 p-0 text-sm leading-relaxed text-neutral-300">
-                <li>
-                    1. Set <InlineCode>MCP_ENDPOINT_ENABLED=true</InlineCode> in the deployment environment — anything
-                    else keeps the endpoint disabled. All MCP configuration is environment-only (see{' '}
-                    <InlineCode>.env.example</InlineCode>).
-                </li>
-                <li>
-                    2. Optionally set <InlineCode>MCP_ACCESS_KEYS</InlineCode> (comma-separated bearer keys; unset means
-                    open access) and <InlineCode>MCP_BLOCKED_IPS</InlineCode>.
-                </li>
-                <li>
-                    3. The variables are read once at startup: on Vercel add them in Project Settings → Environment
-                    Variables and redeploy; locally put them in <InlineCode>.env.local</InlineCode> and restart the dev
-                    server.
-                </li>
-                <li>4. Reload this page — Status flips to Ready.</li>
-            </ol>
-            <button
-                type="button"
-                onClick={() => copy(buildHowToRunPrompt(origin))}
-                className={cn(
-                    'mt-4 flex cursor-pointer items-center gap-1.5 rounded border border-solid border-white/10 bg-transparent px-2.5 py-1.5',
-                    'text-xs font-medium text-neutral-200 hover:bg-heavy-metal-800',
-                    copyState === 'copied' && 'text-dark-accent',
-                    copyState === 'errored' && 'text-red-500',
-                )}
-            >
-                {copyIcon}
-                {copyState === 'copied' ? 'Copied' : 'Copy prompt'}
-            </button>
-        </div>
-    );
-}
-
-function StatusValue({ onShowHowToRun, status }: { onShowHowToRun: () => void; status: EndpointStatus }) {
+function StatusValue({ status }: { status: EndpointStatus }) {
     if (status.state === 'checking') {
         return <span className="text-neutral-500">Checking…</span>;
     }
@@ -596,13 +527,15 @@ function StatusValue({ onShowHowToRun, status }: { onShowHowToRun: () => void; s
             <span className="flex items-center gap-1.5">
                 <span className="size-1.5 rounded-full bg-neutral-500" aria-hidden />
                 Disabled
-                <button
-                    type="button"
-                    onClick={onShowHowToRun}
-                    className="cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:underline"
+                <a
+                    href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-dark-accent no-underline"
                 >
                     How to run
-                </button>
+                    <ExternalLink size={12} aria-hidden />
+                </a>
             </span>
         );
     }
@@ -746,7 +679,9 @@ function ExamplesCarousel() {
                                                 setExpanded(true);
                                                 setEngaged(true);
                                             }}
-                                            className="cursor-pointer self-start border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:underline"
+                                            // Match the link hover: `<a>` darkens via the global `a:hover`
+                                            // (#2b8a6e); a `<button>` isn't covered by it, so set it explicitly.
+                                            className="cursor-pointer self-start border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:text-[#2b8a6e]"
                                         >
                                             Expand message
                                         </button>
@@ -764,7 +699,7 @@ function ExamplesCarousel() {
 function HeroFact({ label, children }: { label: string; children: React.ReactNode }) {
     return (
         <div className="flex min-w-0 flex-col gap-1">
-            <span className="text-xs uppercase tracking-wide text-neutral-500">{label}</span>
+            <span className="text-sm uppercase tracking-wide text-neutral-500">{label}</span>
             <span className="truncate text-sm text-neutral-200">{children}</span>
         </div>
     );

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -1,0 +1,469 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Minus, Plus, Tool } from 'react-feather';
+
+import { Button } from '@/app/components/shared/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
+import { cn } from '@/app/components/shared/utils';
+
+import { AGENT_INSTRUCTIONS_SNIPPET, AGENT_INSTRUCTIONS_TARGETS, SETUP_CLIENTS_OPEN } from '../lib/setup-clients';
+import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
+import { CodeBlock } from './CodeBlock';
+import { DocCard } from './DocCard';
+import { InlineCode } from './DocSection';
+
+// Real entities only (customer feedback: "make the example actual examples").
+const EXAMPLES = [
+    {
+        answer: 'USDC — an spl-token:mint with 6 decimals and variable supply. The mint authority (BJE5MMbq…5ruG) is still active and a freeze authority (7dGbd2QZ…Crar) is set.',
+        label: 'Token mint',
+        question: 'What are the mint authority, supply and decimals of EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'SQDS4ep6…pCf is an upgradeable program (bpf-upgradeable-loader). The payload names its upgrade authority and last deploy slot, and reports the on-chain Anchor IDL it publishes.',
+        label: 'Program inspection',
+        question: 'Inspect SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf — is it upgradeable and does it publish an IDL?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'Every instruction comes back decoded — program name, typed args and accounts — with inner instructions nested under their parent. Programs publishing an on-chain IDL decode through it; token instructions decode through bundled parsers; the rest stay labeled raw.',
+        label: 'Transaction walkthrough',
+        question:
+            'Walk me through this transaction signature instruction by instruction, including inner instructions.',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: 'The mint payload lists each parsed Token-2022 extension with its current config and its authority, so you can tell which knobs are still live and who holds them.',
+        label: 'Token-2022 extensions',
+        question: 'Which Token-2022 extensions are enabled on this mint, and who can still change them?',
+        tool: 'inspect_entity',
+    },
+];
+
+const INSPECT_ENTITY_COVERS = [
+    'SPL Token and Token-2022 mints, token accounts and multisigs, including parsed Token-2022 extensions.',
+    'Upgradeable programs — upgradeability, upgrade authority, last deploy slot and on-chain IDL discovery.',
+    'Stake, vote, nonce, sysvar, config, address lookup table and feature accounts.',
+    'Compressed NFTs, nftoken accounts and Solana Attestation Service accounts.',
+    'Transactions — signers, fee, status and instructions with inner instructions, decoded through IDL, bundled and raw sources.',
+    'Accounts of unrecognised programs, decoded through the owner program’s on-chain IDL when it publishes one.',
+];
+
+// A real reply: USDC mint on mainnet-beta.
+const INSPECT_ENTITY_RESPONSE = `{
+    "payload": {
+        "entity": {
+            "kind": "spl-token:mint",
+            "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "decimals": 6,
+            "freeze_authority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
+            "is_initialized": true,
+            "mint_authority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
+            "supply": "7902797573976355",
+            "supply_type": "variable",
+            "token_program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+    },
+    "errors": []
+}`;
+
+type EndpointStatus = { state: 'checking' | 'ready' | 'disabled'; ms?: number };
+
+export function McpDocsOverviewViewV2() {
+    const origin = useDeploymentOrigin();
+    const [client, setClient] = useState(SETUP_CLIENTS_OPEN[0].id);
+    const [status, setStatus] = useState<EndpointStatus>({ state: 'checking' });
+
+    // Live health probe: any non-503 answer from /mcp means the endpoint is up.
+    useEffect(() => {
+        const started = performance.now();
+        fetch('/mcp')
+            .then(response =>
+                setStatus({
+                    ms: Math.round(performance.now() - started),
+                    state: response.status === 503 ? 'disabled' : 'ready',
+                }),
+            )
+            .catch(() => setStatus({ state: 'disabled' }));
+    }, []);
+
+    return (
+        <div className="mx-auto w-full max-w-3xl px-4 py-10">
+            {/* Hero */}
+            <h1 className="mb-4 mt-0 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                Live on-chain data for coding agents
+            </h1>
+            <p className="mb-6 mt-0 text-lg leading-relaxed text-neutral-300">
+                Connect your MCP client to the Explorer and let your agent read decoded on-chain state — accounts,
+                programs, tokens and transactions — with the same IDL decoding and enrichments the Explorer renders.
+            </p>
+            <div className="mb-8 flex flex-wrap gap-3">
+                <Button asChild variant="accent" size="lg" style={{ paddingInline: '1rem' }}>
+                    <a href="#setup" className="no-underline">
+                        Set up your agent
+                    </a>
+                </Button>
+                <Button asChild variant="outline" size="lg" style={{ paddingInline: '1rem' }}>
+                    <a href="#tools" className="no-underline">
+                        Browse the tools
+                    </a>
+                </Button>
+            </div>
+            <DocCard transparent className="mb-12">
+                <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
+                    <HeroFact label="Status">
+                        <StatusValue status={status} />
+                    </HeroFact>
+                    <HeroFact label="Endpoint">
+                        <span className="font-mono text-xs">{origin}/mcp</span>
+                    </HeroFact>
+                    <HeroFact label="Transport">
+                        <span className="font-mono text-xs">Streamable HTTP, stateless</span>
+                    </HeroFact>
+                    <HeroFact label="Auth">
+                        <span className="font-mono text-xs">Open — no key required</span>
+                    </HeroFact>
+                    <HeroFact label="Clusters">
+                        <span className="font-mono text-xs">mainnet-beta · devnet · testnet · simd296</span>
+                    </HeroFact>
+                    <HeroFact label="Tools">
+                        <span className="font-mono text-xs">inspect_entity · ping</span>
+                    </HeroFact>
+                </div>
+            </DocCard>
+
+            {/* Setup */}
+            <SectionTitle
+                id="setup"
+                subtitle="Pick your tool, copy the config — snippets already point at this deployment. No API key needed."
+            >
+                Setup
+            </SectionTitle>
+            <DocCard className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+                <Tabs value={client} onValueChange={setClient}>
+                    <TabsList
+                        style={{ display: 'flex' }}
+                        className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
+                    >
+                        {SETUP_CLIENTS_OPEN.map(({ id, label }) => (
+                            <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
+                                {label}
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+                    {SETUP_CLIENTS_OPEN.map(setupClient => (
+                        <TabsContent key={setupClient.id} value={setupClient.id}>
+                            <p className="mb-3 mt-0 text-sm text-neutral-300">{setupClient.where}</p>
+                            <CodeBlock code={setupClient.snippet(origin)} />
+                            <p className="mb-0 mt-3 text-sm leading-relaxed text-neutral-300">
+                                <span className="font-medium text-neutral-300">Verify:</span> {setupClient.verify}
+                            </p>
+                        </TabsContent>
+                    ))}
+                </Tabs>
+            </DocCard>
+
+            {/* Agent instructions */}
+            <SectionTitle subtitle="Teach the agent to reach for the Explorer instead of guessing — add the block below to the instructions file your tool reads.">
+                Agent instructions
+            </SectionTitle>
+            <DocCard className="mb-12 overflow-hidden">
+                <p className="m-0 p-4 text-sm text-neutral-300 sm:p-6">
+                    {AGENT_INSTRUCTIONS_TARGETS.map((target, index) => (
+                        <React.Fragment key={target.file}>
+                            {index > 0 && <span className="text-neutral-500"> / </span>}
+                            <InlineCode>{target.file}</InlineCode>
+                        </React.Fragment>
+                    ))}
+                </p>
+                {/* Snippet as the card's bottom segment behind a full-width divider (no nested card). */}
+                <div className="border-0 border-t border-solid border-white/10">
+                    <CodeBlock variant="flush" code={AGENT_INSTRUCTIONS_SNIPPET} />
+                </div>
+            </DocCard>
+
+            {/* Tools */}
+            <SectionTitle
+                id="tools"
+                subtitle="The server registers two tools. Both are read-only — nothing signs, sends or mutates."
+            >
+                Tools
+            </SectionTitle>
+            <ToolsShowcase />
+
+            {/* Examples */}
+            <SectionTitle subtitle="Things worth asking once the server is connected.">Examples</SectionTitle>
+            <ExamplesCarousel />
+        </div>
+    );
+}
+
+const TOOL_NAMES = ['inspect_entity', 'ping'] as const;
+
+/** Tool reference behind the same underline-tab navigation as the Setup card. */
+function ToolsShowcase() {
+    const [tool, setTool] = useState<string>(TOOL_NAMES[0]);
+
+    return (
+        <DocCard className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+            <Tabs value={tool} onValueChange={setTool}>
+                <TabsList
+                    style={{ display: 'flex' }}
+                    className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
+                >
+                    {TOOL_NAMES.map(name => (
+                        <TabsTrigger key={name} value={name} className="shrink-0 whitespace-nowrap font-mono">
+                            {name}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+                <TabsContent value="inspect_entity">
+                    <InspectEntityDoc />
+                </TabsContent>
+                <TabsContent value="ping">
+                    <PingDoc />
+                </TabsContent>
+            </Tabs>
+        </DocCard>
+    );
+}
+
+function InspectEntityDoc() {
+    return (
+        <div>
+            <p className="m-0 text-base leading-relaxed text-neutral-300">
+                Retrieves detailed on-chain data for any Solana address or transaction signature. The tool detects which
+                one it was given.
+            </p>
+
+            <ToolDocDivider />
+            <ToolDocSection title="What it covers" defaultOpen={false}>
+                <ul className="m-0 mt-3 flex list-none flex-col gap-1.5 p-0 text-sm leading-relaxed text-neutral-300">
+                    {INSPECT_ENTITY_COVERS.map(item => (
+                        <li key={item} className="flex gap-2">
+                            <span className="mt-[7px] size-1 shrink-0 rounded-full bg-neutral-600" aria-hidden />
+                            <span>{item}</span>
+                        </li>
+                    ))}
+                </ul>
+            </ToolDocSection>
+
+            <ToolDocDivider />
+            <ToolDocSection title="Request parameters">
+                <div className="mt-3 flex flex-col gap-3">
+                    <ToolParam name="identifier" required>
+                        A base58 string, 1–128 characters: a 32-byte account address or a 64-byte transaction signature.
+                    </ToolParam>
+                    <ToolParam name="cluster">
+                        One of <InlineCode>mainnet-beta</InlineCode>, <InlineCode>devnet</InlineCode>,{' '}
+                        <InlineCode>testnet</InlineCode>, <InlineCode>simd296</InlineCode>. Defaults to{' '}
+                        <InlineCode>mainnet-beta</InlineCode>.
+                    </ToolParam>
+                </div>
+            </ToolDocSection>
+
+            <ToolDocDivider />
+            <ToolDocSection title="Response">
+                <div className="mt-3">
+                    <CodeBlock code={INSPECT_ENTITY_RESPONSE} />
+                    <p className="mb-0 mt-4 text-sm leading-relaxed text-neutral-300">
+                        Accounts owned by the legacy loaders are not supported yet and answer with a{' '}
+                        <InlineCode>CURRENTLY_UNSUPPORTED</InlineCode> error. Fields that cannot be resolved come back
+                        as explicit unknown markers rather than being dropped.
+                    </p>
+                </div>
+            </ToolDocSection>
+        </div>
+    );
+}
+
+/** Collapsible tool-doc section: heading with the +/- right after it, framed by the dividers. */
+function ToolDocSection({
+    children,
+    defaultOpen = true,
+    title,
+}: {
+    children: React.ReactNode;
+    defaultOpen?: boolean;
+    title: string;
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+
+    return (
+        <div>
+            <button
+                type="button"
+                aria-expanded={open}
+                onClick={() => setOpen(current => !current)}
+                className="group flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left"
+            >
+                <h4 className="m-0 text-sm font-medium text-white">{title}</h4>
+                <span className="text-neutral-500 transition-colors group-hover:text-dark-accent">
+                    {open ? <Minus size={14} aria-hidden /> : <Plus size={14} aria-hidden />}
+                </span>
+            </button>
+            {open && children}
+        </div>
+    );
+}
+
+/** Full-bleed rule between the tool-doc sections (compensates the card padding). */
+function ToolDocDivider() {
+    return <div className="-mx-4 my-4 border-0 border-t border-solid border-white/10 sm:-mx-6" />;
+}
+
+function PingDoc() {
+    return (
+        <p className="m-0 text-base leading-relaxed text-neutral-300">
+            Basic health tool. Takes no arguments and answers <InlineCode>pong</InlineCode>. Ask the agent to call it to
+            verify the connection end-to-end.
+        </p>
+    );
+}
+
+function ToolParam({ name, required, children }: { name: string; required?: boolean; children: React.ReactNode }) {
+    return (
+        <div>
+            <div className="flex items-baseline gap-2">
+                <InlineCode>{name}</InlineCode>
+                <span className="text-xs text-neutral-500">{required ? 'required' : 'optional'}</span>
+            </div>
+            <p className="mb-0 mt-1.5 text-sm leading-relaxed text-neutral-300">{children}</p>
+        </div>
+    );
+}
+
+function StatusValue({ status }: { status: EndpointStatus }) {
+    if (status.state === 'checking') {
+        return <span className="text-neutral-500">Checking…</span>;
+    }
+    if (status.state === 'disabled') {
+        return (
+            <span className="flex items-center gap-1.5">
+                <span className="size-1.5 rounded-full bg-neutral-500" aria-hidden />
+                Disabled
+            </span>
+        );
+    }
+    return (
+        <span className="flex items-center gap-1.5">
+            <span className="size-1.5 rounded-full bg-dark-accent" aria-hidden />
+            Ready{status.ms !== undefined && <span className="text-neutral-500">· {status.ms} ms</span>}
+        </span>
+    );
+}
+
+function SectionTitle({ children, id, subtitle }: { children: React.ReactNode; id?: string; subtitle?: string }) {
+    return (
+        <div className="mb-5 scroll-mt-6" id={id}>
+            <h2 className="m-0 text-2xl font-semibold text-white">{children}</h2>
+            {subtitle && <p className="mb-0 mt-1.5 text-sm text-neutral-300">{subtitle}</p>}
+        </div>
+    );
+}
+
+const EXAMPLE_ROTATION_MS = 6000;
+
+/**
+ * Chat-app layout: example titles as a "chat list" beside a vertical divider,
+ * the selected conversation on the right. Auto-advances; hover pauses; a click
+ * selects. Conversations are stacked in one grid cell so the card keeps the
+ * height of the tallest one.
+ */
+function ExamplesCarousel() {
+    const [index, setIndex] = useState(0);
+    const [paused, setPaused] = useState(false);
+
+    useEffect(() => {
+        if (paused) {
+            return;
+        }
+        const timer = setInterval(() => setIndex(current => (current + 1) % EXAMPLES.length), EXAMPLE_ROTATION_MS);
+        return () => clearInterval(timer);
+        // `index` restarts the timer after a manual selection so the next auto-advance waits a full period.
+    }, [paused, index]);
+
+    return (
+        <DocCard
+            transparent
+            className="mb-12 overflow-hidden"
+            onMouseEnter={() => setPaused(true)}
+            onMouseLeave={() => setPaused(false)}
+        >
+            <div className="flex flex-col sm:flex-row">
+                {/* Chat list */}
+                <div
+                    role="tablist"
+                    aria-label="Examples"
+                    className="flex shrink-0 flex-col border-0 border-b border-solid border-white/10 py-2.5 sm:w-52 sm:border-b-0 sm:border-r sm:py-3"
+                >
+                    {EXAMPLES.map((example, exampleIndex) => {
+                        const active = exampleIndex === index;
+                        return (
+                            <button
+                                key={example.label}
+                                type="button"
+                                role="tab"
+                                aria-selected={active}
+                                onClick={() => setIndex(exampleIndex)}
+                                className={cn(
+                                    'cursor-pointer border-0 bg-transparent px-4 py-2.5 text-left text-sm sm:py-3',
+                                    'border-solid transition-colors',
+                                    // Active marker: left bar, both in the stacked (mobile) and the sidebar (desktop) list.
+                                    'border-l-2',
+                                    active
+                                        ? 'border-dark-accent bg-heavy-metal-900 text-white'
+                                        : 'border-transparent text-neutral-400 hover:bg-heavy-metal-900 hover:text-neutral-200',
+                                )}
+                            >
+                                {example.label}
+                            </button>
+                        );
+                    })}
+                </div>
+
+                {/* Conversation view */}
+                <div className="grid min-w-0 grow">
+                    {EXAMPLES.map((example, exampleIndex) => {
+                        const active = exampleIndex === index;
+                        return (
+                            <div
+                                key={example.label}
+                                aria-hidden={!active}
+                                className={cn(
+                                    'col-start-1 row-start-1 flex flex-col justify-end gap-2 p-4 transition-opacity duration-500 sm:p-6',
+                                    active ? 'opacity-100' : 'pointer-events-none opacity-0',
+                                )}
+                            >
+                                <div className="max-w-[85%] self-end rounded-2xl rounded-br-md border border-solid border-white/10 bg-white/10 px-4 py-2.5 text-sm leading-relaxed text-white">
+                                    {example.question}
+                                </div>
+                                <div className="flex items-center gap-1.5 self-start px-1 text-xs text-neutral-500">
+                                    <Tool size={12} aria-hidden />
+                                    <span>
+                                        Ran <span className="font-mono text-neutral-400">{example.tool}</span> ·
+                                        Explorer MCP
+                                    </span>
+                                </div>
+                                <div className="max-w-[85%] self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-white/5 px-4 py-2.5 text-sm leading-relaxed text-neutral-300">
+                                    {example.answer}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </DocCard>
+    );
+}
+
+function HeroFact({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex min-w-0 flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-neutral-500">{label}</span>
+            <span className="truncate text-sm text-neutral-200">{children}</span>
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -55,6 +55,19 @@ function useStickyRelease(tailPx = 320) {
     return { sectionRef, stripRef };
 }
 
+// On tab switch, pull the section's top up to the top of the window — but only if it has scrolled above the
+// viewport (you're inside/past the section). If the section top is still at or below the viewport top (you're
+// above it), leave the scroll alone. Uses `window.scrollTo` (not `scrollIntoView`, which wouldn't move the
+// page here) and defers a frame so it lands after the tab click's own focus-into-view scroll.
+function scrollSectionToTop(el: HTMLElement | null) {
+    if (!el) return;
+    requestAnimationFrame(() => {
+        const rectTop = el.getBoundingClientRect().top;
+        if (rectTop >= 0) return;
+        window.scrollTo({ behavior: 'instant', top: window.scrollY + rectTop });
+    });
+}
+
 /** Table inside an example answer, mirroring the tables the agent printed. */
 function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
     return (
@@ -372,11 +385,18 @@ export function McpDocsOverviewViewV2() {
                 Setup
             </SectionTitle>
             <DocCard ref={setupSticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
-                <Tabs value={client} onValueChange={setClient}>
+                <Tabs
+                    value={client}
+                    onValueChange={value => {
+                        setClient(value);
+                        // Switching tabs resets scroll to the top of the (possibly shorter/taller) new panel.
+                        scrollSectionToTop(setupSticky.sectionRef.current);
+                    }}
+                >
                     <TabsList
                         ref={setupSticky.stripRef}
                         style={{ display: 'flex' }}
-                        className="sticky top-0 z-10 -mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6"
+                        className="sticky top-0 z-10 -mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 [scrollbar-width:none] sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6 [&::-webkit-scrollbar]:hidden"
                     >
                         {SETUP_CLIENTS_OPEN.map(({ id, label }) => (
                             <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
@@ -446,11 +466,18 @@ function ToolsShowcase() {
 
     return (
         <DocCard ref={sticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
-            <Tabs value={tool} onValueChange={setTool}>
+            <Tabs
+                value={tool}
+                onValueChange={value => {
+                    setTool(value);
+                    // Switching tabs resets scroll to the top of the new panel.
+                    scrollSectionToTop(sticky.sectionRef.current);
+                }}
+            >
                 <TabsList
                     ref={sticky.stripRef}
                     style={{ display: 'flex' }}
-                    className="sticky top-0 z-10 -mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6"
+                    className="sticky top-0 z-10 -mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 [scrollbar-width:none] sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6 [&::-webkit-scrollbar]:hidden"
                 >
                     {TOOL_NAMES.map(name => (
                         <TabsTrigger key={name} value={name} className="shrink-0 whitespace-nowrap">
@@ -672,7 +699,7 @@ function ExamplesCarousel() {
                     role="tablist"
                     aria-label="Examples"
                     className={cn(
-                        'sticky top-0 z-10 flex shrink-0 flex-row gap-x-5 overflow-x-auto rounded-t-[11px] border-0 border-b border-solid border-white/10 bg-dark-background px-4',
+                        'sticky top-0 z-10 flex shrink-0 flex-row gap-x-5 overflow-x-auto rounded-t-[11px] border-0 border-b border-solid border-white/10 bg-dark-background px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
                         'sm:static sm:z-auto sm:w-52 sm:flex-col sm:gap-x-0 sm:overflow-visible sm:rounded-none sm:border-b-0 sm:border-r sm:bg-transparent sm:px-0 sm:py-3',
                     )}
                 >
@@ -689,6 +716,8 @@ function ExamplesCarousel() {
                                     // Re-selecting the current chat won't change `index` — collapse explicitly.
                                     setExpanded(false);
                                     setEngaged(true);
+                                    // Switching chats resets scroll to the top of the new conversation.
+                                    scrollSectionToTop(sticky.sectionRef.current);
                                 }}
                                 className={cn(
                                     'cursor-pointer whitespace-nowrap border-0 bg-transparent px-0 py-4 text-left text-sm transition-colors sm:px-4 sm:py-3',

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -296,10 +296,14 @@ export function McpDocsOverviewViewV2() {
                             href={`${origin}/mcp`}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-sm text-dark-accent no-underline"
+                            className="text-sm text-dark-accent no-underline [overflow-wrap:anywhere]"
                         >
                             {`${origin}/mcp`}
-                            <ExternalLink size={12} aria-hidden />
+                            <ExternalLink
+                                size={12}
+                                aria-hidden
+                                className="relative -top-0.5 ml-1 inline align-text-bottom"
+                            />
                         </a>
                     </HeroFact>
                     <HeroFact label="Transport">
@@ -700,7 +704,7 @@ function HeroFact({ label, children }: { label: string; children: React.ReactNod
     return (
         <div className="flex min-w-0 flex-col gap-1">
             <span className="text-sm uppercase tracking-wide text-neutral-500">{label}</span>
-            <span className="truncate text-sm text-neutral-200">{children}</span>
+            <span className="text-sm text-neutral-200">{children}</span>
         </div>
     );
 }

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -389,6 +389,12 @@ export function McpDocsOverviewViewV2() {
 
 const TOOL_NAMES = ['inspect_entity', 'ping'] as const;
 
+// Tab labels: plain words, capitalised. The tab `value` stays the raw tool name (it keys the panels).
+const TOOL_LABELS: Record<(typeof TOOL_NAMES)[number], string> = {
+    inspect_entity: 'Inspect entity',
+    ping: 'Ping',
+};
+
 /** Tool reference behind the same underline-tab navigation as the Setup card. */
 function ToolsShowcase() {
     const [tool, setTool] = useState<string>(TOOL_NAMES[0]);
@@ -401,8 +407,8 @@ function ToolsShowcase() {
                     className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
                 >
                     {TOOL_NAMES.map(name => (
-                        <TabsTrigger key={name} value={name} className="shrink-0 whitespace-nowrap font-mono">
-                            {name}
+                        <TabsTrigger key={name} value={name} className="shrink-0 whitespace-nowrap">
+                            {TOOL_LABELS[name]}
                         </TabsTrigger>
                     ))}
                 </TabsList>

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -1,43 +1,218 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { Minus, Plus, Tool } from 'react-feather';
+import React, { useEffect, useRef, useState } from 'react';
+import { Check, Copy, Minus, Plus, Tool, X, XCircle } from 'react-feather';
 
 import { Button } from '@/app/components/shared/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
 import { cn } from '@/app/components/shared/utils';
+import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
 
 import { AGENT_INSTRUCTIONS_SNIPPET, AGENT_INSTRUCTIONS_TARGETS, SETUP_CLIENTS_OPEN } from '../lib/setup-clients';
 import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
 import { CodeBlock } from './CodeBlock';
+import { CopyableEndpoint } from './CopyableEndpoint';
 import { DocCard } from './DocCard';
 import { InlineCode } from './DocSection';
 
-// Real entities only (customer feedback: "make the example actual examples").
-const EXAMPLES = [
+/** Table inside an example answer, mirroring the tables the agent printed. */
+function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-xs">
+                <thead>
+                    <tr>
+                        {head.map(title => (
+                            <th
+                                key={title}
+                                className="border border-solid border-white/10 px-2.5 py-1.5 text-left font-medium text-neutral-400"
+                            >
+                                {title}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map(row => (
+                        <tr key={row[0]}>
+                            {row.map(cell => (
+                                <td
+                                    key={cell}
+                                    className="border border-solid border-white/10 px-2.5 py-1.5 align-top text-neutral-300 [overflow-wrap:anywhere]"
+                                >
+                                    {cell}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+/** Bold intra-answer heading, standing in for the terminal's highlighted lines. */
+function AnswerHeading({ children }: { children: React.ReactNode }) {
+    return <p className="m-0 font-medium text-white">{children}</p>;
+}
+
+// Real conversations with a coding agent connected to this MCP server, shortened
+// without losing the facts; the long tails sit in `more` behind "Expand message".
+const EXAMPLES: { answer: React.ReactNode; label: string; more?: React.ReactNode; question: string; tool: string }[] = [
     {
-        answer: 'USDC — an spl-token:mint with 6 decimals and variable supply. The mint authority (BJE5MMbq…5ruG) is still active and a freeze authority (7dGbd2QZ…Crar) is set.',
+        answer: (
+            <>
+                <p className="m-0">{'USDC (EPjFWdd5...) — SPL Token mint on mainnet-beta:'}</p>
+                <AnswerTable
+                    head={['Field', 'Value']}
+                    rows={[
+                        ['Mint authority', 'BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG'],
+                        ['Supply', '7748676460441051 raw → 7,748,676,460.441051 USDC'],
+                        ['Decimals', '6'],
+                    ]}
+                />
+                <p className="m-0">
+                    {
+                        'Supply is variable (mint authority present); freeze authority is 7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar.'
+                    }
+                </p>
+            </>
+        ),
         label: 'Token mint',
         question: 'What are the mint authority, supply and decimals of EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v?',
         tool: 'inspect_entity',
     },
     {
-        answer: 'SQDS4ep6…pCf is an upgradeable program (bpf-upgradeable-loader). The payload names its upgrade authority and last deploy slot, and reports the on-chain Anchor IDL it publishes.',
+        answer: (
+            <>
+                <p className="m-0">
+                    {'Squads Multisig Program (SQDS4ep65T...) — BPF upgradeable-loader program on mainnet-beta.'}
+                </p>
+                <p className="m-0">
+                    {
+                        'Upgradeable: no — upgrade_authority: null, the authority was revoked, so the program is frozen. Last deployed at slot 302582236; executable data lives at Fy3YMJCvwbAXUgUM5b91ucUVA3jYzwWLHL3MwBqKsh8n.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'IDL: yes — published on-chain via Anchor, served as Codama, program name "Squads Multisig Program".'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'Extras: a verified build against Squads-Protocol/v4 @ 2a47b4c (signer sqdcVVoTcKZjXU8yPUwKFbGx1Hig1rhbWJQtMRXp2E1) and an embedded security.txt — audited by OtterSec and Neodyme, contact security@sqds.io.'
+                    }
+                </p>
+            </>
+        ),
         label: 'Program inspection',
         question: 'Inspect SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf — is it upgradeable and does it publish an IDL?',
         tool: 'inspect_entity',
     },
     {
-        answer: 'Every instruction comes back decoded — program name, typed args and accounts — with inner instructions nested under their parent. Programs publishing an on-chain IDL decode through it; token instructions decode through bundled parsers; the rest stay labeled raw.',
+        answer: (
+            <>
+                <p className="m-0">
+                    {
+                        'A v0 message, success, finalized at slot 439023338. One signer: EVybKZ6kp8CccQSkcAdfsstG5aX8mbQQC6jrKTcuFhVp. Fee 5000 lamports, CU consumed 67888; 53 accounts total, 34 pulled in from 5 address lookup tables.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'There are no inner instructions — anywhere: three invoke [1] lines in the logs and no [2] depth at all. That is the most interesting fact in this transaction.'
+                    }
+                </p>
+            </>
+        ),
         label: 'Transaction walkthrough',
+        more: (
+            <>
+                <AnswerHeading>Instruction 1 — ComputeBudget</AnswerHeading>
+                <p className="m-0">
+                    {
+                        'SetComputeUnitLimit, value 600,000. No SetComputeUnitPrice anywhere, so no priority fee — the 5000 lamport fee is base fee only.'
+                    }
+                </p>
+                <AnswerHeading>Instruction 2 — System transfer</AnswerHeading>
+                <p className="m-0">
+                    {
+                        'system::transfer, 1002 lamports from EVybKZ6k… (the signer) → Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY. Trivially small, and not a Jito tip pattern.'
+                    }
+                </p>
+                <AnswerHeading>
+                    Instruction 3 — unknown program 8GCr9711iFUmGdW4vPGoBYHoLEACKHKY8aycYNuxViXk
+                </AnswerHeading>
+                <p className="m-0">
+                    {
+                        'The whole payload of the transaction: 53 account references, 154 bytes of data, 67,588 CU consumed. Not decodable — the program is unverified and publishes no IDL (authority 2zYaeycd8jK1RjH9ZXLTHJp13xjmdC5FhPpSWtZrsXwp, deployed at slot 436916586), so the instruction stays raw.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'The account list still talks: LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo (Meteora DLMM), pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA (PumpSwap AMM) plus pfeeUxB6… (PumpSwap fee config), full token infra, and pool/vault-looking accounts from the lookup tables — a multi-venue swap router shape.'
+                    }
+                </p>
+                <AnswerHeading>The thing worth flagging</AnswerHeading>
+                <p className="m-0">
+                    {
+                        'A 53-account instruction touching two AMM programs issued zero CPIs — it burned 67.5k CU reading accounts and returned success without invoking Token, Meteora, or PumpSwap even once. The consistent read (inference, not proof) is an arbitrage/MEV bot: load candidate pools, compute profitability on-chain, exit cleanly when the opportunity is not there. For certainty you would need the program source or a dump of its executable data (FkFnystz3DzSqDr3o64nLsUkecA9dvd9nNTrHZZBCtwQ).'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'The 154-byte payload has no recognizable Anchor discriminator; two constants stand out — e8764817 = 390,000,000 (0.39 SOL if lamports) and a trailing f64 1.0, which reads like a threshold/slippage parameter.'
+                    }
+                </p>
+            </>
+        ),
         question:
-            'Walk me through this transaction signature instruction by instruction, including inner instructions.',
+            'Walk me through this transaction signature 3MVAxtaFp76y23DBd3MdXTEjpzH8zFtVB1HtVdYSKqZPpx1R9gEkDXCF9bX26vkAvyerz2K54eMCFF7cPpkzArM1 instruction by instruction, including inner instructions.',
         tool: 'inspect_entity',
     },
     {
-        answer: 'The mint payload lists each parsed Token-2022 extension with its current config and its authority, so you can tell which knobs are still live and who holds them.',
+        answer: (
+            <>
+                <p className="m-0">
+                    {
+                        '"Sent from my Pumpfun App" (App) — Token-2022 mint, 6 decimals, supply 912,905,455.031061 App, fixed.'
+                    }
+                </p>
+                <p className="m-0">{'Only two extensions, and nobody can change any of them:'}</p>
+                <AnswerTable
+                    head={['Extension', 'Current state', 'Who can change it']}
+                    rows={[
+                        ['metadataPointer', 'points at the mint itself', 'authority: null — nobody'],
+                        [
+                            'tokenMetadata',
+                            'name "Sent from my Pumpfun App", symbol "App", uri, no additional fields',
+                            'updateAuthority: null — nobody',
+                        ],
+                    ]}
+                />
+            </>
+        ),
         label: 'Token-2022 extensions',
-        question: 'Which Token-2022 extensions are enabled on this mint, and who can still change them?',
+        more: (
+            <>
+                <p className="m-0">
+                    {
+                        'Mint and freeze authorities are also null (supply_type: fixed), and the extensions that carry real issuer power are simply absent: no permanentDelegate, no transferHook, no transferFeeConfig, no confidential-transfer config. There is no key anywhere with authority over this mint.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'Two caveats before reading that as "safe": the on-chain metadata pointer is frozen, but it points at https://md.sdfgsdfsdf.uk/metadata/XGrhDXnd — whoever controls that domain can change the name, image and description at any time; and mint-level renunciation says nothing about liquidity or holder concentration — no authority to rug the mint ≠ no way to rug.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'Incidentally, this mint appeared in the transaction above — one of the read-only accounts pulled in from lookup table BMAAGcWbUNNVE15DpETYXBW7L1Ba4jqq1JywECkzNLSW in instruction 3, consistent with scanning pools for this token and finding nothing worth executing.'
+                    }
+                </p>
+            </>
+        ),
+        question:
+            'Which Token-2022 extensions are enabled on this mint 49nkLrXi8nCZBVKsShDNasEtPe4Vn1mx9Xbr3kTa8pTL, and who can still change them?',
         tool: 'inspect_entity',
     },
 ];
@@ -75,6 +250,7 @@ export function McpDocsOverviewViewV2() {
     const origin = useDeploymentOrigin();
     const [client, setClient] = useState(SETUP_CLIENTS_OPEN[0].id);
     const [status, setStatus] = useState<EndpointStatus>({ state: 'checking' });
+    const [showHowToRun, setShowHowToRun] = useState(false);
 
     // Live health probe: any non-503 answer from /mcp means the endpoint is up.
     useEffect(() => {
@@ -114,10 +290,10 @@ export function McpDocsOverviewViewV2() {
             <DocCard transparent className="mb-12">
                 <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
                     <HeroFact label="Status">
-                        <StatusValue status={status} />
+                        <StatusValue status={status} onShowHowToRun={() => setShowHowToRun(true)} />
                     </HeroFact>
                     <HeroFact label="Endpoint">
-                        <span className="font-mono text-xs">{origin}/mcp</span>
+                        <CopyableEndpoint url={`${origin}/mcp`} />
                     </HeroFact>
                     <HeroFact label="Transport">
                         <span className="font-mono text-xs">Streamable HTTP, stateless</span>
@@ -132,6 +308,9 @@ export function McpDocsOverviewViewV2() {
                         <span className="font-mono text-xs">inspect_entity · ping</span>
                     </HeroFact>
                 </div>
+                {status.state === 'disabled' && showHowToRun && (
+                    <HowToRunHint origin={origin} onClose={() => setShowHowToRun(false)} />
+                )}
             </DocCard>
 
             {/* Setup */}
@@ -335,7 +514,80 @@ function ToolParam({ name, required, children }: { name: string; required?: bool
     );
 }
 
-function StatusValue({ status }: { status: EndpointStatus }) {
+/** Prompt for a coding agent that enables the endpoint — mirrors the steps shown in the hint. */
+function buildHowToRunPrompt(origin: string): string {
+    return [
+        `Enable the MCP endpoint of this Solana Explorer deployment (${origin}). The /mcp route answers 503 until it is explicitly enabled; all MCP configuration is environment-only (see .env.example).`,
+        '',
+        '1. Set MCP_ENDPOINT_ENABLED=true in the deployment environment — anything else keeps the endpoint disabled.',
+        '2. Optionally set MCP_ACCESS_KEYS (comma-separated bearer keys; unset means open access) and MCP_BLOCKED_IPS (comma-separated IPs rejected with 403).',
+        '3. The variables are read once at startup: on Vercel add them in Project Settings → Environment Variables and redeploy; for a local checkout put them in .env.local and restart the dev server.',
+        `4. Verify: GET ${origin}/mcp must stop answering 503, and an MCP client pointed at ${origin}/mcp should list the inspect_entity and ping tools.`,
+    ].join('\n');
+}
+
+/** Shown only when the live probe actually got a 503 (or could not reach /mcp at all). */
+function HowToRunHint({ onClose, origin }: { onClose: () => void; origin: string }) {
+    const [copyState, copy] = useCopyToClipboard(1000);
+
+    const copyIcon = {
+        copied: <Check size={14} aria-hidden />,
+        copy: <Copy size={14} aria-hidden />,
+        errored: <XCircle size={14} aria-hidden />,
+    }[copyState];
+
+    return (
+        <div className="border-0 border-t border-solid border-white/10 p-4 sm:p-6">
+            <div className="mb-3 flex items-center justify-between gap-2">
+                <h3 className="m-0 text-sm font-medium text-white">How to run</h3>
+                <button
+                    type="button"
+                    aria-label="Close"
+                    onClick={onClose}
+                    className="flex cursor-pointer rounded border-0 bg-transparent p-1 text-neutral-500 hover:bg-heavy-metal-800 hover:text-neutral-200"
+                >
+                    <X size={14} aria-hidden />
+                </button>
+            </div>
+            <p className="mb-3 mt-0 text-sm leading-relaxed text-neutral-300">
+                The endpoint is opt-in by design — this deployment keeps <InlineCode>/mcp</InlineCode> answering{' '}
+                <InlineCode>503</InlineCode> until it is enabled explicitly:
+            </p>
+            <ol className="m-0 flex list-none flex-col gap-1.5 p-0 text-sm leading-relaxed text-neutral-300">
+                <li>
+                    1. Set <InlineCode>MCP_ENDPOINT_ENABLED=true</InlineCode> in the deployment environment — anything
+                    else keeps the endpoint disabled. All MCP configuration is environment-only (see{' '}
+                    <InlineCode>.env.example</InlineCode>).
+                </li>
+                <li>
+                    2. Optionally set <InlineCode>MCP_ACCESS_KEYS</InlineCode> (comma-separated bearer keys; unset means
+                    open access) and <InlineCode>MCP_BLOCKED_IPS</InlineCode>.
+                </li>
+                <li>
+                    3. The variables are read once at startup: on Vercel add them in Project Settings → Environment
+                    Variables and redeploy; locally put them in <InlineCode>.env.local</InlineCode> and restart the dev
+                    server.
+                </li>
+                <li>4. Reload this page — Status flips to Ready.</li>
+            </ol>
+            <button
+                type="button"
+                onClick={() => copy(buildHowToRunPrompt(origin))}
+                className={cn(
+                    'mt-4 flex cursor-pointer items-center gap-1.5 rounded border border-solid border-white/10 bg-transparent px-2.5 py-1.5',
+                    'text-xs font-medium text-neutral-200 hover:bg-heavy-metal-800',
+                    copyState === 'copied' && 'text-dark-accent',
+                    copyState === 'errored' && 'text-red-500',
+                )}
+            >
+                {copyIcon}
+                {copyState === 'copied' ? 'Copied' : 'Copy prompt'}
+            </button>
+        </div>
+    );
+}
+
+function StatusValue({ onShowHowToRun, status }: { onShowHowToRun: () => void; status: EndpointStatus }) {
     if (status.state === 'checking') {
         return <span className="text-neutral-500">Checking…</span>;
     }
@@ -344,6 +596,13 @@ function StatusValue({ status }: { status: EndpointStatus }) {
             <span className="flex items-center gap-1.5">
                 <span className="size-1.5 rounded-full bg-neutral-500" aria-hidden />
                 Disabled
+                <button
+                    type="button"
+                    onClick={onShowHowToRun}
+                    className="cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:underline"
+                >
+                    How to run
+                </button>
             </span>
         );
     }
@@ -368,31 +627,53 @@ const EXAMPLE_ROTATION_MS = 6000;
 
 /**
  * Chat-app layout: example titles as a "chat list" beside a vertical divider,
- * the selected conversation on the right. Auto-advances; hover pauses; a click
- * selects. Conversations are stacked in one grid cell so the card keeps the
- * height of the tallest one.
+ * the selected conversation on the right. Auto-advances; hovering the card
+ * pauses the rotation, and any tap/click (a chat or "Expand message") parks it
+ * until the section scrolls out of view — important on touch devices with no
+ * hover. Long conversations start collapsed behind "Expand message" and
+ * collapse again on every conversation change.
  */
 function ExamplesCarousel() {
     const [index, setIndex] = useState(0);
-    const [paused, setPaused] = useState(false);
+    const [hovered, setHovered] = useState(false);
+    const [engaged, setEngaged] = useState(false);
+    const [expanded, setExpanded] = useState(false);
+    const rootRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (paused) {
+        if (hovered || engaged) {
             return;
         }
         const timer = setInterval(() => setIndex(current => (current + 1) % EXAMPLES.length), EXAMPLE_ROTATION_MS);
         return () => clearInterval(timer);
-        // `index` restarts the timer after a manual selection so the next auto-advance waits a full period.
-    }, [paused, index]);
+        // `index` restarts the timer after an auto-advance so every conversation gets a full period.
+    }, [hovered, engaged, index]);
+
+    // Every newly shown conversation starts collapsed — including returning to one expanded before.
+    useEffect(() => setExpanded(false), [index]);
+
+    // A tap/click parks the rotation; leaving the viewport re-arms it.
+    useEffect(() => {
+        if (!engaged || rootRef.current === null) {
+            return;
+        }
+        const observer = new IntersectionObserver(([entry]) => {
+            if (!entry.isIntersecting) {
+                setEngaged(false);
+            }
+        });
+        observer.observe(rootRef.current);
+        return () => observer.disconnect();
+    }, [engaged]);
 
     return (
         <DocCard
             transparent
             className="mb-12 overflow-hidden"
-            onMouseEnter={() => setPaused(true)}
-            onMouseLeave={() => setPaused(false)}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
         >
-            <div className="flex flex-col sm:flex-row">
+            <div ref={rootRef} className="flex flex-col sm:flex-row">
                 {/* Chat list */}
                 <div
                     role="tablist"
@@ -407,7 +688,12 @@ function ExamplesCarousel() {
                                 type="button"
                                 role="tab"
                                 aria-selected={active}
-                                onClick={() => setIndex(exampleIndex)}
+                                onClick={() => {
+                                    setIndex(exampleIndex);
+                                    // Re-selecting the current chat won't change `index` — collapse explicitly.
+                                    setExpanded(false);
+                                    setEngaged(true);
+                                }}
                                 className={cn(
                                     'cursor-pointer border-0 bg-transparent px-4 py-2.5 text-left text-sm sm:py-3',
                                     'border-solid transition-colors',
@@ -424,8 +710,9 @@ function ExamplesCarousel() {
                     })}
                 </div>
 
-                {/* Conversation view */}
-                <div className="grid min-w-0 grow">
+                {/* Conversation view: the active conversation defines the height (no inner scroll);
+                    inactive ones sit absolutely on top of it, kept mounted for the cross-fade. */}
+                <div className="relative min-w-0 grow">
                     {EXAMPLES.map((example, exampleIndex) => {
                         const active = exampleIndex === index;
                         return (
@@ -433,11 +720,13 @@ function ExamplesCarousel() {
                                 key={example.label}
                                 aria-hidden={!active}
                                 className={cn(
-                                    'col-start-1 row-start-1 flex flex-col justify-end gap-2 p-4 transition-opacity duration-500 sm:p-6',
-                                    active ? 'opacity-100' : 'pointer-events-none opacity-0',
+                                    'flex flex-col gap-2 p-4 transition-opacity duration-500 sm:p-6',
+                                    active
+                                        ? 'opacity-100'
+                                        : 'pointer-events-none absolute inset-0 overflow-hidden opacity-0',
                                 )}
                             >
-                                <div className="max-w-[85%] self-end rounded-2xl rounded-br-md border border-solid border-white/10 bg-white/10 px-4 py-2.5 text-sm leading-relaxed text-white">
+                                <div className="max-w-[85%] self-end rounded-2xl rounded-br-md border border-solid border-white/10 bg-white/10 px-4 py-2.5 text-sm leading-relaxed text-white [overflow-wrap:anywhere]">
                                     {example.question}
                                 </div>
                                 <div className="flex items-center gap-1.5 self-start px-1 text-xs text-neutral-500">
@@ -447,8 +736,21 @@ function ExamplesCarousel() {
                                         Explorer MCP
                                     </span>
                                 </div>
-                                <div className="max-w-[85%] self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-white/5 px-4 py-2.5 text-sm leading-relaxed text-neutral-300">
+                                <div className="flex max-w-[85%] flex-col gap-3 self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-white/5 px-4 py-2.5 text-sm leading-relaxed text-neutral-300 [overflow-wrap:anywhere]">
                                     {example.answer}
+                                    {expanded && example.more}
+                                    {example.more !== undefined && !expanded && (
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setExpanded(true);
+                                                setEngaged(true);
+                                            }}
+                                            className="cursor-pointer self-start border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:underline"
+                                        >
+                                            Expand message
+                                        </button>
+                                    )}
                                 </div>
                             </div>
                         );

--- a/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewViewV2.tsx
@@ -13,6 +13,48 @@ import { CodeBlock } from './CodeBlock';
 import { DocCard } from './DocCard';
 import { InlineCode } from './DocSection';
 
+// Mobile-only sticky tab strip. While scrolling a section its tab strip pins to the top of the window; once
+// less than `tailPx` is left below the strip to the section's end, it detaches and scrolls away — kept
+// `position: sticky` but with `top` driven negative, so it re-pins on the way back up and its
+// box/width/horizontal-scroll are preserved. Desktop (>= sm) leaves the strip static.
+function useStickyRelease(tailPx = 320) {
+    const sectionRef = useRef<HTMLDivElement | null>(null);
+    const stripRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 575.98px)');
+        let raf = 0;
+        const update = () => {
+            raf = 0;
+            const section = sectionRef.current;
+            const strip = stripRef.current;
+            if (!section || !strip) return;
+            if (!mq.matches) {
+                strip.style.top = '';
+                return;
+            }
+            const rect = section.getBoundingClientRect();
+            const threshold = tailPx + strip.offsetHeight;
+            strip.style.top = rect.bottom < threshold ? `${Math.round(rect.bottom - threshold)}px` : '0px';
+        };
+        const onScroll = () => {
+            if (!raf) raf = requestAnimationFrame(update);
+        };
+        update();
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        mq.addEventListener('change', onScroll);
+        return () => {
+            window.removeEventListener('scroll', onScroll);
+            window.removeEventListener('resize', onScroll);
+            mq.removeEventListener('change', onScroll);
+            if (raf) cancelAnimationFrame(raf);
+        };
+    }, [tailPx]);
+
+    return { sectionRef, stripRef };
+}
+
 /** Table inside an example answer, mirroring the tables the agent printed. */
 function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
     return (
@@ -250,6 +292,7 @@ export function McpDocsOverviewViewV2() {
     const origin = useDeploymentOrigin();
     const [client, setClient] = useState(SETUP_CLIENTS_OPEN[0].id);
     const [status, setStatus] = useState<EndpointStatus>({ state: 'checking' });
+    const setupSticky = useStickyRelease();
 
     // Live health probe: any non-503 answer from /mcp means the endpoint is up.
     useEffect(() => {
@@ -328,11 +371,12 @@ export function McpDocsOverviewViewV2() {
             >
                 Setup
             </SectionTitle>
-            <DocCard className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+            <DocCard ref={setupSticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
                 <Tabs value={client} onValueChange={setClient}>
                     <TabsList
+                        ref={setupSticky.stripRef}
                         style={{ display: 'flex' }}
-                        className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
+                        className="sticky top-0 z-10 -mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6"
                     >
                         {SETUP_CLIENTS_OPEN.map(({ id, label }) => (
                             <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
@@ -398,13 +442,15 @@ const TOOL_LABELS: Record<(typeof TOOL_NAMES)[number], string> = {
 /** Tool reference behind the same underline-tab navigation as the Setup card. */
 function ToolsShowcase() {
     const [tool, setTool] = useState<string>(TOOL_NAMES[0]);
+    const sticky = useStickyRelease();
 
     return (
-        <DocCard className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+        <DocCard ref={sticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
             <Tabs value={tool} onValueChange={setTool}>
                 <TabsList
+                    ref={sticky.stripRef}
                     style={{ display: 'flex' }}
-                    className="-mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto border-b border-white/10 px-4 sm:-mx-6 sm:px-6"
+                    className="sticky top-0 z-10 -mx-4 mb-4 flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6"
                 >
                     {TOOL_NAMES.map(name => (
                         <TabsTrigger key={name} value={name} className="shrink-0 whitespace-nowrap">
@@ -582,6 +628,7 @@ function ExamplesCarousel() {
     const [engaged, setEngaged] = useState(false);
     const [expanded, setExpanded] = useState(false);
     const rootRef = useRef<HTMLDivElement | null>(null);
+    const sticky = useStickyRelease();
 
     useEffect(() => {
         if (hovered || engaged) {
@@ -611,17 +658,23 @@ function ExamplesCarousel() {
 
     return (
         <DocCard
+            ref={sticky.sectionRef}
             transparent
-            className="mb-12 overflow-hidden"
+            className="mb-12"
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
         >
             <div ref={rootRef} className="flex flex-col sm:flex-row">
-                {/* Chat list */}
+                {/* Chat list — mobile: a sticky, horizontal, scrollable underline tab strip (like Setup/Tools);
+                    desktop: a static vertical sidebar with a left-bar active marker. */}
                 <div
+                    ref={sticky.stripRef}
                     role="tablist"
                     aria-label="Examples"
-                    className="flex shrink-0 flex-col border-0 border-b border-solid border-white/10 py-2.5 sm:w-52 sm:border-b-0 sm:border-r sm:py-3"
+                    className={cn(
+                        'sticky top-0 z-10 flex shrink-0 flex-row gap-x-5 overflow-x-auto rounded-t-[11px] border-0 border-b border-solid border-white/10 bg-dark-background px-4',
+                        'sm:static sm:z-auto sm:w-52 sm:flex-col sm:gap-x-0 sm:overflow-visible sm:rounded-none sm:border-b-0 sm:border-r sm:bg-transparent sm:px-0 sm:py-3',
+                    )}
                 >
                     {EXAMPLES.map((example, exampleIndex) => {
                         const active = exampleIndex === index;
@@ -638,13 +691,12 @@ function ExamplesCarousel() {
                                     setEngaged(true);
                                 }}
                                 className={cn(
-                                    'cursor-pointer border-0 bg-transparent px-4 py-2.5 text-left text-sm sm:py-3',
-                                    'border-solid transition-colors',
-                                    // Active marker: left bar, both in the stacked (mobile) and the sidebar (desktop) list.
-                                    'border-l-2',
+                                    'cursor-pointer whitespace-nowrap border-0 bg-transparent px-0 py-4 text-left text-sm transition-colors sm:px-4 sm:py-3',
+                                    // Active marker: underline on mobile, left bar on the desktop sidebar.
+                                    'border-b-2 border-solid sm:border-b-0 sm:border-l-2',
                                     active
-                                        ? 'border-dark-accent bg-heavy-metal-900 text-white'
-                                        : 'border-transparent text-neutral-400 hover:bg-heavy-metal-900 hover:text-neutral-200',
+                                        ? 'border-dark-accent text-white sm:bg-heavy-metal-900'
+                                        : 'border-transparent text-neutral-400 hover:text-neutral-200 sm:hover:bg-heavy-metal-900',
                                 )}
                             >
                                 {example.label}

--- a/app/features/mcp-docs/ui/VersionSwitcher.tsx
+++ b/app/features/mcp-docs/ui/VersionSwitcher.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React from 'react';
+
+import { cn } from '@/app/components/shared/utils';
+
+import type { McpDocsVersion } from '../lib/useMcpDocsVersion';
+
+const VERSIONS: McpDocsVersion[] = ['v1', 'v2'];
+
+/** Prototype toggle shown above the docs pages while the two variants coexist. */
+export function VersionSwitcher({
+    value,
+    onChange,
+}: {
+    value: McpDocsVersion;
+    onChange: (version: McpDocsVersion) => void;
+}) {
+    return (
+        <div className="flex items-center justify-end gap-2">
+            <span className="text-xs uppercase tracking-wide text-neutral-500">Version</span>
+            <div className="flex overflow-hidden rounded-lg border border-solid border-white/10">
+                {VERSIONS.map(version => (
+                    <button
+                        key={version}
+                        type="button"
+                        onClick={() => onChange(version)}
+                        className={cn(
+                            'cursor-pointer border-0 px-3 py-1 text-xs font-medium uppercase transition-colors',
+                            value === version
+                                ? 'bg-heavy-metal-800 text-white'
+                                : 'bg-transparent text-neutral-500 hover:text-neutral-200',
+                        )}
+                    >
+                        {version}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/app/mcp/docs/advanced/page-client.tsx
+++ b/app/mcp/docs/advanced/page-client.tsx
@@ -2,30 +2,27 @@
 
 import { useClusterPath } from '@utils/url';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
-import { McpDocsAdvancedView, useMcpDocsVersion, VersionSwitcher } from '@/app/features/mcp-docs';
+import { McpDocsAdvancedView, VersionSwitcher } from '@/app/features/mcp-docs';
 
+// The advanced reference is part of the hidden v1 prototype: nothing on the
+// shipped v2 page links here, and this page's hash is taken by its own section
+// anchors, so it renders unconditionally. The switcher only offers the way out.
 export default function McpDocsAdvancedPageClient() {
-    const [version, setVersion] = useMcpDocsVersion();
     const router = useRouter();
     const overviewPath = useClusterPath({ pathname: '/mcp/docs' });
-
-    // V2 has no advanced page — the tool reference lives on the overview.
-    useEffect(() => {
-        if (version === 'v2') {
-            router.replace(overviewPath);
-        }
-    }, [version, overviewPath, router]);
-
-    if (version === 'v2') {
-        return undefined;
-    }
 
     return (
         <>
             <div className="mx-auto w-full max-w-5xl px-4 pt-6">
-                <VersionSwitcher value={version} onChange={setVersion} />
+                <VersionSwitcher
+                    value="v1"
+                    onChange={version => {
+                        if (version === 'v2') {
+                            router.push(overviewPath);
+                        }
+                    }}
+                />
             </div>
             <McpDocsAdvancedView />
         </>

--- a/app/mcp/docs/advanced/page-client.tsx
+++ b/app/mcp/docs/advanced/page-client.tsx
@@ -1,7 +1,33 @@
 'use client';
 
-import { McpDocsAdvancedView } from '@/app/features/mcp-docs';
+import { useClusterPath } from '@utils/url';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { McpDocsAdvancedView, useMcpDocsVersion, VersionSwitcher } from '@/app/features/mcp-docs';
 
 export default function McpDocsAdvancedPageClient() {
-    return <McpDocsAdvancedView />;
+    const [version, setVersion] = useMcpDocsVersion();
+    const router = useRouter();
+    const overviewPath = useClusterPath({ pathname: '/mcp/docs' });
+
+    // V2 has no advanced page — the tool reference lives on the overview.
+    useEffect(() => {
+        if (version === 'v2') {
+            router.replace(overviewPath);
+        }
+    }, [version, overviewPath, router]);
+
+    if (version === 'v2') {
+        return undefined;
+    }
+
+    return (
+        <>
+            <div className="mx-auto w-full max-w-5xl px-4 pt-6">
+                <VersionSwitcher value={version} onChange={setVersion} />
+            </div>
+            <McpDocsAdvancedView />
+        </>
+    );
 }

--- a/app/mcp/docs/advanced/page-client.tsx
+++ b/app/mcp/docs/advanced/page-client.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { McpDocsAdvancedView } from '@/app/features/mcp-docs';
+
+export default function McpDocsAdvancedPageClient() {
+    return <McpDocsAdvancedView />;
+}

--- a/app/mcp/docs/advanced/page.tsx
+++ b/app/mcp/docs/advanced/page.tsx
@@ -1,0 +1,10 @@
+import McpDocsAdvancedPageClient from './page-client';
+
+export const metadata = {
+    description: `Explorer MCP advanced configuration and tool reference`,
+    title: `MCP Advanced | Solana`,
+};
+
+export default function McpDocsAdvancedPage() {
+    return <McpDocsAdvancedPageClient />;
+}

--- a/app/mcp/docs/page-client.tsx
+++ b/app/mcp/docs/page-client.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { McpDocsOverviewView } from '@/app/features/mcp-docs';
+
+export default function McpDocsPageClient() {
+    return <McpDocsOverviewView />;
+}

--- a/app/mcp/docs/page-client.tsx
+++ b/app/mcp/docs/page-client.tsx
@@ -1,7 +1,20 @@
 'use client';
 
-import { McpDocsOverviewView } from '@/app/features/mcp-docs';
+import {
+    McpDocsOverviewView,
+    McpDocsOverviewViewV2,
+    useMcpDocsVersion,
+    VersionSwitcher,
+} from '@/app/features/mcp-docs';
 
 export default function McpDocsPageClient() {
-    return <McpDocsOverviewView />;
+    const [version, setVersion] = useMcpDocsVersion();
+    return (
+        <>
+            <div className="mx-auto w-full max-w-3xl px-4 pt-6">
+                <VersionSwitcher value={version} onChange={setVersion} />
+            </div>
+            {version === 'v2' ? <McpDocsOverviewViewV2 /> : <McpDocsOverviewView />}
+        </>
+    );
 }

--- a/app/mcp/docs/page-client.tsx
+++ b/app/mcp/docs/page-client.tsx
@@ -9,12 +9,17 @@ import {
 
 export default function McpDocsPageClient() {
     const [version, setVersion] = useMcpDocsVersion();
-    return (
-        <>
-            <div className="mx-auto w-full max-w-3xl px-4 pt-6">
-                <VersionSwitcher value={version} onChange={setVersion} />
-            </div>
-            {version === 'v2' ? <McpDocsOverviewViewV2 /> : <McpDocsOverviewView />}
-        </>
-    );
+
+    // The v1 prototype is hidden behind the #v1 hash; only there does the switcher show up.
+    if (version === 'v1') {
+        return (
+            <>
+                <div className="mx-auto w-full max-w-3xl px-4 pt-6">
+                    <VersionSwitcher value={version} onChange={setVersion} />
+                </div>
+                <McpDocsOverviewView />
+            </>
+        );
+    }
+    return <McpDocsOverviewViewV2 />;
 }

--- a/app/mcp/docs/page.tsx
+++ b/app/mcp/docs/page.tsx
@@ -1,0 +1,10 @@
+import McpDocsPageClient from './page-client';
+
+export const metadata = {
+    description: `Connect AI coding agents to the Explorer MCP server`,
+    title: `MCP | Solana`,
+};
+
+export default function McpDocsPage() {
+    return <McpDocsPageClient />;
+}

--- a/docs/specs/mcp-docs-pages.md
+++ b/docs/specs/mcp-docs-pages.md
@@ -1,6 +1,6 @@
 ---
 feature: mcp-docs-pages
-status: building         # draft | approved | building | shipped
+status: building # draft | approved | building | shipped
 owner: Alexey Stulikov
 figma: n/a — visual reference is https://mcp.solana.com/ (sizes, accents, section order); styles come from the Explorer palette
 updated: 2026-08-12
@@ -14,11 +14,11 @@ The Explorer ships an MCP server (`/mcp`), but nothing in the product reveals it
 
 ## 2. Who this is for
 
-| Persona | Context | What they need from this flow |
-| --- | --- | --- |
-| AI-assisted developer | Uses Claude Code / Cursor / Codex / Windsurf / VS Code, wants on-chain data in their agent | Copy-paste setup for their client, agent-instructions block, understanding of what `inspect_entity` returns |
-| Deployment owner / ops | Runs an Explorer deployment, decides whether to expose MCP | Enabling steps, access control (keys, IP blocklist), RPC quota isolation, telemetry knobs — and why each exists |
-| Curious Explorer visitor | Landed from the header, does not know what MCP is | A fast answer to "what is this and is it for me" without reading a reference manual |
+| Persona                  | Context                                                                                    | What they need from this flow                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| AI-assisted developer    | Uses Claude Code / Cursor / Codex / Windsurf / VS Code, wants on-chain data in their agent | Copy-paste setup for their client, agent-instructions block, understanding of what `inspect_entity` returns     |
+| Deployment owner / ops   | Runs an Explorer deployment, decides whether to expose MCP                                 | Enabling steps, access control (keys, IP blocklist), RPC quota isolation, telemetry knobs — and why each exists |
+| Curious Explorer visitor | Landed from the header, does not know what MCP is                                          | A fast answer to "what is this and is it for me" without reading a reference manual                             |
 
 ## 3. What we're validating
 
@@ -46,11 +46,11 @@ The Explorer ships an MCP server (`/mcp`), but nothing in the product reveals it
 
 ## 5. Screens
 
-| # | Screen | Route | Reference | Status |
-| --- | --- | --- | --- | --- |
-| 1 | Header entry "MCP" | all pages (Navbar) | Feature Gates item as pattern | not started |
-| 2 | MCP overview | `/mcp/docs` | mcp.solana.com landing structure | not started |
-| 3 | MCP advanced reference | `/mcp/docs/advanced` | MCP-ADVANCED.md content | not started |
+| #   | Screen                 | Route                | Reference                        | Status      |
+| --- | ---------------------- | -------------------- | -------------------------------- | ----------- |
+| 1   | Header entry "MCP"     | all pages (Navbar)   | Feature Gates item as pattern    | not started |
+| 2   | MCP overview           | `/mcp/docs`          | mcp.solana.com landing structure | not started |
+| 3   | MCP advanced reference | `/mcp/docs/advanced` | MCP-ADVANCED.md content          | not started |
 
 ## 6. Primary flow map
 
@@ -80,11 +80,11 @@ flowchart TD
 
 Static content pages — no loading/empty/error states. The only stateful element is the per-client switcher in the overview's Setup section (Tabs candidate): one client's config visible at a time.
 
-| Screen | Loading | Empty | Error | Partial | Success |
-| --- | --- | --- | --- | --- | --- |
-| Header entry | n/a | n/a | n/a | n/a | active-state highlight on `/mcp/docs*` |
-| Overview | n/a (static) | n/a | n/a | n/a | rendered |
-| Advanced | n/a (static) | n/a | n/a | n/a | rendered, anchors resolvable |
+| Screen       | Loading      | Empty | Error | Partial | Success                                |
+| ------------ | ------------ | ----- | ----- | ------- | -------------------------------------- |
+| Header entry | n/a          | n/a   | n/a   | n/a     | active-state highlight on `/mcp/docs*` |
+| Overview     | n/a (static) | n/a   | n/a   | n/a     | rendered                               |
+| Advanced     | n/a (static) | n/a   | n/a   | n/a     | rendered, anchors resolvable           |
 
 ## 9. Async and system sequence
 
@@ -92,11 +92,11 @@ Skipped — no async behavior; all content is static.
 
 ## 10. Data
 
-| Field | Type | Source in prototype | Notes |
-| --- | --- | --- | --- |
-| Page copy | static | `MCP.md` / `MCP-ADVANCED.md` drafts, hand-translated into TSX | TSX is the source of truth; the `.md` drafts stay out of the repo |
-| Endpoint URL in snippets | string, dynamic | `window.location.origin` on the client; `<deployment>` placeholder as SSR/no-JS fallback | Visitor sees a copy-ready config for the deployment they are on |
-| Client configs (5 tools) | static snippets | MCP.md Setup section | Copyable |
+| Field                    | Type            | Source in prototype                                                                      | Notes                                                             |
+| ------------------------ | --------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Page copy                | static          | `MCP.md` / `MCP-ADVANCED.md` drafts, hand-translated into TSX                            | TSX is the source of truth; the `.md` drafts stay out of the repo |
+| Endpoint URL in snippets | string, dynamic | `window.location.origin` on the client; `<deployment>` placeholder as SSR/no-JS fallback | Visitor sees a copy-ready config for the deployment they are on   |
+| Client configs (5 tools) | static snippets | MCP.md Setup section                                                                     | Copyable                                                          |
 
 **Fixture rule:** placeholder data only — snippets show `<key>` / `<deployment>`, never real access keys.
 
@@ -108,14 +108,14 @@ Skipped — no async behavior; all content is static.
 
 ## 12. Copy
 
-| Location | Text | Notes |
-| --- | --- | --- |
-| Navbar item | `MCP` | Final |
-| Overview title | `Explorer MCP` | |
-| Overview subtitle | `Live on-chain data for coding agents` | Mirrors MCP.md lead |
-| Chunk card, each | `<chunk title>` + one line "who it's for" + one line "what it gives" | Distilled from MCP-ADVANCED.md "why" notes |
-| Advanced title | `Advanced configuration & reference` | |
-| All content | English | Repo rule: everything user-facing in English |
+| Location          | Text                                                                 | Notes                                        |
+| ----------------- | -------------------------------------------------------------------- | -------------------------------------------- |
+| Navbar item       | `MCP`                                                                | Final                                        |
+| Overview title    | `Explorer MCP`                                                       |                                              |
+| Overview subtitle | `Live on-chain data for coding agents`                               | Mirrors MCP.md lead                          |
+| Chunk card, each  | `<chunk title>` + one line "who it's for" + one line "what it gives" | Distilled from MCP-ADVANCED.md "why" notes   |
+| Advanced title    | `Advanced configuration & reference`                                 |                                              |
+| All content       | English                                                              | Repo rule: everything user-facing in English |
 
 ## 13. Acceptance criteria
 
@@ -132,17 +132,17 @@ Skipped — no async behavior; all content is static.
 
 All resolved 2026-08-12:
 
-| # | Question | Decision |
-| --- | --- | --- |
-| 1 | Chunk presentation on the overview | Essentials (setup, agent instructions) inline and immediately visible; specific chunks as cards linking to `/mcp/docs/advanced#anchor` |
-| 2 | Content source | Hand-written TSX; `MCP.md`/`MCP-ADVANCED.md` remain uncommitted drafts |
-| 3 | Navbar label | `MCP` |
-| 4 | Cluster-aware paths | Yes — `useClusterPath`, consistent with Feature Gates and Inspector |
-| 5 | Deployment URL in snippets | Dynamic `window.location.origin`; `<deployment>` placeholder as SSR/no-JS fallback |
+| #   | Question                           | Decision                                                                                                                               |
+| --- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Chunk presentation on the overview | Essentials (setup, agent instructions) inline and immediately visible; specific chunks as cards linking to `/mcp/docs/advanced#anchor` |
+| 2   | Content source                     | Hand-written TSX; `MCP.md`/`MCP-ADVANCED.md` remain uncommitted drafts                                                                 |
+| 3   | Navbar label                       | `MCP`                                                                                                                                  |
+| 4   | Cluster-aware paths                | Yes — `useClusterPath`, consistent with Feature Gates and Inspector                                                                    |
+| 5   | Deployment URL in snippets         | Dynamic `window.location.origin`; `<deployment>` placeholder as SSR/no-JS fallback                                                     |
 
 ## 15. Changelog
 
-| Date | Change | Why |
-| --- | --- | --- |
-| 2026-08-12 | Initial draft | Bootstrap for HOO-1081 before implementation |
-| 2026-08-12 | Resolved all §14 questions; overview keeps essentials inline, specifics link to advanced; TSX content; dynamic host in snippets | Interview with owner |
+| Date       | Change                                                                                                                          | Why                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| 2026-08-12 | Initial draft                                                                                                                   | Bootstrap for HOO-1081 before implementation |
+| 2026-08-12 | Resolved all §14 questions; overview keeps essentials inline, specifics link to advanced; TSX content; dynamic host in snippets | Interview with owner                         |

--- a/docs/specs/mcp-docs-pages.md
+++ b/docs/specs/mcp-docs-pages.md
@@ -1,0 +1,148 @@
+---
+feature: mcp-docs-pages
+status: building         # draft | approved | building | shipped
+owner: Alexey Stulikov
+figma: n/a — visual reference is https://mcp.solana.com/ (sizes, accents, section order); styles come from the Explorer palette
+updated: 2026-08-12
+---
+
+# MCP docs pages — design spec
+
+## 1. Problem
+
+The Explorer ships an MCP server (`/mcp`), but nothing in the product reveals it exists: the endpoint returns bare JSON, and all setup/configuration knowledge lives in repo README files that neither agent users nor deployment owners ever see. There is no place to send a person who asks "how do I connect my agent to the Explorer?".
+
+## 2. Who this is for
+
+| Persona | Context | What they need from this flow |
+| --- | --- | --- |
+| AI-assisted developer | Uses Claude Code / Cursor / Codex / Windsurf / VS Code, wants on-chain data in their agent | Copy-paste setup for their client, agent-instructions block, understanding of what `inspect_entity` returns |
+| Deployment owner / ops | Runs an Explorer deployment, decides whether to expose MCP | Enabling steps, access control (keys, IP blocklist), RPC quota isolation, telemetry knobs — and why each exists |
+| Curious Explorer visitor | Landed from the header, does not know what MCP is | A fast answer to "what is this and is it for me" without reading a reference manual |
+
+## 3. What we're validating
+
+**Question:** Can a visitor tell within one screen who each documentation chunk is for and what it gives them — and reach the full chunk in one click/tap?
+**How we'll know:** every advanced chunk is represented on the main page by a summary (audience + benefit), and each summary leads to the concrete documentation (link to the advanced page section, or an expanding block) without dead ends.
+
+## 4. Scope
+
+**In scope**
+
+1. New header entry next to Feature Gates, active-state aware.
+2. Main page `/mcp/docs`: hero (what MCP gives), then the essential chunks **inline and immediately visible** (setup per client, agent instructions), then a catalog of the specific chunks — each card with "who needs it / what it gives" and a link to its advanced section.
+3. Advanced page `/mcp/docs/advanced`: the concrete documentation chunks (enabling & access control, RPC configuration, preview deployments, `inspect_entity` reference, output envelope & errors, telemetry, smoke test, architecture), each anchor-addressable.
+4. Tailwind styling using the Explorer's existing tokens and shared components only.
+
+**Out of scope (stub or omit)**
+
+1. Any change to the MCP endpoint itself (`app/mcp/route.ts`, `entity-inspector`).
+2. Search integration for docs content.
+3. Localization.
+
+**Explicitly deferred to production**
+
+1. Syntax highlighting for code blocks (plain `<pre>` styling first).
+
+## 5. Screens
+
+| # | Screen | Route | Reference | Status |
+| --- | --- | --- | --- | --- |
+| 1 | Header entry "MCP" | all pages (Navbar) | Feature Gates item as pattern | not started |
+| 2 | MCP overview | `/mcp/docs` | mcp.solana.com landing structure | not started |
+| 3 | MCP advanced reference | `/mcp/docs/advanced` | MCP-ADVANCED.md content | not started |
+
+## 6. Primary flow map
+
+```mermaid
+flowchart TD
+    A([Entry: header MCP item]) --> B[/mcp/docs overview/]
+    B --> C{What does the visitor want?}
+    C -->|Set up their agent| D[Setup section: pick client, copy config]
+    C -->|Understand a topic| E[Chunk catalog card]
+    E --> F[/mcp/docs/advanced#anchor/]
+    C -->|Just browsing| G[Highlights + examples]
+    D --> H([Exit: config pasted into their tool])
+    F --> I([Exit: topic read])
+```
+
+## 7. Alternate and failure paths
+
+```mermaid
+flowchart TD
+    A[Direct URL /mcp/docs/advanced] -->|no context| B[Advanced page header links back to overview]
+    C[Deep link with #anchor] --> D[Anchored section scrolled into view]
+    E[Mobile visitor] --> F[Header item inside burger menu]
+    G[Visitor hits /mcp directly] -->|JSON 503/401| H[Out of scope: endpoint behavior unchanged]
+```
+
+## 8. Screen states
+
+Static content pages — no loading/empty/error states. The only stateful element is the per-client switcher in the overview's Setup section (Tabs candidate): one client's config visible at a time.
+
+| Screen | Loading | Empty | Error | Partial | Success |
+| --- | --- | --- | --- | --- | --- |
+| Header entry | n/a | n/a | n/a | n/a | active-state highlight on `/mcp/docs*` |
+| Overview | n/a (static) | n/a | n/a | n/a | rendered |
+| Advanced | n/a (static) | n/a | n/a | n/a | rendered, anchors resolvable |
+
+## 9. Async and system sequence
+
+Skipped — no async behavior; all content is static.
+
+## 10. Data
+
+| Field | Type | Source in prototype | Notes |
+| --- | --- | --- | --- |
+| Page copy | static | `MCP.md` / `MCP-ADVANCED.md` drafts, hand-translated into TSX | TSX is the source of truth; the `.md` drafts stay out of the repo |
+| Endpoint URL in snippets | string, dynamic | `window.location.origin` on the client; `<deployment>` placeholder as SSR/no-JS fallback | Visitor sees a copy-ready config for the deployment they are on |
+| Client configs (5 tools) | static snippets | MCP.md Setup section | Copyable |
+
+**Fixture rule:** placeholder data only — snippets show `<key>` / `<deployment>`, never real access keys.
+
+## 11. Design system
+
+**Components reused:** `Navbar` primitives (`NavbarItem`, `NavbarLink`) for the header entry; `PageContainer` for page shell; `BaseCard` / `BaseCardSection` for chunk catalog cards and doc sections; `Tabs` (candidate for the per-client setup switcher); `ExpandInfoButton` (candidate for expanding chunks); `Copyable` for config snippets; `Table` for env-var and account-kind tables.
+**Components needed (new):** code block (styled `<pre>` with copy affordance — `Copyable` wraps inline values, multiline block needs a small wrapper); anchor-linked section heading for the advanced page.
+**Tokens missing for this design:** none expected — text/emphasis sizes mapped onto the existing `dk`-free Tailwind palette. Known constraint: Tailwind gradient utilities don't render in this app (no `@tailwind base`), so any mcp.solana.com-style gradient accent must be an inline `linear-gradient` or be dropped.
+
+## 12. Copy
+
+| Location | Text | Notes |
+| --- | --- | --- |
+| Navbar item | `MCP` | Final |
+| Overview title | `Explorer MCP` | |
+| Overview subtitle | `Live on-chain data for coding agents` | Mirrors MCP.md lead |
+| Chunk card, each | `<chunk title>` + one line "who it's for" + one line "what it gives" | Distilled from MCP-ADVANCED.md "why" notes |
+| Advanced title | `Advanced configuration & reference` | |
+| All content | English | Repo rule: everything user-facing in English |
+
+## 13. Acceptance criteria
+
+- [ ] Every screen in §5 exists and is reachable by clicking, not by URL editing
+- [ ] Every chunk of MCP-ADVANCED.md is represented on the overview with audience + benefit, and reachable in one click
+- [ ] Every terminal node in §6 and §7 is implemented
+- [ ] Works at 375px and 1280px (header entry included in the mobile burger)
+- [ ] Keyboard-navigable; visible focus states; anchors reachable by URL
+- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass
+- [ ] Only design tokens used — no hardcoded colors or spacing; no `dk`-tagged legacy styles
+- [ ] The question in §3 can be tested on a preview URL
+
+## 14. Open questions
+
+All resolved 2026-08-12:
+
+| # | Question | Decision |
+| --- | --- | --- |
+| 1 | Chunk presentation on the overview | Essentials (setup, agent instructions) inline and immediately visible; specific chunks as cards linking to `/mcp/docs/advanced#anchor` |
+| 2 | Content source | Hand-written TSX; `MCP.md`/`MCP-ADVANCED.md` remain uncommitted drafts |
+| 3 | Navbar label | `MCP` |
+| 4 | Cluster-aware paths | Yes — `useClusterPath`, consistent with Feature Gates and Inspector |
+| 5 | Deployment URL in snippets | Dynamic `window.location.origin`; `<deployment>` placeholder as SSR/no-JS fallback |
+
+## 15. Changelog
+
+| Date | Change | Why |
+| --- | --- | --- |
+| 2026-08-12 | Initial draft | Bootstrap for HOO-1081 before implementation |
+| 2026-08-12 | Resolved all §14 questions; overview keeps essentials inline, specifics link to advanced; TSX content; dynamic host in snippets | Interview with owner |

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,10 @@ const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    // Dev-only: allow the dev server to be reached from other devices on the LAN (Next 15+ otherwise
+    // rejects requests — including the HMR websocket — from non-localhost origins). Set DEV_ORIGIN to the
+    // Mac's LAN IP/host. Ignored in production.
+    allowedDevOrigins: process.env.DEV_ORIGIN ? [process.env.DEV_ORIGIN] : [],
     // Use separate build directory for dev server to avoid conflicts with production builds
     distDir: process.env.NODE_ENV === 'production' ? '.next' : '.next-dev',
     outputFileTracingRoot: projectRoot,


### PR DESCRIPTION
## Description

MCP documentation pages for the Explorer's MCP server. The trimmed v2 (shaped by customer feedback) is now the page everyone sees; the v1 prototype stays reachable only via `/mcp/docs#v1`.

- **Page header**: new `MCP` entry next to Feature Gates (cluster-aware).
- **`/mcp/docs`**: live endpoint status probe, endpoint as an external link with an icon (wraps to show the full URL), per-client setup snippets pointing at the current deployment, agent-instructions card, on-page tool reference (`inspect_entity`, `ping`).
- **Examples**: chat-style carousel of four real agent conversations, tables included; long answers behind "Expand message"; rotation pauses on hover and after any tap.
- **Mobile**: each section's tabs become a horizontal, scrollable strip that pins to the top while scrolling the section (releasing near its end); switching a tab scrolls to the top of the new panel.
- **Disabled state**: "How to run" links out to the MCP README.
- **v1 prototype**: hidden behind `/mcp/docs#v1` together with its advanced reference. Spec in `docs/specs/mcp-docs-pages.md`.

## Type of change

-   [x] Design update
-   [x] New feature

## Screenshots

TODO — add header before/after and documentation page screenshots before review.

## Testing

TODO — add localhost URL and steps before review.

## Related Issues

Linear: HOO-1081

## Checklist

-   [ ] My code follows the project's style guidelines
-   [ ] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
