### PR TITLE
feat(timestamp): reusable copyable timestamp with pinnable formats

### DIFF
--- a/app/components/shared/ui/timestamp.stories.tsx
+++ b/app/components/shared/ui/timestamp.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook-config/types';
 import type { ReactNode } from 'react';
-import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
+import { expect, screen, userEvent, within } from 'storybook/test';
 
 import { cn } from '@/app/components/shared/utils';
 import { RelativeBands } from '@/app/ui/RelativeBands';
@@ -32,16 +32,6 @@ export const Default: Story = {
     args: { unixTimestamp },
 };
 
-// Trigger renders in UTC instead of the viewer's local time.
-export const UtcTrigger: Story = {
-    args: { display: 'utc', unixTimestamp },
-};
-
-// The trigger label can be anything (e.g. a relative time); the dropdown is unchanged.
-export const CustomLabel: Story = {
-    args: { children: 'about 1 hour ago', unixTimestamp },
-};
-
 // Opens the dropdown and asserts the three copyable rows are present.
 export const OpenDropdown: Story = {
     args: { unixTimestamp },
@@ -53,19 +43,6 @@ export const OpenDropdown: Story = {
         expect(screen.getByText('Local')).toBeInTheDocument();
         expect(screen.getByText('Unix Timestamp')).toBeInTheDocument();
         expect(screen.getByText(String(unixTimestamp))).toBeInTheDocument();
-    },
-};
-
-// Pinning UTC in the dropdown flips the trigger to the UTC representation.
-export const PinDefault: Story = {
-    args: { unixTimestamp },
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-        await userEvent.click(canvas.getByRole('button'));
-        const pinUtc = await screen.findByRole('button', { name: 'Pin UTC as default' });
-        await userEvent.click(pinUtc);
-        // Trigger (in the canvas) now shows the UTC time (06:41:51 UTC), not the local zone.
-        await waitFor(() => expect(canvas.getByRole('button')).toHaveTextContent('06:41:51 UTC'));
     },
 };
 
@@ -111,30 +88,7 @@ export const InTransactionOverview: Story = {
     render: ({ unixTimestamp: ts }) => <TransactionOverviewSlice unixTimestamp={ts} />,
 };
 
-// Same slice pre-sized to a 375px phone (bsXs) — open it to check wrapping and the dropdown on mobile.
-export const InTransactionOverviewMobile: Story = {
-    args: { unixTimestamp },
-    globals: { viewport: { value: 'bsXs' } },
-    render: ({ unixTimestamp: ts }) => <TransactionOverviewSlice unixTimestamp={ts} />,
-};
-
 // One date per relative-time band, so every granularity (seconds … years) is visible at once.
 export const RelativeTimeBands: Story = {
     render: () => <RelativeBands />,
-};
-
-// Fifteen copies down a tall, scrollable page — open one near the top and one near the bottom
-// to see the dropdown flip its side (Radix collision handling) against the viewport edges.
-export const FifteenOnAPage: Story = {
-    args: { unixTimestamp },
-    render: ({ unixTimestamp: ts }) => (
-        <div className="flex flex-col gap-24 py-8">
-            {Array.from({ length: 15 }, (_, index) => index + 1).map(n => (
-                <div key={n} className="flex items-start gap-3">
-                    <span className="w-8 shrink-0 text-sm text-outer-space-300">#{n}</span>
-                    <Timestamp unixTimestamp={ts} />
-                </div>
-            ))}
-        </div>
-    ),
 };

--- a/app/components/shared/ui/timestamp.stories.tsx
+++ b/app/components/shared/ui/timestamp.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import type { ReactNode } from 'react';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
+
+import { cn } from '@/app/components/shared/utils';
+import { RelativeBands } from '@/app/ui/RelativeBands';
+
+import { Timestamp } from './timestamp';
+import { setPinnedTimestampDisplay } from './useTimestampDisplay';
+
+// 06:41:51 Aug 06, 2026 (UTC) — the values from the reference design.
+const unixTimestamp = 1785998511;
+
+const meta: Meta<typeof Timestamp> = {
+    argTypes: {
+        display: { control: 'inline-radio', options: ['relative', 'local', 'utc', 'unix'] },
+        unixTimestamp: { control: 'number' },
+    },
+    // The pinned representation is shared, persisted state — reset it so stories don't leak into each other.
+    beforeEach: () => {
+        setPinnedTimestampDisplay(undefined);
+    },
+    component: Timestamp,
+    tags: ['autodocs', 'test'],
+    title: 'Components/Shared/Timestamp',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: { unixTimestamp },
+};
+
+// Trigger renders in UTC instead of the viewer's local time.
+export const UtcTrigger: Story = {
+    args: { display: 'utc', unixTimestamp },
+};
+
+// The trigger label can be anything (e.g. a relative time); the dropdown is unchanged.
+export const CustomLabel: Story = {
+    args: { children: 'about 1 hour ago', unixTimestamp },
+};
+
+// Opens the dropdown and asserts the three copyable rows are present.
+export const OpenDropdown: Story = {
+    args: { unixTimestamp },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('button'));
+        // PopoverContent portals to document.body, so query the screen rather than the canvas.
+        expect(await screen.findByText('UTC')).toBeInTheDocument();
+        expect(screen.getByText('Local')).toBeInTheDocument();
+        expect(screen.getByText('Unix Timestamp')).toBeInTheDocument();
+        expect(screen.getByText(String(unixTimestamp))).toBeInTheDocument();
+    },
+};
+
+// Pinning UTC in the dropdown flips the trigger to the UTC representation.
+export const PinDefault: Story = {
+    args: { unixTimestamp },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('button'));
+        const pinUtc = await screen.findByRole('button', { name: 'Pin UTC as default' });
+        await userEvent.click(pinUtc);
+        // Trigger (in the canvas) now shows the UTC time (06:41:51 UTC), not the local zone.
+        await waitFor(() => expect(canvas.getByRole('button')).toHaveTextContent('06:41:51 UTC'));
+    },
+};
+
+// A faithful slice of the transaction Overview card (app/features/transaction/ui/SummaryCard.tsx):
+// same responsive grid rows, with the two legacy "Timestamp (Local)" / "Timestamp (UTC)" rows
+// collapsed into a single clickable Timestamp. Rendered here to check the fit — especially on mobile.
+function OverviewRow({ label, children, divider = true }: { label: string; children: ReactNode; divider?: boolean }) {
+    return (
+        <div
+            className={cn(
+                'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
+                divider && 'border-b border-solid border-white/10',
+            )}
+        >
+            <div className="flex flex-wrap items-center gap-1 overflow-hidden text-sm text-outer-space-300">
+                {label}
+            </div>
+            <div className="break-all font-mono text-sm text-white">{children}</div>
+        </div>
+    );
+}
+
+function TransactionOverviewSlice({ unixTimestamp: ts }: { unixTimestamp: number }) {
+    return (
+        <div className="max-w-xl overflow-hidden rounded-lg border border-solid border-outer-space-800">
+            <OverviewRow label="Signature">
+                5Nf3xW8pQ7mKd2rBvLhTq9YzJ4cHs6UgAe1oPnR8tXwVbM3kD7yFjZ2uNqW5aCgE9iShL4rT6xUvB1nYmK
+            </OverviewRow>
+            <OverviewRow label="Block">312049876</OverviewRow>
+            <OverviewRow label="Timestamp">
+                <Timestamp unixTimestamp={ts} />
+            </OverviewRow>
+            <OverviewRow label="Fee" divider={false}>
+                0.000005 SOL
+            </OverviewRow>
+        </div>
+    );
+}
+
+// How the component sits inside the transaction Overview table.
+export const InTransactionOverview: Story = {
+    args: { unixTimestamp },
+    render: ({ unixTimestamp: ts }) => <TransactionOverviewSlice unixTimestamp={ts} />,
+};
+
+// Same slice pre-sized to a 375px phone (bsXs) — open it to check wrapping and the dropdown on mobile.
+export const InTransactionOverviewMobile: Story = {
+    args: { unixTimestamp },
+    globals: { viewport: { value: 'bsXs' } },
+    render: ({ unixTimestamp: ts }) => <TransactionOverviewSlice unixTimestamp={ts} />,
+};
+
+// One date per relative-time band, so every granularity (seconds … years) is visible at once.
+export const RelativeTimeBands: Story = {
+    render: () => <RelativeBands />,
+};
+
+// Fifteen copies down a tall, scrollable page — open one near the top and one near the bottom
+// to see the dropdown flip its side (Radix collision handling) against the viewport edges.
+export const FifteenOnAPage: Story = {
+    args: { unixTimestamp },
+    render: ({ unixTimestamp: ts }) => (
+        <div className="flex flex-col gap-24 py-8">
+            {Array.from({ length: 15 }, (_, index) => index + 1).map(n => (
+                <div key={n} className="flex items-start gap-3">
+                    <span className="w-8 shrink-0 text-sm text-outer-space-300">#{n}</span>
+                    <Timestamp unixTimestamp={ts} />
+                </div>
+            ))}
+        </div>
+    ),
+};

--- a/app/components/shared/ui/timestamp.tsx
+++ b/app/components/shared/ui/timestamp.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import * as React from 'react';
+import { CheckCircle, ChevronDown, Copy, Star, XCircle } from 'react-feather';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/app/components/shared/ui/popover';
+import {
+    setPinnedTimestampDisplay,
+    type TimestampDisplay,
+    usePinnedTimestampDisplay,
+} from '@/app/components/shared/ui/useTimestampDisplay';
+import { cn } from '@/app/components/shared/utils';
+import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
+import { displayTimestampAbsolute, displayTimestampRelative } from '@/app/utils/date';
+
+export interface TimestampProps {
+    /** Unix timestamp in seconds (e.g. a block's `blockTime`). */
+    unixTimestamp: number;
+    /** Fallback representation for the trigger when nothing is pinned. Defaults to local time. */
+    display?: TimestampDisplay;
+    /** Overrides the trigger label; the chevron is always appended. */
+    children?: React.ReactNode;
+    /** Fixed "now" (ms) for the relative label. Omit to use the live clock; supply it to freeze
+     *  the relative value (deterministic demos/tests, or one shared clock across many instances). */
+    referenceMs?: number;
+    className?: string;
+}
+
+// Copy affordance built directly on the dk-free useCopyToClipboard hook so the component
+// stays entirely on Tailwind/design-system tokens (the shared Copyable emits text-dk-* colors).
+function CopyButton({ text }: { text: string }) {
+    const [state, copy] = useCopyToClipboard(1000);
+    const Icon = state === 'copied' ? CheckCircle : state === 'errored' ? XCircle : Copy;
+    const color =
+        state === 'copied'
+            ? 'text-success-400'
+            : state === 'errored'
+              ? 'text-red-400'
+              : 'text-neutral-500 hover:text-neutral-200';
+    return (
+        <button
+            type="button"
+            onClick={() => copy(text)}
+            title="Copy"
+            className={cn('flex cursor-pointer items-center border-0 bg-transparent p-0', color)}
+        >
+            <Icon size={14} />
+        </button>
+    );
+}
+
+// One row of the dropdown: label + value, plus pin and copy affordances on the right.
+function TimestampRow({
+    label,
+    value,
+    isPinned,
+    onTogglePin,
+    withSeparator,
+}: {
+    label: string;
+    value: string;
+    isPinned: boolean;
+    onTogglePin: () => void;
+    withSeparator: boolean;
+}) {
+    return (
+        <div
+            className={cn(
+                'flex items-start justify-between gap-6 px-4 py-3',
+                isPinned && 'bg-white/[0.03]',
+                withSeparator && 'border-b border-solid border-outer-space-800',
+            )}
+        >
+            <div className="flex flex-col gap-0.5">
+                <span className="text-xs text-neutral-500">{label}</span>
+                <span className="whitespace-nowrap text-sm tabular-nums text-neutral-200">{value}</span>
+            </div>
+            <div className="mt-0.5 flex items-center gap-3">
+                <button
+                    type="button"
+                    onClick={onTogglePin}
+                    aria-pressed={isPinned}
+                    title={isPinned ? `Unpin ${label}` : `Pin ${label} as default`}
+                    className={cn(
+                        'flex cursor-pointer items-center border-0 bg-transparent p-0',
+                        isPinned ? 'text-teal-400' : 'text-neutral-500 hover:text-neutral-200',
+                    )}
+                >
+                    <Star size={14} fill={isPinned ? 'currentColor' : 'none'} />
+                </button>
+                <CopyButton text={value} />
+            </div>
+        </div>
+    );
+}
+
+// Clock for the relative label. When `fixed` is given, use it verbatim (no ticking). Otherwise set
+// once on mount — so SSR and the first client render use the absolute fallback and hydrate cleanly —
+// then tick every second only while "Relative" is the shown format.
+function useNow(ticking: boolean, fixed: number | undefined): number | undefined {
+    const [now, setNow] = React.useState<number | undefined>(undefined);
+    React.useEffect(() => {
+        if (fixed !== undefined) return;
+        setNow(Date.now());
+        if (!ticking) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [ticking, fixed]);
+    return fixed ?? now;
+}
+
+/**
+ * Clickable timestamp: renders a formatted time with a chevron, and opens a dropdown
+ * exposing the relative ("X ago"), UTC, local, and Unix-seconds representations — each
+ * individually copyable and pinnable. Pinning a representation makes every Timestamp across
+ * Explorer default to it. Use anywhere a timestamp is shown so the presentation stays consistent.
+ */
+export function Timestamp({ unixTimestamp, display = 'local', children, referenceMs, className }: TimestampProps) {
+    const pinned = usePinnedTimestampDisplay();
+    const effective = pinned ?? display;
+    const now = useNow(effective === 'relative', referenceMs);
+
+    const ms = unixTimestamp * 1000;
+    const labels: Record<TimestampDisplay, string> = {
+        local: displayTimestampAbsolute(ms, false),
+        // Until `now` is set on the client, fall back to the absolute time so hydration matches.
+        relative: now === undefined ? displayTimestampAbsolute(ms, false) : displayTimestampRelative(ms, now),
+        unix: String(unixTimestamp),
+        utc: displayTimestampAbsolute(ms, true),
+    };
+
+    const rows: { key: TimestampDisplay; label: string }[] = [
+        { key: 'utc', label: 'UTC' },
+        { key: 'local', label: 'Local' },
+        { key: 'relative', label: 'Relative' },
+        { key: 'unix', label: 'Unix Timestamp' },
+    ];
+
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <button
+                    type="button"
+                    className={cn(
+                        'inline-flex cursor-pointer items-start gap-1 border-0 bg-transparent p-0 text-left leading-snug',
+                        // Force our standard (non-mono) font and whole-word wrapping even inside a font-mono/break-all cell.
+                        'break-normal font-[family-name:var(--explorer-default-font)]',
+                        'text-neutral-200 hover:text-white',
+                        className,
+                    )}
+                >
+                    <span className="min-w-0">{children ?? labels[effective]}</span>
+                    <ChevronDown size={14} className="mt-0.5 shrink-0 text-neutral-500" />
+                </button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-80 p-0">
+                {rows.map((row, index) => (
+                    <TimestampRow
+                        key={row.key}
+                        label={row.label}
+                        value={labels[row.key]}
+                        isPinned={pinned === row.key}
+                        onTogglePin={() => setPinnedTimestampDisplay(pinned === row.key ? undefined : row.key)}
+                        withSeparator={index < rows.length - 1}
+                    />
+                ))}
+                <div className="flex items-start gap-1.5 border-t border-solid border-outer-space-800 px-4 py-2.5 text-xs leading-snug text-neutral-500">
+                    <Star size={11} className="mt-0.5 shrink-0" />
+                    Star a format to make it the default everywhere in Explorer.
+                </div>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/app/components/shared/ui/timestamp.tsx
+++ b/app/components/shared/ui/timestamp.tsx
@@ -16,7 +16,7 @@ import { displayTimestampAbsolute, displayTimestampRelative } from '@/app/utils/
 export interface TimestampProps {
     /** Unix timestamp in seconds (e.g. a block's `blockTime`). */
     unixTimestamp: number;
-    /** Fallback representation for the trigger when nothing is pinned. Defaults to local time. */
+    /** Fallback representation for the trigger when nothing is pinned. Defaults to UTC. */
     display?: TimestampDisplay;
     /** Overrides the trigger label; the chevron is always appended. */
     children?: React.ReactNode;
@@ -115,7 +115,7 @@ function useNow(ticking: boolean, fixed: number | undefined): number | undefined
  * individually copyable and pinnable. Pinning a representation makes every Timestamp across
  * Explorer default to it. Use anywhere a timestamp is shown so the presentation stays consistent.
  */
-export function Timestamp({ unixTimestamp, display = 'local', children, referenceMs, className }: TimestampProps) {
+export function Timestamp({ unixTimestamp, display = 'utc', children, referenceMs, className }: TimestampProps) {
     const pinned = usePinnedTimestampDisplay();
     const effective = pinned ?? display;
     const now = useNow(effective === 'relative', referenceMs);

--- a/app/components/shared/ui/useTimestampDisplay.ts
+++ b/app/components/shared/ui/useTimestampDisplay.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+// The representations a Timestamp can render. `unix` shows the raw seconds, `relative` shows "X ago".
+export type TimestampDisplay = 'utc' | 'local' | 'unix' | 'relative';
+
+const STORAGE_KEY = 'explorer:timestamp-display';
+
+// A module-level store shared by every Timestamp instance: pinning in one dropdown
+// re-renders all of them, the choice survives reloads, and the `storage` event keeps
+// other tabs in sync. Backed by useSyncExternalStore so SSR/hydration stays consistent.
+// `undefined` means "not pinned"; `cacheValid` distinguishes that from "not yet read".
+const listeners = new Set<() => void>();
+let cached: TimestampDisplay | undefined;
+let cacheValid = false;
+
+function readStorage(): TimestampDisplay | undefined {
+    if (typeof window === 'undefined') return undefined;
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return value === 'utc' || value === 'local' || value === 'unix' || value === 'relative' ? value : undefined;
+}
+
+function subscribe(onChange: () => void): () => void {
+    listeners.add(onChange);
+    const onStorage = (event: StorageEvent) => {
+        if (event.key === STORAGE_KEY) {
+            cacheValid = false; // force a re-read on the next snapshot
+            onChange();
+        }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => {
+        listeners.delete(onChange);
+        window.removeEventListener('storage', onStorage);
+    };
+}
+
+function getSnapshot(): TimestampDisplay | undefined {
+    if (!cacheValid) {
+        cached = readStorage();
+        cacheValid = true;
+    }
+    return cached;
+}
+
+function getServerSnapshot(): TimestampDisplay | undefined {
+    return undefined;
+}
+
+/** Pin (or, with `undefined`, clear) the representation every Timestamp shows by default. */
+export function setPinnedTimestampDisplay(value: TimestampDisplay | undefined): void {
+    if (typeof window !== 'undefined') {
+        if (value === undefined) window.localStorage.removeItem(STORAGE_KEY);
+        else window.localStorage.setItem(STORAGE_KEY, value);
+    }
+    cached = value;
+    cacheValid = true;
+    listeners.forEach(listener => listener());
+}
+
+/** The currently pinned representation, or `undefined` when the user hasn't pinned one. */
+export function usePinnedTimestampDisplay(): TimestampDisplay | undefined {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/app/ui/RelativeBands.tsx
+++ b/app/ui/RelativeBands.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Timestamp } from '@/app/components/shared/ui/timestamp';
+import { cn } from '@/app/components/shared/utils';
+
+const MIN = 60;
+const HOUR = 3600;
+const DAY = 86400;
+
+// One representative age (seconds into the past) per relative-time band in displayTimestampRelative.
+const BANDS: { note: string; offset: number }[] = [
+    { note: '< 1 min → seconds', offset: 25 },
+    { note: '< 10 min → minutes + seconds', offset: 3 * MIN + 20 },
+    { note: '10 min – 1 h → minutes', offset: 25 * MIN },
+    { note: '1 – 8 h → hours + minutes', offset: 3 * HOUR + 15 * MIN },
+    { note: '8 – 48 h → hours', offset: 20 * HOUR },
+    { note: '48 h – 12 d → days + hours', offset: 5 * DAY + 4 * HOUR },
+    { note: '12 – 30 d → days', offset: 20 * DAY },
+    { note: '30 – 365 d → months + days', offset: 100 * DAY },
+    { note: '1 – 3 y → years + months', offset: 400 * DAY },
+    { note: '> 3 y → years', offset: 4 * 365 * DAY },
+];
+
+// A row per band, all sharing one frozen `now` (captured on mount). Passing that same reference to
+// every Timestamp keeps each value exactly at its band's age — no ticking, no ±1s flicker.
+export function RelativeBands() {
+    const [nowSeconds, setNowSeconds] = useState<number | undefined>(undefined);
+    useEffect(() => {
+        setNowSeconds(Math.floor(Date.now() / 1000));
+    }, []);
+
+    // Client-only: skip SSR/first render so hydration matches (relative time depends on the clock).
+    if (nowSeconds === undefined) return <></>;
+
+    return (
+        <div className="flex max-w-xl flex-col overflow-hidden rounded-lg border border-solid border-outer-space-800">
+            {BANDS.map((band, index) => (
+                <div
+                    key={band.note}
+                    className={cn(
+                        'flex items-start justify-between gap-4 px-4 py-3',
+                        index < BANDS.length - 1 && 'border-b border-solid border-white/10',
+                    )}
+                >
+                    <span className="text-sm text-outer-space-300">{band.note}</span>
+                    <Timestamp
+                        unixTimestamp={nowSeconds - band.offset}
+                        display="relative"
+                        referenceMs={nowSeconds * 1000}
+                    />
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/app/ui/page.tsx
+++ b/app/ui/page.tsx
@@ -1,0 +1,85 @@
+import '@/app/styles/styles.css';
+
+import { type Metadata } from 'next/types';
+import { type ReactNode } from 'react';
+
+import { Timestamp } from '@/app/components/shared/ui/timestamp';
+import { cn } from '@/app/components/shared/utils';
+import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
+
+import { RelativeBands } from './RelativeBands';
+
+// Unlinked scratch page for eyeballing shared UI primitives in the real app (fonts, tokens,
+// portals) without Storybook. Keep it out of search engines and the nav — it's URL-only.
+export const metadata: Metadata = {
+    robots: { follow: false, index: false },
+    title: 'UI Playground | Solana Explorer',
+};
+
+// 06:41:51 Aug 06, 2026 (UTC) — same sample used in the Timestamp stories.
+const unixTimestamp = 1785998511;
+
+function Section({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
+    return (
+        <section className="mb-12">
+            <h2 className="mb-1 text-xl font-semibold text-white">{title}</h2>
+            {description && <p className="mb-4 text-sm text-outer-space-300">{description}</p>}
+            {children}
+        </section>
+    );
+}
+
+// Mirrors the transaction Overview card rows (app/features/transaction/ui/SummaryCard.tsx).
+function OverviewRow({ label, children, divider = true }: { label: string; children: ReactNode; divider?: boolean }) {
+    return (
+        <div
+            className={cn(
+                'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
+                divider && 'border-b border-solid border-white/10',
+            )}
+        >
+            <div className="flex flex-wrap items-center gap-1 overflow-hidden text-sm text-outer-space-300">
+                {label}
+            </div>
+            <div className="break-all font-mono text-sm text-white">{children}</div>
+        </div>
+    );
+}
+
+export default function UiPlaygroundPage() {
+    return (
+        <PageContainer className="my-8 max-w-4xl">
+            <h1 className="mb-2 text-4xl font-bold text-white">UI Playground</h1>
+            <p className="mb-10 text-gray-400">Click a timestamp to open its dropdown; star a format to pin it.</p>
+
+            <Section title="Timestamp" description="Standalone — opens UTC / Local / Unix, each copyable and pinnable.">
+                <Timestamp unixTimestamp={unixTimestamp} />
+            </Section>
+
+            <Section
+                title="In transaction Overview"
+                description="A slice of the transaction Overview card, with the timestamp row in context."
+            >
+                <div className="max-w-xl overflow-hidden rounded-lg border border-solid border-outer-space-800">
+                    <OverviewRow label="Signature">
+                        5Nf3xW8pQ7mKd2rBvLhTq9YzJ4cHs6UgAe1oPnR8tXwVbM3kD7yFjZ2uNqW5aCgE9iShL4rT6xUvB1nYmK
+                    </OverviewRow>
+                    <OverviewRow label="Block">312049876</OverviewRow>
+                    <OverviewRow label="Timestamp">
+                        <Timestamp unixTimestamp={unixTimestamp} />
+                    </OverviewRow>
+                    <OverviewRow label="Fee" divider={false}>
+                        0.000005 SOL
+                    </OverviewRow>
+                </div>
+            </Section>
+
+            <Section
+                title="Relative bands"
+                description="One date per band of the relative-time format, so each granularity is visible at once."
+            >
+                <RelativeBands />
+            </Section>
+        </PageContainer>
+    );
+}

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -53,6 +53,85 @@ export function displayTimestampWithoutDate(unixTimestamp: number, shortTimeZone
     return timeString;
 }
 
+// "Aug 6, 2026 at 06:41:51 UTC" — native en-US (CLDR) order: date, "at", 24h padded time, short
+// zone name (UTC / GMT+3). `unixTimestampMs` is milliseconds, matching the other display* helpers.
+export function displayTimestampAbsolute(unixTimestampMs: number, utc = false): string {
+    const date = new Date(unixTimestampMs);
+    const timeZone = utc ? 'UTC' : undefined;
+    const dateString = new Intl.DateTimeFormat('en-US', {
+        day: 'numeric',
+        month: 'short',
+        timeZone,
+        year: 'numeric',
+    }).format(date);
+    const timeString = new Intl.DateTimeFormat('en-US', {
+        hour: '2-digit',
+        hourCycle: 'h23',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZone,
+        timeZoneName: 'short',
+    }).format(date);
+    return `${dateString} at ${timeString}`;
+}
+
+function pluralUnit(value: number, name: string): string {
+    return `${value} ${name}${value === 1 ? '' : 's'}`;
+}
+
+const MINUTE_S = 60;
+const HOUR_S = 3600;
+const DAY_S = 86400;
+const YEAR_S = 365 * DAY_S;
+// A twelfth of the year, not a flat 30 days — otherwise 12×30 ≠ 365 and the remainder near a
+// year rolls over to a nonsensical "12 months" / "2 years 12 months".
+const MONTH_S = Math.floor(YEAR_S / 12);
+
+// Human "time since" with granularity that coarsens as the event recedes, per these bands:
+//   <10m  minutes + seconds   |  10m–1h  minutes         |  1h–8h   hours + minutes
+//   8h–48h hours              |  48h–12d days + hours     |  12d–30d days
+//   30d–365d months + days    |  1y–3y   years + months   |  >3y     years
+// A zero secondary unit is dropped ("3 hours 0 minutes" → "3 hours"). Both args are milliseconds.
+export function displayTimestampRelative(unixTimestampMs: number, nowMs: number): string {
+    const diffSeconds = Math.round((nowMs - unixTimestampMs) / 1000);
+    const abs = Math.abs(diffSeconds);
+
+    let parts: string[];
+    if (abs < 10 * MINUTE_S) {
+        parts = [pluralUnit(Math.floor(abs / MINUTE_S), 'minute'), pluralUnit(abs % MINUTE_S, 'second')];
+    } else if (abs < HOUR_S) {
+        parts = [pluralUnit(Math.floor(abs / MINUTE_S), 'minute')];
+    } else if (abs < 8 * HOUR_S) {
+        parts = [
+            pluralUnit(Math.floor(abs / HOUR_S), 'hour'),
+            pluralUnit(Math.floor((abs % HOUR_S) / MINUTE_S), 'minute'),
+        ];
+    } else if (abs < 48 * HOUR_S) {
+        parts = [pluralUnit(Math.floor(abs / HOUR_S), 'hour')];
+    } else if (abs < 12 * DAY_S) {
+        parts = [pluralUnit(Math.floor(abs / DAY_S), 'day'), pluralUnit(Math.floor((abs % DAY_S) / HOUR_S), 'hour')];
+    } else if (abs < 30 * DAY_S) {
+        parts = [pluralUnit(Math.floor(abs / DAY_S), 'day')];
+    } else if (abs < YEAR_S) {
+        parts = [
+            pluralUnit(Math.floor(abs / MONTH_S), 'month'),
+            pluralUnit(Math.floor((abs % MONTH_S) / DAY_S), 'day'),
+        ];
+    } else if (abs < 3 * YEAR_S) {
+        parts = [
+            pluralUnit(Math.floor(abs / YEAR_S), 'year'),
+            pluralUnit(Math.floor((abs % YEAR_S) / MONTH_S), 'month'),
+        ];
+    } else {
+        parts = [pluralUnit(Math.floor(abs / YEAR_S), 'year')];
+    }
+
+    // Drop a zero-valued unit; if everything is zero the event is right now.
+    const text = parts.filter(part => !part.startsWith('0 ')).join(' ');
+    if (text === '') return 'just now';
+    return diffSeconds >= 0 ? `${text} ago` : `in ${text}`;
+}
+
 // Drops date-fns' "less than" prefixes on sub-minute buckets; everything else
 // inherits stock en-US phrasing (about/almost/over/half a).
 const relativeLocale: Locale = {


### PR DESCRIPTION
## Description

Adds a reusable `Timestamp` component that unifies how timestamps are shown
across Explorer. Today the presentation is inconsistent — block pages show
separate UTC and Local rows, transactions show only local. This lands a single
clickable element that renders the time and opens a dropdown to switch, copy,
or pin the format.

-   **Timestamp dropdown** — click a timestamp to open UTC, Local, Relative
    ("X ago"), and Unix-seconds representations, each with its own copy button.
-   **Pinnable default** — the trigger shows UTC by default; star another
    format to make it the default everywhere; the choice persists (localStorage)
    and syncs across mounted instances and browser tabs.
-   **Relative format** — granularity coarsens with age: seconds under a
    minute, then minutes+seconds, hours+minutes, days+hours, months+days,
    up to years.
-   **Absolute format** — keeps the explorer's existing date-first
    "Aug 6, 2026 at 06:41:51 UTC" order (native en-US); the trigger uses the
    standard sans font (not mono), wraps by whole words, and is left-aligned
    with the chevron pinned to the top line.
-   **Preview** — an unlinked, noindexed `/ui` page plus Storybook stories to
    inspect the component, including inside a transaction Overview slice.

Block and transaction pages are intentionally not switched over here — this PR
ships the shared primitive; adopting it in those pages is a follow-up.

## Type of change

-   [x] New feature
-   [x] Design update

## Screenshots

<img width="658" height="570" alt="image" src="https://github.com/user-attachments/assets/a1feb3c0-409a-4c40-9cb7-89b3b6db9d80" />

## Testing

1. Storybook `Components/Shared/Timestamp`: open the dropdown, copy a row, star
   a format and confirm the trigger + other instances follow, and check the
   `Relative Time Bands` and `In Transaction Overview Mobile` stories.
2. App: `pnpm dev`, open `http://localhost:3000/ui` — same interactions in the
   real app, plus the "Relative bands" list showing every granularity.
3. `pnpm lint`, `pnpm test:ci`, `pnpm build`, `pnpm test:sb` pass locally.

## Related Issues

HOO-1034

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes

