### PR TITLE
feat(account): rework vote account page layout, tables and header

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -80,7 +80,7 @@ import {
     DSCOMMON_CONTENT_MAX_WIDTH_M,
     DSCOMMON_PAGE_PADDING_X,
 } from '@/app/shared/ui/page-spacing/spacing';
-import { useStickyHeaderHeight } from '@/app/shared/ui/sticky-header/useStickyHeaderHeight';
+import { StickyHeader } from '@/app/shared/ui/sticky-header/StickyHeader';
 import { isAttestationAccount } from '@/app/utils/attestation-service';
 import {
     fetchFullTokenInfo,
@@ -401,31 +401,16 @@ function MoreSection({
         [baseUrl, buildClusterPath],
     );
 
-    // Track the sticky bar's height into --sticky-header-height so anchored content beneath it
-    // (e.g. TokenExtensionsSection's scroll-margin-top) still clears the bar without StickyHeader.
-    const tabBarRef = React.useRef<HTMLDivElement>(null);
-    useStickyHeaderHeight(tabBarRef);
-
     return (
         <>
-            {/* Full-bleed sticky tab bar, structured exactly like the block page: the negative margins
-                stretch the background edge-to-edge while the matching padding pulls the tabs back onto
-                the content column. Underline (border-b) matches the block page too: full-bleed into the
-                page margins on mobile/tablet (border on this wrapper) and clipped to the content column
-                at `lg` (border moves to the inner column wrapper below). */}
-            <div
-                ref={tabBarRef}
-                className={cn(
-                    'sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] lg:border-b-0 [&::-webkit-scrollbar]:hidden',
-                    DSCOMMON_BETWEEN_BLOCKS.marginClassName,
-                )}
-            >
-                <div className="lg:border-0 lg:border-b lg:border-solid lg:border-neutral-800">
-                    <NavigationTabs buildHref={buildHref} tabs={tabs} className="gap-5">
-                        {asyncChildren}
-                    </NavigationTabs>
-                </div>
-            </div>
+            {/* StickyHeader owns the full-bleed background, the responsive underline and the
+                --sticky-header-height publishing. It must sit directly in the content column (it is here)
+                so its pull-back lines the tabs up with the page body. */}
+            <StickyHeader className={DSCOMMON_BETWEEN_BLOCKS.marginClassName}>
+                <NavigationTabs buildHref={buildHref} tabs={tabs} className="gap-5">
+                    {asyncChildren}
+                </NavigationTabs>
+            </StickyHeader>
             {children}
         </>
     );

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -410,17 +410,21 @@ function MoreSection({
         <>
             {/* Full-bleed sticky tab bar, structured exactly like the block page: the negative margins
                 stretch the background edge-to-edge while the matching padding pulls the tabs back onto
-                the content column. Unlike the block page we keep the full-width underline (border-b). */}
+                the content column. Underline (border-b) matches the block page too: full-bleed into the
+                page margins on mobile/tablet (border on this wrapper) and clipped to the content column
+                at `lg` (border moves to the inner column wrapper below). */}
             <div
                 ref={tabBarRef}
                 className={cn(
-                    'sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                    'sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] lg:border-b-0 [&::-webkit-scrollbar]:hidden',
                     DSCOMMON_BETWEEN_BLOCKS.marginClassName,
                 )}
             >
-                <NavigationTabs buildHref={buildHref} tabs={tabs} className="gap-5">
-                    {asyncChildren}
-                </NavigationTabs>
+                <div className="lg:border-0 lg:border-b lg:border-solid lg:border-neutral-800">
+                    <NavigationTabs buildHref={buildHref} tabs={tabs} className="gap-5">
+                        {asyncChildren}
+                    </NavigationTabs>
+                </div>
             </div>
             {children}
         </>

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -60,6 +60,7 @@ import useSWRImmutable from 'swr/immutable';
 
 import { CompressedNftCard } from '@/app/components/account/CompressedNftCard';
 import { SolanaAttestationServiceCard } from '@/app/components/account/sas/SolanaAttestationCard';
+import { cn } from '@/app/components/shared/utils';
 import { getFeatureInfo, useFeatureInfo } from '@/app/entities/feature-gate';
 import { hasTokenMetadata } from '@/app/features/metadata';
 import {
@@ -73,8 +74,13 @@ import {
 import { useCompressedNft } from '@/app/providers/compressed-nft';
 import { useSquadsMultisigLookup } from '@/app/providers/squadsMultisig';
 import { type NavigationTab, NavigationTabLink, NavigationTabs } from '@/app/shared/ui/navigation-tabs';
-import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
-import { StickyHeader } from '@/app/shared/ui/sticky-header/StickyHeader';
+import {
+    DSCOMMON_BEFORE_HEADER,
+    DSCOMMON_BETWEEN_BLOCKS,
+    DSCOMMON_CONTENT_MAX_WIDTH_M,
+    DSCOMMON_PAGE_PADDING_X,
+} from '@/app/shared/ui/page-spacing/spacing';
+import { useStickyHeaderHeight } from '@/app/shared/ui/sticky-header/useStickyHeaderHeight';
 import { isAttestationAccount } from '@/app/utils/attestation-service';
 import {
     fetchFullTokenInfo,
@@ -191,8 +197,17 @@ function AddressLayoutInner({ children, params: { address } }: InnerProps) {
         }
     }, [address, status, info]); // eslint-disable-line react-hooks/exhaustive-deps
 
+    // Content column, max-width + horizontal/top padding all from the shared DSCOMMON size tokens
+    // (the max-width matches the transaction page).
     return (
-        <PageContainer variant="pulled-up">
+        <div
+            className={cn(
+                'mx-auto flex w-full flex-col',
+                DSCOMMON_CONTENT_MAX_WIDTH_M.className,
+                DSCOMMON_PAGE_PADDING_X.className,
+                DSCOMMON_BEFORE_HEADER.className,
+            )}
+        >
             <Header
                 address={address}
                 account={info?.data}
@@ -212,7 +227,7 @@ function AddressLayoutInner({ children, params: { address } }: InnerProps) {
                     {children}
                 </DetailsSections>
             )}
-        </PageContainer>
+        </div>
     );
 }
 
@@ -386,15 +401,27 @@ function MoreSection({
         [baseUrl, buildClusterPath],
     );
 
+    // Track the sticky bar's height into --sticky-header-height so anchored content beneath it
+    // (e.g. TokenExtensionsSection's scroll-margin-top) still clears the bar without StickyHeader.
+    const tabBarRef = React.useRef<HTMLDivElement>(null);
+    useStickyHeaderHeight(tabBarRef);
+
     return (
         <>
-            <StickyHeader>
-                <PageContainer>
-                    <NavigationTabs buildHref={buildHref} tabs={tabs}>
-                        {asyncChildren}
-                    </NavigationTabs>
-                </PageContainer>
-            </StickyHeader>
+            {/* Full-bleed sticky tab bar, structured exactly like the block page: the negative margins
+                stretch the background edge-to-edge while the matching padding pulls the tabs back onto
+                the content column. Unlike the block page we keep the full-width underline (border-b). */}
+            <div
+                ref={tabBarRef}
+                className={cn(
+                    'sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                    DSCOMMON_BETWEEN_BLOCKS.marginClassName,
+                )}
+            >
+                <NavigationTabs buildHref={buildHref} tabs={tabs} className="gap-5">
+                    {asyncChildren}
+                </NavigationTabs>
+            </div>
             {children}
         </>
     );

--- a/app/address/[address]/rewards/page.tsx
+++ b/app/address/[address]/rewards/page.tsx
@@ -19,5 +19,5 @@ export async function generateMetadata(props: AddressPageMetadataProps): Promise
 export default async function BlockRewardsPage(props: Props) {
     const { address } = await props.params;
 
-    return <RewardsCard address={address} />;
+    return <RewardsCard address={address} layout="grid" />;
 }

--- a/app/address/[address]/vote-history/page-client.tsx
+++ b/app/address/[address]/vote-history/page-client.tsx
@@ -19,7 +19,7 @@ function VotesCardRenderer({
     if (!isParsedAccountProgram(parsedData, VOTE_PROGRAM_LABEL)) {
         return onNotFound();
     }
-    return <VotesCard voteAccount={parsedData.parsed} />;
+    return <VotesCard voteAccount={parsedData.parsed} layout="grid" />;
 }
 
 export default function VoteHistoryPageClient({ params: { address } }: Props) {

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -263,10 +263,10 @@ function MoreSection({ children, slot }: { children: React.ReactNode; slot: numb
 
     return (
         <>
-            <StickyHeader>
-                <PageContainer>
-                    <NavigationTabs buildHref={buildHref} tabs={TABS} />
-                </PageContainer>
+            {/* StickyHeader sits directly in the block's content column (the outer PageContainer), so it
+                takes the tabs alone — no inner column wrapper — and pulls them back to the column itself. */}
+            <StickyHeader className="mb-8">
+                <NavigationTabs buildHref={buildHref} tabs={TABS} />
             </StickyHeader>
             {children}
         </>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -6,6 +6,7 @@ import { TokenMarketData, useTokenMarketData } from '@/app/features/token-market
 import { TokenVerificationBadge, type VerificationTarget } from '@/app/features/token-verification-badge';
 import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 import { isNativeMint, isTokenMintByOwner } from '@/app/shared/model/token-program';
+import { DSCOMMON_AFTER_HEADER } from '@/app/shared/ui/page-spacing/spacing';
 
 type HeaderProps = ComponentProps<typeof AccountHeader>;
 
@@ -31,8 +32,8 @@ export function Header({ address, account, tokenInfo, isTokenInfoLoading }: Head
     );
 
     return (
-        <div className="mb-8">
-            <div className="flex flex-col items-start gap-4 border-0 border-b border-solid border-dk-gray-700-dark py-6 lg:flex-row lg:items-end lg:justify-between lg:gap-1">
+        <div className={DSCOMMON_AFTER_HEADER.className}>
+            <div className="flex flex-col items-start gap-4 pt-6 lg:flex-row lg:items-end lg:justify-between lg:gap-1">
                 <AccountHeader
                     address={address}
                     account={account}

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -23,6 +23,7 @@ import { dasImageAddress } from '@/app/components/account/das-image-address';
 import { ProgramHeader } from '@/app/components/shared/account/ProgramHeader';
 import { ProxiedImage } from '@/app/features/metadata';
 import { getProxiedUri } from '@/app/features/metadata/utils';
+import { PageHeader } from '@/app/shared/ui/page-header/PageHeader';
 import { type FullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
 
 export function AccountHeader({
@@ -102,12 +103,12 @@ export function AccountHeader({
 }
 
 function AccountDetailsHeader({ title }: { title: string }) {
-    return (
-        <div className="flex flex-col justify-center gap-1 md:min-h-[69px]">
-            <h6 className="uppercase tracking-[0.08em] text-dk-gray-700">Details</h6>
-            <h2 className="mb-0">{title}</h2>
-        </div>
-    );
+    // min-h keeps the "Details / <title>" header a consistent height across account types (it matches
+    // the token-mint header), but centering ~57px of content in 69px would add ~6px above and below the
+    // title and inflate the page's top and title→card gaps vs the block page. The negative `-my` pulls
+    // that overhang back out of the flow so the visible spacing matches the block page while the box
+    // itself stays 69px tall. `as="div"` because this header is nested inside the account Header row.
+    return <PageHeader as="div" title={title} className="justify-center md:-my-1.5 md:min-h-[69px]" />;
 }
 
 function TokenMintHeader({

--- a/app/components/account/RewardsCard.tsx
+++ b/app/components/account/RewardsCard.tsx
@@ -4,6 +4,8 @@ import { Epoch } from '@components/common/Epoch';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { Slot } from '@components/common/Slot';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
+import { cn } from '@components/shared/utils';
 import { isParsedAccountProgram, STAKE_PROGRAM_LABEL } from '@explorer/parsers';
 import { useAccountInfo } from '@providers/accounts';
 import { useFetchRewards, useRewards } from '@providers/accounts/rewards';
@@ -13,12 +15,24 @@ import { lamportsToSolString } from '@utils/index';
 import React from 'react';
 
 import { Button } from '@/app/components/shared/ui/button';
-import { Card, CardBody, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
+import { Card, CardBody } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 const U64_MAX = BigInt('0xffffffffffffffff');
 
-export function RewardsCard({ address }: { address: string }) {
+export type RewardsLayout = 'table' | 'grid';
+
+// Column labels shared by both layouts so the header copy can't drift between table and grid. The SOL
+// unit lives in the header; the rows repeat it with the `◎` glyph.
+const COLUMNS = ['Epoch', 'Effective Slot', 'Reward (SOL)', 'Post Balance (SOL)'] as const;
+
+// The reward fields the row rendering needs (the provider's entry carries more, e.g. commission).
+type RewardEntry = { epoch: number; effectiveSlot: number; amount: number; postBalance: number };
+
+// SOL amount with the currency glyph, e.g. `◎0.0125`.
+const solAmount = (lamports: number | bigint) => `◎${lamportsToSolString(lamports)}`;
+
+export function RewardsCard({ address, layout = 'table' }: { address: string; layout?: RewardsLayout }) {
     const pubkey = React.useMemo(() => new PublicKey(address), [address]);
     const info = useAccountInfo(address);
     const account = info?.data;
@@ -54,78 +68,152 @@ export function RewardsCard({ address }: { address: string }) {
         return <ErrorCard retry={loadMore} text="Failed to fetch rewards" />;
     }
 
-    const rewardsList = rewards.data.rewards.map(reward => {
-        if (!reward) {
-            return null;
-        }
-
-        return (
-            <BaseTable.Row key={reward.epoch}>
-                <BaseTable.Cell>
-                    <Epoch epoch={reward.epoch} link />
-                </BaseTable.Cell>
-                <BaseTable.Cell>
-                    <Slot slot={reward.effectiveSlot} link />
-                </BaseTable.Cell>
-                <BaseTable.Cell>{lamportsToSolString(reward.amount)}</BaseTable.Cell>
-                <BaseTable.Cell>{lamportsToSolString(reward.postBalance)}</BaseTable.Cell>
-            </BaseTable.Row>
-        );
-    });
-    const rewardsFound = rewardsList.some(r => r);
+    const rewardList = rewards.data.rewards.filter((r): r is NonNullable<typeof r> => r !== null);
+    const rewardsFound = rewardList.length > 0;
     const { foundOldest, lowestFetchedEpoch, highestFetchedEpoch } = rewards.data;
     const fetching = rewards.status === FetchStatus.Fetching;
 
-    return (
-        <>
-            <Card ui="dashkit">
-                <CardHeader ui="dashkit">
-                    <CardTitle as="h3" ui="dashkit">
-                        Rewards
-                    </CardTitle>
-                </CardHeader>
+    const emptyBody = (
+        <CardBody ui="dashkit">
+            No rewards issued between epochs {lowestFetchedEpoch} and {highestFetchedEpoch}
+        </CardBody>
+    );
 
-                {rewardsFound ? (
-                    <BaseTable ui="dashkit" variant="card" nowrap>
-                        <BaseTable.Head>
-                            <BaseTable.Row>
-                                <BaseTable.HeaderCell className="w-px text-dk-gray-700">Epoch</BaseTable.HeaderCell>
-                                <BaseTable.HeaderCell className="text-dk-gray-700">Effective Slot</BaseTable.HeaderCell>
-                                <BaseTable.HeaderCell className="text-dk-gray-700">Reward Amount</BaseTable.HeaderCell>
-                                <BaseTable.HeaderCell className="text-dk-gray-700">Post Balance</BaseTable.HeaderCell>
-                            </BaseTable.Row>
-                        </BaseTable.Head>
-                        <BaseTable.Body>{rewardsList}</BaseTable.Body>
-                    </BaseTable>
+    // Both footer states get a uniform 12px inset on all sides (p-3), with the grid's row-separator border.
+    const footer = foundOldest ? (
+        <div className="border-1 border-t border-white/10 p-3 text-dk-gray-700 [border-top-style:solid]">
+            Fetched full reward history
+        </div>
+    ) : (
+        <div className="border-1 border-t border-white/10 p-3 [border-top-style:solid]">
+            <Button ui="dashkit" variant="primary" className="w-full" onClick={() => loadMore()} disabled={fetching}>
+                {fetching ? (
+                    <>
+                        <span className="spinner-grow spinner-grow-sm mr-1.5 align-text-top"></span>
+                        Loading
+                    </>
                 ) : (
-                    <CardBody ui="dashkit">
-                        No rewards issued between epochs {lowestFetchedEpoch} and {highestFetchedEpoch}
-                    </CardBody>
+                    'Load More'
                 )}
+            </Button>
+        </div>
+    );
 
-                <CardFooter ui="dashkit">
-                    {foundOldest ? (
-                        <div className="text-center text-dk-gray-700">Fetched full reward history</div>
-                    ) : (
-                        <Button
-                            ui="dashkit"
-                            variant="primary"
-                            className="w-full"
-                            onClick={() => loadMore()}
-                            disabled={fetching}
-                        >
-                            {fetching ? (
-                                <>
-                                    <span className="spinner-grow spinner-grow-sm mr-1.5 align-text-top"></span>
-                                    Loading
-                                </>
-                            ) : (
-                                'Load More'
-                            )}
-                        </Button>
-                    )}
-                </CardFooter>
-            </Card>
-        </>
+    // Heading lifted out above the card via CollapsibleSection — same pattern as the Vote History card
+    // (`className=""` so the surface comes from the `<Card>` below).
+    return (
+        <CollapsibleSection title="Rewards" className="">
+            {layout === 'grid' ? (
+                <Card variant="tight" className="!rounded-lg border-outer-space-800 bg-outer-space-900">
+                    {rewardsFound ? <RewardsGrid rewards={rewardList} /> : emptyBody}
+                    {footer}
+                </Card>
+            ) : (
+                <Card ui="dashkit" marginBottom="none">
+                    {rewardsFound ? <RewardsTable rewards={rewardList} /> : emptyBody}
+                    {footer}
+                </Card>
+            )}
+        </CollapsibleSection>
+    );
+}
+
+// `<table>` layout — the shared BaseTable (dashkit surface) with the original columns.
+function RewardsTable({ rewards }: { rewards: RewardEntry[] }) {
+    return (
+        <BaseTable ui="dashkit" variant="card" nowrap>
+            <BaseTable.Head>
+                <BaseTable.Row>
+                    <BaseTable.HeaderCell className="w-px text-dk-gray-700">{COLUMNS[0]}</BaseTable.HeaderCell>
+                    <BaseTable.HeaderCell className="text-dk-gray-700">{COLUMNS[1]}</BaseTable.HeaderCell>
+                    <BaseTable.HeaderCell className="text-dk-gray-700">{COLUMNS[2]}</BaseTable.HeaderCell>
+                    <BaseTable.HeaderCell className="text-dk-gray-700">{COLUMNS[3]}</BaseTable.HeaderCell>
+                </BaseTable.Row>
+            </BaseTable.Head>
+            <BaseTable.Body>
+                {rewards.map(reward => (
+                    <BaseTable.Row key={reward.epoch}>
+                        <BaseTable.Cell>
+                            <Epoch epoch={reward.epoch} link />
+                        </BaseTable.Cell>
+                        <BaseTable.Cell>
+                            <Slot slot={reward.effectiveSlot} link />
+                        </BaseTable.Cell>
+                        <BaseTable.Cell className="font-mono">{solAmount(reward.amount)}</BaseTable.Cell>
+                        <BaseTable.Cell className="font-mono">{solAmount(reward.postBalance)}</BaseTable.Cell>
+                    </BaseTable.Row>
+                ))}
+            </BaseTable.Body>
+        </BaseTable>
+    );
+}
+
+// Four equal-width columns, shared by the desktop header row and each desktop data row.
+const GRID_TEMPLATE = 'grid-cols-4 gap-5';
+
+// Grid layout, responsive like the transaction Tokens/Accounts tables: an `sm`+ grid (header row + data
+// rows) and, below `sm`, each row stacks into labelled fields. Cell padding matches the Vote History
+// table (px-3 py-2.5). Reward and Post Balance are right-aligned.
+function RewardsGrid({ rewards }: { rewards: RewardEntry[] }) {
+    return (
+        <div className="text-sm text-white">
+            <div
+                className={cn(
+                    'border-1 hidden border-b border-white/10 px-3 py-2.5 text-xs uppercase text-outer-space-300 [border-bottom-style:solid] sm:grid',
+                    GRID_TEMPLATE,
+                )}
+            >
+                {COLUMNS.map((label, i) => (
+                    <div key={label} className={i >= 2 ? 'text-right' : undefined}>
+                        {label}
+                    </div>
+                ))}
+            </div>
+            {rewards.map(reward => (
+                <RewardRow key={reward.epoch} reward={reward} />
+            ))}
+        </div>
+    );
+}
+
+function MobileField({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex items-center gap-2">
+            <span className="w-28 shrink-0 text-outer-space-300">{label}</span>
+            {children}
+        </div>
+    );
+}
+
+function RewardRow({ reward }: { reward: RewardEntry }) {
+    return (
+        <div className="border-1 border-b border-white/10 [border-bottom-style:solid] last:border-b-0">
+            {/* Below sm: stacked, labelled fields. */}
+            <div className="flex flex-col gap-1 px-3 py-3 sm:hidden">
+                <MobileField label="Epoch">
+                    <Epoch epoch={reward.epoch} link />
+                </MobileField>
+                <MobileField label="Effective Slot">
+                    <Slot slot={reward.effectiveSlot} link />
+                </MobileField>
+                <MobileField label="Reward">
+                    <span className="font-mono">{solAmount(reward.amount)}</span>
+                </MobileField>
+                <MobileField label="Post Balance">
+                    <span className="font-mono">{solAmount(reward.postBalance)}</span>
+                </MobileField>
+            </div>
+            {/* sm+: grid row aligned to the header. */}
+            <div className={cn('hidden min-h-9 items-center px-3 py-2.5 sm:grid', GRID_TEMPLATE)}>
+                <div>
+                    <Epoch epoch={reward.epoch} link />
+                </div>
+                <div>
+                    <Slot slot={reward.effectiveSlot} link />
+                </div>
+                <div className="text-right font-mono">{solAmount(reward.amount)}</div>
+                <div className="text-right font-mono">{solAmount(reward.postBalance)}</div>
+            </div>
+        </div>
     );
 }

--- a/app/components/account/__stories__/RewardsCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/RewardsCard.responsive.stories.tsx
@@ -70,7 +70,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const args = { address: ADDRESS };
+// Grid layout so the mobile labelled-stack adaptation is what these viewport variants exercise.
+const args = { address: ADDRESS, layout: 'grid' as const };
 
 export const Mobile: Story = {
     args,

--- a/app/components/account/__stories__/RewardsCard.stories.tsx
+++ b/app/components/account/__stories__/RewardsCard.stories.tsx
@@ -53,9 +53,36 @@ const withRewards: Decorator = Story => (
 );
 
 const meta = {
+    argTypes: {
+        layout: {
+            control: 'inline-radio',
+            description:
+                'Inner list rendering. `table` uses the shared `<BaseTable>`; `grid` uses a CSS-grid built from `div`s (the way we render the other grid tables).',
+            options: ['table', 'grid'],
+        },
+    },
     component: RewardsCard,
     decorators: [withClusterAndAccounts],
-    parameters: nextjsParameters,
+    parameters: {
+        ...nextjsParameters,
+        docs: {
+            description: {
+                component: [
+                    "An account's staking/inflation rewards by epoch. Amounts are in SOL (lamports → SOL); the",
+                    'unit is in the header and repeated per row with the `◎` glyph. `layout` picks table vs grid.',
+                    '',
+                    '## References',
+                    '',
+                    '- [Card](?path=/docs/components-shared-card-basecard--docs) — the card surface plus the "Rewards" header and the Load-More footer.',
+                    '- [BaseTable](?path=/docs/components-shared-table-basetable--docs) — the `layout="table"` list (the original dashkit table).',
+                    '- Rewards grid — the `layout="grid"` list: a pure-Tailwind CSS grid (`auto auto 1fr 1fr`) built from `div`s with `role="table"`/`row`/`cell`, mirroring the Vote History / transaction Accounts tables.',
+                    '- [Button](?path=/docs/components-shared-button--docs) — the "Load More" button in the footer.',
+                    '- `Epoch` / `Slot` — render the Epoch and Effective Slot cells as linked values.',
+                    '- [LoadingCard](?path=/docs/components-common-loadingcard--docs) / [ErrorCard](?path=/docs/components-common-errorcard--docs) — the loading and fetch-error states.',
+                ].join('\n'),
+            },
+        },
+    },
     tags: ['autodocs', 'test'],
     title: 'Components/Account/RewardsCard',
 } satisfies Meta<typeof RewardsCard>;
@@ -65,5 +92,11 @@ type Story = StoryObj<typeof meta>;
 
 export const WithRewardsList: Story = {
     args: { address: ADDRESS },
+    decorators: [withRewards],
+};
+
+// `layout="grid"` renders the same rewards as a CSS grid instead of a `<table>`.
+export const GridLayout: Story = {
+    args: { address: ADDRESS, layout: 'grid' },
     decorators: [withRewards],
 };

--- a/app/components/shared/ui/sizes.stories.tsx
+++ b/app/components/shared/ui/sizes.stories.tsx
@@ -1,0 +1,212 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import React from 'react';
+
+import { Switch } from '@/app/components/shared/ui/switch';
+import { PageHeader } from '@/app/shared/ui/page-header/PageHeader';
+import {
+    DSCOMMON_AFTER_HEADER,
+    DSCOMMON_BEFORE_HEADER,
+    DSCOMMON_BETWEEN_BLOCKS,
+    DSCOMMON_MAX_WIDTHS,
+    DSCOMMON_PAGE_PADDING_X,
+    DSCOMMON_SPACINGS,
+    type Spacing,
+    type Tier,
+    TIER_LABEL,
+    TIER_ORDER,
+    tierRange,
+} from '@/app/shared/ui/page-spacing/spacing';
+
+// Design-system size tokens for a detail page (Transaction / Block / Account): the content column
+// max-width and the vertical/horizontal spacing rhythm. REFERENCE — the coloured bands in the example
+// below make the spacings visible. The tokens live in `@/app/shared/ui/page-spacing/spacing` and are
+// applied by the real pages.
+const SPACINGS = DSCOMMON_SPACINGS;
+
+// A band whose height IS the documented gap. When `show`, it's tinted with dashed guide lines and the
+// name + value to the right; when off, it collapses to an invisible spacer of the same height, so the
+// real gap stays but the guides disappear.
+function Band({ label, value, h, show }: { label: string; value: string; h: string; show: boolean }) {
+    if (!show) return <div aria-hidden className={h} />;
+    return (
+        <div className={`border-accent/50 bg-accent/10 relative border-y border-dashed ${h}`}>
+            <span className="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-[11px] text-white">
+                {label} <span className="ml-1 font-mono text-accent">{value}</span>
+            </span>
+        </div>
+    );
+}
+
+// A stand-in content block, matched to the detail-page card surface.
+function Block({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="rounded-lg border border-solid border-outer-space-800 bg-outer-space-900 px-4 py-6 text-sm text-white">
+            {children}
+        </div>
+    );
+}
+
+// One example page for a tier — real PageHeader, real card surfaces, gaps drawn as labelled bands sized
+// to that tier's values.
+function ExampleColumn({ tier, width, showGuides }: { tier: Tier; width: string; showGuides: boolean }) {
+    const pad = DSCOMMON_PAGE_PADDING_X.values[tier].px === '24px' ? 'px-6' : 'px-4';
+    const band = (s: Spacing) => {
+        const v = s.values[tier];
+        return <Band h={v.band ?? ''} label={s.label} show={showGuides} value={v.px} />;
+    };
+    return (
+        <div>
+            <div className="mb-3 text-sm font-medium text-white">
+                {TIER_LABEL[tier]} <span className="font-mono text-outer-space-300">· {tierRange(tier)}</span>
+            </div>
+            <div className={width}>
+                <div className={`flex flex-col rounded-lg border border-dashed border-neutral-700 ${pad}`}>
+                    {band(DSCOMMON_BEFORE_HEADER)}
+                    <PageHeader title="Page title" />
+                    {band(DSCOMMON_AFTER_HEADER)}
+                    <Block>First block</Block>
+                    {band(DSCOMMON_BETWEEN_BLOCKS)}
+                    <Block>Second block</Block>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+    return <h2 className="m-0 mb-3 text-xs font-medium uppercase tracking-wide text-outer-space-300">{children}</h2>;
+}
+
+// Max-width tokens: variable name, what it caps, its value, and the applied Tailwind class.
+function MaxWidths() {
+    return (
+        <div className="overflow-x-auto rounded-lg border border-solid border-outer-space-800">
+            <table className="w-full border-collapse text-sm text-white">
+                <thead>
+                    <tr className="text-left text-xs uppercase text-outer-space-300">
+                        <th className="px-3 py-2 font-normal">Variable</th>
+                        <th className="px-3 py-2 font-normal">Size</th>
+                        <th className="px-3 py-2 font-normal">Value</th>
+                        <th className="px-3 py-2 font-normal">Class</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {DSCOMMON_MAX_WIDTHS.map(w => (
+                        <tr key={w.name} className="border-t border-solid border-outer-space-800">
+                            <td className="px-3 py-2 font-mono text-accent">{w.name}</td>
+                            <td className="px-3 py-2">{w.label}</td>
+                            <td className="px-3 py-2 font-mono">{w.value}</td>
+                            <td className="px-3 py-2 font-mono text-outer-space-300">{w.className}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+// Each tier column shows the value AND the Tailwind class that produces it at that tier (the class is
+// tier-specific — e.g. `px-4` on mobile vs `lg:px-6` from lg on).
+function Legend() {
+    return (
+        <div className="overflow-x-auto rounded-lg border border-solid border-outer-space-800">
+            <table className="w-full border-collapse text-sm text-white">
+                <thead>
+                    <tr className="text-left text-xs uppercase text-outer-space-300">
+                        <th className="px-3 py-2 font-normal">Variable</th>
+                        <th className="px-3 py-2 font-normal">Spacing</th>
+                        {TIER_ORDER.map(t => (
+                            <th key={t} className="px-3 py-2 font-normal">
+                                {TIER_LABEL[t]} ({tierRange(t)})
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {SPACINGS.map(s => (
+                        <tr key={s.name} className="border-t border-solid border-outer-space-800 align-top">
+                            <td className="px-3 py-2 font-mono text-accent">{s.name}</td>
+                            <td className="px-3 py-2">{s.label}</td>
+                            {TIER_ORDER.map(t => (
+                                <td key={t} className="px-3 py-2 font-mono">
+                                    <div>{s.values[t].px}</div>
+                                    <div className="text-xs text-outer-space-300">{s.values[t].cls}</div>
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+function SizesView() {
+    // Toggle the guide lines (tinted bands + labels) on/off; the real gaps stay either way.
+    const [showGuides, setShowGuides] = React.useState(true);
+    const widths = ['w-[320px]', 'w-[460px] max-w-full', 'w-[560px] max-w-full'];
+    return (
+        <div className="min-h-screen bg-heavy-metal-900 py-8">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4">
+                <section>
+                    <SectionHeading>Max widths</SectionHeading>
+                    <MaxWidths />
+                </section>
+                <section>
+                    <SectionHeading>Page spacings</SectionHeading>
+                    <Legend />
+                </section>
+            </div>
+
+            {/* Solid, edge-to-edge divider between the token tables and the live example page. */}
+            <div className="my-8 border-0 border-t border-solid border-neutral-600" />
+
+            <div className="mx-auto w-full max-w-5xl overflow-x-auto px-4">
+                <div className="mb-2 text-xs font-medium uppercase tracking-wide text-outer-space-300">
+                    Example page — one column per tier
+                </div>
+                <div className="mb-6 flex items-center gap-3">
+                    <Switch aria-label="Show spacing guides" checked={showGuides} onCheckedChange={setShowGuides} />
+                    <span className="select-none text-sm text-white">Show spacing guides</span>
+                </div>
+                <div className="flex flex-col gap-12">
+                    {TIER_ORDER.map((tier, i) => (
+                        <ExampleColumn key={tier} tier={tier} width={widths[i] ?? 'w-full'} showGuides={showGuides} />
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+const meta = {
+    component: SizesView,
+    parameters: {
+        docs: {
+            description: {
+                component: [
+                    'Design-system size tokens for a detail page (Transaction / Block / Account): the content',
+                    'column max-width and the vertical/horizontal spacing rhythm. Each is its own `DSCOMMON_*`',
+                    'variable; the spacing values are per-tier and the tier boundaries (`TIER_BREAKPOINTS`) are a',
+                    'per-page variable. Tokens live in `@/app/shared/ui/page-spacing/spacing`.',
+                    '',
+                    '## References',
+                    '',
+                    '- [PageHeader](?path=/docs/components-shared-pageheader--docs) — the "Details / <title>" page header rendered at the top of each example column.',
+                    '- [Card](?path=/docs/components-shared-card-basecard--docs) — the detail-page block surface; the example blocks stand in for it.',
+                    '- [Switch](?path=/docs/components-shared-switch--docs) — toggles the spacing guide lines on the example page.',
+                ].join('\n'),
+            },
+        },
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    title: 'Design System/Sizes',
+} satisfies Meta<typeof SizesView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Reference: Story = {
+    render: () => <SizesView />,
+};

--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -45,7 +45,9 @@ export function Row({ children, className, divider, ...props }: RowProps) {
         <div
             className={cn(
                 'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
-                divider && 'border-1 border-b border-white/10 [border-bottom-style:solid]',
+                // `last:border-b-0` drops the trailing divider so it can't double up with the card's own
+                // bottom border — the shared idiom used across the account/transaction cards.
+                divider && 'border-1 border-b border-white/10 [border-bottom-style:solid] last:border-b-0',
                 className,
             )}
             {...props}

--- a/app/features/vote/ui/VoteAccountSection.tsx
+++ b/app/features/vote/ui/VoteAccountSection.tsx
@@ -1,129 +1,236 @@
-import { AccountAddressRow, AccountBalanceRow } from '@components/common/Account';
 import { Address } from '@components/common/Address';
+import { Copyable } from '@components/common/Copyable';
 import { Slot } from '@components/common/Slot';
 import { SolBalance } from '@components/common/SolBalance';
-import { useRefreshAccount } from '@entities/account';
-import { AccountCard } from '@features/account';
+import { TableCardBody } from '@components/common/TableCardBody';
+import { RefreshButton } from '@components/shared/ui/refresh-button';
+import { cn } from '@components/shared/utils';
+import { useRawAccountDataOnMount, useRefreshAccount } from '@entities/account';
+import { AccountDownloadDropdown } from '@features/account';
 import { Account } from '@providers/accounts';
 import { displayTimestamp } from '@utils/date';
+import React from 'react';
+import { Code } from 'react-feather';
 
-import { BaseTable } from '@/app/shared/ui/Table';
+import { Button } from '@/app/components/shared/ui/button';
+import { BaseRawAccountRows } from '@/app/shared/ui/BaseRawAccountRows';
+import { Card } from '@/app/shared/ui/Card';
+import { DSCOMMON_BETWEEN_BLOCKS } from '@/app/shared/ui/page-spacing/spacing';
 
 import { VoteAccount } from '../lib/validators';
 
+// Grid-based key/value row, mirroring the block Overview card so account overview cards stay consistent
+// across pages. The `1fr` value column lets long mono values wrap (`break-all`) instead of forcing the
+// whole card into horizontal scroll on narrow screens.
+type RowProps = React.HTMLAttributes<HTMLDivElement> & { divider?: boolean };
+function Row({ children, className, divider, ...props }: RowProps) {
+    return (
+        <div
+            className={cn(
+                'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
+                divider && 'border-1 border-b border-white/10 [border-bottom-style:solid]',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+}
+
+function Label({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn('flex flex-wrap items-center gap-1 overflow-hidden text-sm text-outer-space-300', className)}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+}
+
+// `mono` toggles the monospace face — on for hashes/addresses/numbers, off for prose like dates.
+// (cn is plain clsx here, so an added `font-sans` wouldn't reliably beat a hardcoded `font-mono`;
+// omitting `font-mono` and inheriting the sans default is the robust way to opt out.)
+// `breakAll` lets a long unbreakable token (a pubkey) wrap anywhere instead of forcing horizontal
+// scroll; turn it off for space-separated prose so words wrap whole, only at the spaces.
+function Value({
+    children,
+    className,
+    mono = true,
+    breakAll = true,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement> & { mono?: boolean; breakAll?: boolean }) {
+    return (
+        <div className={cn('text-sm text-white', breakAll && 'break-all', mono && 'font-mono', className)} {...props}>
+            {children}
+        </div>
+    );
+}
+
+// Raw account bytes view — mounted only while the Raw toggle is on so its SWR fetch (useRawAccountDataOnMount)
+// doesn't run for the common case. Kept in the shared BaseTable format the other account cards use.
+function RawAccountRows({ account }: { account: Account }) {
+    const { data, isLoading } = useRawAccountDataOnMount(account.pubkey);
+    return (
+        <TableCardBody>
+            <BaseRawAccountRows account={account} rawData={data} isLoading={isLoading} />
+        </TableCardBody>
+    );
+}
+
 export function VoteAccountSection({ account, voteAccount }: { account: Account; voteAccount: VoteAccount }) {
     const refresh = useRefreshAccount();
+    const [showRaw, setShowRaw] = React.useState(false);
     const rootSlot = voteAccount.info.rootSlot;
+
     return (
-        <AccountCard
-            title="Vote Account"
-            account={account}
-            analyticsSection="vote_account_section"
-            refresh={() => refresh(account.pubkey, 'parsed')}
-        >
-            <AccountAddressRow account={account} />
-            <AccountBalanceRow account={account} />
+        <section className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-2">
+                <h2 className="m-0 text-lg font-normal text-white">Vote Account</h2>
+                <div className="flex items-center gap-2">
+                    <RefreshButton
+                        analyticsSection="vote_account_section"
+                        onClick={() => refresh(account.pubkey, 'parsed')}
+                    />
+                    <Button
+                        variant={showRaw ? 'default' : 'outline'}
+                        size="sm"
+                        aria-label="Raw"
+                        className={showRaw ? 'shadow-active-sm' : undefined}
+                        onClick={() => setShowRaw(r => !r)}
+                    >
+                        <Code size={12} />
+                        <span className="hidden md:inline">Raw</span>
+                    </Button>
+                    <AccountDownloadDropdown pubkey={account.pubkey} space={account.space} />
+                </div>
+            </div>
 
-            <BaseTable.Row>
-                <BaseTable.Cell>
-                    Authorized Voter
-                    {voteAccount.info.authorizedVoters.length > 1 ? 's' : ''}
-                </BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    {voteAccount.info.authorizedVoters.map(voter => {
-                        // The same voter can appear once per epoch, so the pubkey alone is not unique
-                        return (
-                            <Address
-                                pubkey={voter.authorizedVoter}
-                                key={`${voter.epoch}-${voter.authorizedVoter.toString()}`}
-                                alignRight
-                                raw
-                                link
-                            />
-                        );
-                    })}
-                </BaseTable.Cell>
-            </BaseTable.Row>
+            {/* Card outline matched to the block page's tight cards: visible `outer-space-800` border,
+                8px radius, no dashkit shadow. `overflow-hidden` clips the row dividers to the corners.
+                The bottom margin is the shared between-blocks token (gap to the tabs below). */}
+            <Card
+                variant="tight"
+                className={cn(
+                    DSCOMMON_BETWEEN_BLOCKS.marginClassName,
+                    'overflow-hidden !rounded-lg border-outer-space-800 bg-outer-space-900',
+                )}
+            >
+                {showRaw ? (
+                    <RawAccountRows account={account} />
+                ) : (
+                    <>
+                        <Row divider>
+                            <Label>Address</Label>
+                            <Value className="flex w-full min-w-0 items-baseline">
+                                {/* Address renders its own Copyable (Address.tsx) — don't wrap it in another. */}
+                                <Address pubkey={account.pubkey} raw noTruncate />
+                            </Value>
+                        </Row>
 
-            <BaseTable.Row>
-                <BaseTable.Cell>Authorized Withdrawer</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={voteAccount.info.authorizedWithdrawer} alignRight raw link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
+                        <Row divider>
+                            <Label>Balance (SOL)</Label>
+                            <Value className="uppercase">
+                                <SolBalance lamports={account.lamports} />
+                            </Value>
+                        </Row>
 
-            <BaseTable.Row>
-                <BaseTable.Cell>Last Timestamp</BaseTable.Cell>
-                <BaseTable.Cell className="text-right font-mono">
-                    {displayTimestamp(voteAccount.info.lastTimestamp.timestamp * 1000)}
-                </BaseTable.Cell>
-            </BaseTable.Row>
+                        <Row divider>
+                            <Label>Authorized Voter{voteAccount.info.authorizedVoters.length > 1 ? 's' : ''}</Label>
+                            <Value className="flex flex-col gap-1">
+                                {voteAccount.info.authorizedVoters.map(voter => (
+                                    // The same voter can appear once per epoch, so the pubkey alone is not unique
+                                    <Address
+                                        pubkey={voter.authorizedVoter}
+                                        key={`${voter.epoch}-${voter.authorizedVoter.toString()}`}
+                                        link
+                                        noTruncate
+                                    />
+                                ))}
+                            </Value>
+                        </Row>
 
-            <BaseTable.Row>
-                <BaseTable.Cell>Commission</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">{`${voteAccount.info.commission}%`}</BaseTable.Cell>
-            </BaseTable.Row>
+                        <Row divider>
+                            <Label>Authorized Withdrawer</Label>
+                            <Value>
+                                <Address pubkey={voteAccount.info.authorizedWithdrawer} link noTruncate />
+                            </Value>
+                        </Row>
 
-            {voteAccount.info.blsPubkeyCompressed && (
-                <BaseTable.Row>
-                    <BaseTable.Cell>BLS Pubkey</BaseTable.Cell>
-                    <BaseTable.Cell className="text-right font-mono">
-                        {voteAccount.info.blsPubkeyCompressed}
-                    </BaseTable.Cell>
-                </BaseTable.Row>
-            )}
+                        <Row divider>
+                            <Label>Last Timestamp</Label>
+                            <Value mono={false}>
+                                {displayTimestamp(voteAccount.info.lastTimestamp.timestamp * 1000)}
+                            </Value>
+                        </Row>
 
-            {voteAccount.info.inflationRewardsCommissionBps !== undefined && (
-                <BaseTable.Row>
-                    <BaseTable.Cell>Inflation Rewards Commission</BaseTable.Cell>
-                    <BaseTable.Cell className="text-right">
-                        {`${voteAccount.info.inflationRewardsCommissionBps / 100}%`}
-                    </BaseTable.Cell>
-                </BaseTable.Row>
-            )}
+                        <Row divider>
+                            <Label>Commission</Label>
+                            <Value mono={false}>{`${voteAccount.info.commission}%`}</Value>
+                        </Row>
 
-            {voteAccount.info.inflationRewardsCollector && (
-                <BaseTable.Row>
-                    <BaseTable.Cell>Inflation Rewards Collector</BaseTable.Cell>
-                    <BaseTable.Cell className="text-right">
-                        <Address pubkey={voteAccount.info.inflationRewardsCollector} alignRight raw link />
-                    </BaseTable.Cell>
-                </BaseTable.Row>
-            )}
+                        {voteAccount.info.blsPubkeyCompressed && (
+                            <Row divider>
+                                <Label>BLS Pubkey</Label>
+                                <Value className="flex w-full min-w-0 items-baseline">
+                                    <Copyable text={voteAccount.info.blsPubkeyCompressed}>
+                                        <span className="min-w-0 break-all">
+                                            {voteAccount.info.blsPubkeyCompressed}
+                                        </span>
+                                    </Copyable>
+                                </Value>
+                            </Row>
+                        )}
 
-            {voteAccount.info.blockRevenueCommissionBps !== undefined && (
-                <BaseTable.Row>
-                    <BaseTable.Cell>Block Revenue Commission</BaseTable.Cell>
-                    <BaseTable.Cell className="text-right">
-                        {`${voteAccount.info.blockRevenueCommissionBps / 100}%`}
-                    </BaseTable.Cell>
-                </BaseTable.Row>
-            )}
+                        {voteAccount.info.inflationRewardsCommissionBps !== undefined && (
+                            <Row divider>
+                                <Label>Inflation Rewards Commission</Label>
+                                <Value mono={false}>{`${voteAccount.info.inflationRewardsCommissionBps / 100}%`}</Value>
+                            </Row>
+                        )}
 
-            {voteAccount.info.blockRevenueCollector && (
-                <BaseTable.Row>
-                    <BaseTable.Cell>Block Revenue Collector</BaseTable.Cell>
-                    <BaseTable.Cell className="text-right">
-                        <Address pubkey={voteAccount.info.blockRevenueCollector} alignRight raw link />
-                    </BaseTable.Cell>
-                </BaseTable.Row>
-            )}
+                        {voteAccount.info.inflationRewardsCollector && (
+                            <Row divider>
+                                <Label>Inflation Rewards Collector</Label>
+                                <Value>
+                                    <Address pubkey={voteAccount.info.inflationRewardsCollector} link noTruncate />
+                                </Value>
+                            </Row>
+                        )}
 
-            {voteAccount.info.pendingDelegatorRewards !== undefined && (
-                <BaseTable.Row>
-                    <BaseTable.Cell>Pending Delegator Rewards (SOL)</BaseTable.Cell>
-                    <BaseTable.Cell className="text-right">
-                        <SolBalance lamports={BigInt(voteAccount.info.pendingDelegatorRewards)} />
-                    </BaseTable.Cell>
-                </BaseTable.Row>
-            )}
+                        {voteAccount.info.blockRevenueCommissionBps !== undefined && (
+                            <Row divider>
+                                <Label>Block Revenue Commission</Label>
+                                <Value mono={false}>{`${voteAccount.info.blockRevenueCommissionBps / 100}%`}</Value>
+                            </Row>
+                        )}
 
-            <BaseTable.Row>
-                <BaseTable.Cell>Root Slot</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    {rootSlot !== null ? <Slot slot={rootSlot} link /> : 'N/A'}
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </AccountCard>
+                        {voteAccount.info.blockRevenueCollector && (
+                            <Row divider>
+                                <Label>Block Revenue Collector</Label>
+                                <Value>
+                                    <Address pubkey={voteAccount.info.blockRevenueCollector} link noTruncate />
+                                </Value>
+                            </Row>
+                        )}
+
+                        {voteAccount.info.pendingDelegatorRewards !== undefined && (
+                            <Row divider>
+                                <Label>Pending Delegator Rewards (SOL)</Label>
+                                <Value>
+                                    <SolBalance lamports={BigInt(voteAccount.info.pendingDelegatorRewards)} />
+                                </Value>
+                            </Row>
+                        )}
+
+                        <Row>
+                            <Label>Root Slot</Label>
+                            <Value>{rootSlot !== null ? <Slot slot={rootSlot} link /> : 'N/A'}</Value>
+                        </Row>
+                    </>
+                )}
+            </Card>
+        </section>
     );
 }

--- a/app/features/vote/ui/VoteAccountSection.tsx
+++ b/app/features/vote/ui/VoteAccountSection.tsx
@@ -28,7 +28,9 @@ function Row({ children, className, divider, ...props }: RowProps) {
         <div
             className={cn(
                 'grid min-h-9 grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 px-3 py-2.5 md:px-4',
-                divider && 'border-1 border-b border-white/10 [border-bottom-style:solid]',
+                // `last:border-b-0` drops the trailing divider so it can't double up with the card's own
+                // bottom border — the shared idiom used across the account/transaction cards.
+                divider && 'border-1 border-b border-white/10 [border-bottom-style:solid] last:border-b-0',
                 className,
             )}
             {...props}

--- a/app/features/vote/ui/VoteAccountSection.tsx
+++ b/app/features/vote/ui/VoteAccountSection.tsx
@@ -2,7 +2,7 @@ import { Address } from '@components/common/Address';
 import { Copyable } from '@components/common/Copyable';
 import { Slot } from '@components/common/Slot';
 import { SolBalance } from '@components/common/SolBalance';
-import { TableCardBody } from '@components/common/TableCardBody';
+import { RawDataField } from '@components/shared/RawDataField';
 import { RefreshButton } from '@components/shared/ui/refresh-button';
 import { cn } from '@components/shared/utils';
 import { useRawAccountDataOnMount, useRefreshAccount } from '@entities/account';
@@ -13,7 +13,6 @@ import React from 'react';
 import { Code } from 'react-feather';
 
 import { Button } from '@/app/components/shared/ui/button';
-import { BaseRawAccountRows } from '@/app/shared/ui/BaseRawAccountRows';
 import { Card } from '@/app/shared/ui/Card';
 import { DSCOMMON_BETWEEN_BLOCKS } from '@/app/shared/ui/page-spacing/spacing';
 
@@ -71,13 +70,52 @@ function Value({
 }
 
 // Raw account bytes view — mounted only while the Raw toggle is on so its SWR fetch (useRawAccountDataOnMount)
-// doesn't run for the common case. Kept in the shared BaseTable format the other account cards use.
+// doesn't run for the common case. Uses the same grid Row/Label/Value layout as the default view so the
+// card looks consistent when toggled (rather than the old dashkit BaseTable rows).
 function RawAccountRows({ account }: { account: Account }) {
     const { data, isLoading } = useRawAccountDataOnMount(account.pubkey);
     return (
-        <TableCardBody>
-            <BaseRawAccountRows account={account} rawData={data} isLoading={isLoading} />
-        </TableCardBody>
+        <>
+            <Row divider>
+                <Label>Address</Label>
+                <Value className="flex w-full min-w-0 items-baseline">
+                    <Address pubkey={account.pubkey} raw noTruncate />
+                </Value>
+            </Row>
+
+            <Row divider>
+                <Label>Balance (SOL)</Label>
+                <Value className="uppercase">
+                    <SolBalance lamports={account.lamports} />
+                </Value>
+            </Row>
+
+            <Row divider>
+                <Label>Assigned Program Id</Label>
+                <Value>
+                    <Address pubkey={account.owner} link noTruncate />
+                </Value>
+            </Row>
+
+            {account.space !== undefined && (
+                <Row divider>
+                    <Label>Allocated Data Size</Label>
+                    <Value mono={false}>{account.space} byte(s)</Value>
+                </Row>
+            )}
+
+            <Row divider>
+                <Label>Executable</Label>
+                <Value mono={false}>{account.executable ? 'Yes' : 'No'}</Value>
+            </Row>
+
+            <Row divider>
+                <Label>Raw Data</Label>
+                <Value className="min-w-0">
+                    <RawDataField data={data} filename={account.pubkey.toBase58()} loading={isLoading} />
+                </Value>
+            </Row>
+        </>
     );
 }
 

--- a/app/features/vote/ui/VotesCard.tsx
+++ b/app/features/vote/ui/VotesCard.tsx
@@ -30,7 +30,7 @@ export function VotesCard({ voteAccount, layout = 'table' }: { voteAccount: Vote
                 // Surface matched to the transaction Tokens/Accounts card, in pure Tailwind: bg
                 // `outer-space-900` equals `#1e2423` (dashkit `dk-gray-800-dark`); `border-outer-space-800`
                 // gives the card the same tone as the row separators; `rounded-lg` is the 8px radius.
-                <Card variant="tight" className="rounded-lg border-outer-space-800 bg-outer-space-900">
+                <Card variant="tight" className="!rounded-lg border-outer-space-800 bg-outer-space-900">
                     <VotesGrid votes={votes} />
                 </Card>
             ) : (

--- a/app/features/vote/ui/VotesCard.tsx
+++ b/app/features/vote/ui/VotesCard.tsx
@@ -1,49 +1,145 @@
 import { Slot } from '@components/common/Slot';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
+import { cva } from 'class-variance-authority';
 
-import { Card, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
+import { Card, CardFooter } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 import { Vote, VoteAccount } from '../lib/validators';
 
-export function VotesCard({ voteAccount }: { voteAccount: VoteAccount }) {
+// Column labels shared by both layouts so the header copy can't drift between table and grid.
+const COLUMNS = ['Slot', 'Confirmation Count'] as const;
+
+export type VotesLayout = 'table' | 'grid';
+
+// The card is a collapsible section: the "Vote History" heading is lifted out above the surface with a
+// chevron toggle + height animation (shared `CollapsibleSection`, `className=""` so the surface comes
+// from the `<Card>` below).
+//
+// `layout` picks how the vote list is rendered inside the card:
+// - `table` (default) — the shared `<BaseTable>` (a real `<table>`), keeping the original dashkit surface.
+// - `grid` — a CSS-grid list built from `div`s, mirroring the transaction page's Accounts/Token Balances
+//   tables. Desktop visuals match `table`; the internals differ so the two can diverge on mobile later.
+export function VotesCard({ voteAccount, layout = 'table' }: { voteAccount: VoteAccount; layout?: VotesLayout }) {
+    // Newest vote first, matching the original table order.
+    const votes = [...voteAccount.info.votes].reverse();
+
+    return (
+        <CollapsibleSection title="Vote History" className="">
+            {layout === 'grid' ? (
+                // Surface matched to the transaction Tokens/Accounts card, in pure Tailwind: bg
+                // `outer-space-900` equals `#1e2423` (dashkit `dk-gray-800-dark`); `border-outer-space-800`
+                // gives the card the same tone as the row separators; `rounded-lg` is the 8px radius.
+                <Card variant="tight" className="rounded-lg border-outer-space-800 bg-outer-space-900">
+                    <VotesGrid votes={votes} />
+                </Card>
+            ) : (
+                <Card ui="dashkit" marginBottom="none">
+                    <VotesTable votes={votes} />
+                </Card>
+            )}
+        </CollapsibleSection>
+    );
+}
+
+// `<table>` layout — the shared BaseTable (dashkit surface) with the original Slot / Confirmation Count
+// columns and the "No votes found" empty footer.
+function VotesTable({ votes }: { votes: Vote[] }) {
     return (
         <>
-            <Card ui="dashkit">
-                <CardHeader ui="dashkit">
-                    <CardTitle as="h3" ui="dashkit">
-                        Vote History
-                    </CardTitle>
-                </CardHeader>
-                <BaseTable ui="dashkit" variant="card" nowrap>
-                    <BaseTable.Head>
-                        <BaseTable.Row>
-                            <BaseTable.HeaderCell className="w-px text-dk-gray-700">Slot</BaseTable.HeaderCell>
-                            <BaseTable.HeaderCell className="text-dk-gray-700">Confirmation Count</BaseTable.HeaderCell>
+            <BaseTable ui="dashkit" variant="card" nowrap>
+                <BaseTable.Head>
+                    <BaseTable.Row>
+                        <BaseTable.HeaderCell className="w-px text-dk-gray-700">Slot</BaseTable.HeaderCell>
+                        <BaseTable.HeaderCell className="text-dk-gray-700">Confirmation Count</BaseTable.HeaderCell>
+                    </BaseTable.Row>
+                </BaseTable.Head>
+                <BaseTable.Body>
+                    {votes.map(vote => (
+                        <BaseTable.Row key={vote.slot}>
+                            <BaseTable.Cell className="w-px font-mono">
+                                <Slot slot={vote.slot} link />
+                            </BaseTable.Cell>
+                            <BaseTable.Cell className="font-mono">{vote.confirmationCount}</BaseTable.Cell>
                         </BaseTable.Row>
-                    </BaseTable.Head>
-                    <BaseTable.Body>
-                        {voteAccount.info.votes.length > 0 &&
-                            [...voteAccount.info.votes].reverse().map(vote => renderAccountRow(vote))}
-                    </BaseTable.Body>
-                </BaseTable>
+                    ))}
+                </BaseTable.Body>
+            </BaseTable>
 
-                <CardFooter ui="dashkit">
-                    <div className="text-center text-dk-gray-700">
-                        {voteAccount.info.votes.length > 0 ? '' : 'No votes found'}
-                    </div>
-                </CardFooter>
-            </Card>
+            <CardFooter ui="dashkit">
+                <div className="text-center text-dk-gray-700">{votes.length > 0 ? '' : 'No votes found'}</div>
+            </CardFooter>
         </>
     );
 }
 
-const renderAccountRow = (vote: Vote) => {
+// `gridCellVariants` owns all cell styling. `role` picks header vs body chrome; body cells are mono to
+// keep the numeric columns aligned (same as the table). Header cells leave `column` at its default.
+const gridCellVariants = cva('flex px-3 py-2.5', {
+    defaultVariants: { column: 'none', role: 'body' },
+    variants: {
+        // Per-column body concerns. Column widths are set on the grid track (see `VotesGrid`); here
+        // `slot` stays a mono number on one line, while `count` uses the default (non-mono) font and
+        // collapses to `min-w-0`.
+        column: {
+            count: 'min-w-0 whitespace-nowrap',
+            none: '',
+            slot: 'whitespace-nowrap font-mono',
+        },
+        // Header vs body chrome. `header`: muted uppercase `text-xs` labels. `body`: `outer-space-800`
+        // top border (same tone as the card border) as the row separator.
+        role: {
+            body: 'items-center border-t border-solid border-outer-space-800',
+            header: 'items-center whitespace-nowrap text-xs uppercase text-outer-space-300',
+        },
+    },
+});
+
+// CSS-grid layout — a single 2-column grid so columns stay aligned across header and rows the way a
+// `<table>`'s shared columns do. The Slot column follows the transaction Summary card's ratio, raising
+// the floor to 132px (`clamp(132px,25%,200px)`): a fixed responsive band 132–200px targeting 25% of the
+// width, with Confirmation Count taking the rest (`1fr`).
+function VotesGrid({ votes }: { votes: Vote[] }) {
     return (
-        <BaseTable.Row key={vote.slot}>
-            <BaseTable.Cell className="w-px font-mono">
-                <Slot slot={vote.slot} link />
-            </BaseTable.Cell>
-            <BaseTable.Cell className="font-mono">{vote.confirmationCount}</BaseTable.Cell>
-        </BaseTable.Row>
+        <div className="w-full overflow-x-auto text-sm text-white">
+            {/* `role="table"` + `role="row"` wrappers restore the semantics the old `<table>` gave screen
+                readers. The row wrappers use `contents` (`display: contents`) so they generate no box and
+                their cells stay direct participants in this grid — ARIA structure without disturbing the
+                CSS-grid column alignment. */}
+            <div
+                role="table"
+                aria-label="Vote history"
+                className="grid min-w-full grid-cols-[clamp(132px,25%,200px)_1fr]"
+            >
+                <div role="row" className="contents">
+                    {COLUMNS.map(label => (
+                        <div key={label} role="columnheader" className={gridCellVariants({ role: 'header' })}>
+                            {label}
+                        </div>
+                    ))}
+                </div>
+                {votes.length > 0 ? (
+                    votes.map(vote => (
+                        <div key={vote.slot} role="row" className="contents">
+                            <div role="cell" className={gridCellVariants({ column: 'slot' })}>
+                                <Slot slot={vote.slot} link />
+                            </div>
+                            <div role="cell" className={gridCellVariants({ column: 'count' })}>
+                                {vote.confirmationCount}
+                            </div>
+                        </div>
+                    ))
+                ) : (
+                    <div role="row" className="contents">
+                        <div
+                            role="cell"
+                            className="col-span-2 border-t border-solid border-outer-space-800 px-3 py-2.5 text-center text-outer-space-300"
+                        >
+                            No votes found
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
     );
-};
+}

--- a/app/features/vote/ui/__stories__/VoteAccountSection.stories.tsx
+++ b/app/features/vote/ui/__stories__/VoteAccountSection.stories.tsx
@@ -9,7 +9,31 @@ import { accountFixture, BASE_SLOT, voteAccountFixture, voteAccountV4Fixture } f
 const meta = {
     component: VoteAccountSection,
     decorators: [withMockRpc, withClusterAndAccounts, withTokenInfoBatch],
-    parameters: nextjsParameters,
+    parameters: {
+        ...nextjsParameters,
+        docs: {
+            description: {
+                component: [
+                    'The vote account\'s overview card, matched to the block Overview card: the "Vote Account"',
+                    'heading is lifted out above the surface with the account actions beside it, and the fields',
+                    'render as a key/value grid. This component supplies the copy and per-field data; everything',
+                    'else is composed from the shared primitives below.',
+                    '',
+                    '## References',
+                    '',
+                    '- [Card](?path=/docs/components-shared-card-basecard--docs) (`ui="dashkit"`) — the surface holding the rows.',
+                    '- Key/value grid — local `Row`/`Label`/`Value` helpers: a CSS grid (`clamp(100px,25%,200px) 1fr`) with muted `outer-space-300` labels and `break-all` values, mirroring the block Overview card. Long pubkeys wrap instead of forcing horizontal scroll; a bottom `white/10` divider separates rows.',
+                    '- [RefreshButton](?path=/docs/components-shared-refreshbutton--docs) — reloads the parsed account (`analyticsSection="vote_account_section"`).',
+                    '- [Button](?path=/docs/components-shared-button--docs) (`variant="outline" size="sm"`) — the Raw toggle (a `Code` icon plus a `Raw` label on `md+`) that swaps the grid for the raw-bytes view.',
+                    '- [AccountDownloadDropdown](?path=/docs/shared-downloaddropdown--docs) — downloads the raw account data; wraps the shared `DownloadDropdown`.',
+                    '- [Address](?path=/docs/components-common-address--docs) — renders the account address (`raw`) and the linked voter / withdrawer / collector pubkeys; each carries its own copy button (`Copyable`) and tooltip, so rows must not wrap it in another `Copyable`.',
+                    '- `SolBalance` — renders the balance and (SIMD-0185) pending delegator rewards as a ◎ SOL amount.',
+                    '- `Slot` — renders the Root Slot as a linked slot number.',
+                    '- [BaseRawAccountRows](?path=/docs/features-account-baserawaccountrows--docs) inside a `TableCardBody` — the raw-bytes view shown while the Raw toggle is on; mounted lazily so its SWR fetch only runs when opened.',
+                ].join('\n'),
+            },
+        },
+    },
     tags: ['autodocs', 'test'],
     title: 'Features/Vote/VoteAccountSection',
 } satisfies Meta<typeof VoteAccountSection>;

--- a/app/features/vote/ui/__stories__/VotesCard.responsive.stories.tsx
+++ b/app/features/vote/ui/__stories__/VotesCard.responsive.stories.tsx
@@ -25,7 +25,9 @@ const votes = Array.from({ length: 6 }, (_, i) => ({
     slot: BASE_SLOT + i,
 }));
 
+// Grid layout is the mobile-focused one, so the responsive stories exercise it.
 const args = {
+    layout: 'grid' as const,
     voteAccount: voteAccountFixture(votes),
 };
 

--- a/app/features/vote/ui/__stories__/VotesCard.stories.tsx
+++ b/app/features/vote/ui/__stories__/VotesCard.stories.tsx
@@ -5,6 +5,14 @@ import { VotesCard } from '../VotesCard';
 import { BASE_SLOT, voteAccountFixture } from './fixtures';
 
 const meta: Meta<typeof VotesCard> = {
+    argTypes: {
+        layout: {
+            control: 'inline-radio',
+            description:
+                'Inner list rendering. `table` uses the shared `<BaseTable>`; `grid` uses a CSS-grid built from `div`s (desktop-identical, diverges on mobile later).',
+            options: ['table', 'grid'],
+        },
+    },
     component: VotesCard,
     decorators: [withCluster],
     parameters: nextjsParameters,
@@ -29,5 +37,14 @@ export const WithVotes: Story = {
 export const Empty: Story = {
     args: {
         voteAccount: voteAccountFixture([]),
+    },
+};
+
+// `layout="grid"` renders the same list as a CSS grid instead of a `<table>`. Desktop visuals match the
+// table stories above; the internals differ so mobile can diverge later. Flip the `layout` control.
+export const GridLayout: Story = {
+    args: {
+        layout: 'grid',
+        voteAccount: voteAccountFixture(votes),
     },
 };

--- a/app/features/vote/ui/__stories__/VotesCard.stories.tsx
+++ b/app/features/vote/ui/__stories__/VotesCard.stories.tsx
@@ -15,7 +15,26 @@ const meta: Meta<typeof VotesCard> = {
     },
     component: VotesCard,
     decorators: [withCluster],
-    parameters: nextjsParameters,
+    parameters: {
+        ...nextjsParameters,
+        docs: {
+            description: {
+                component: [
+                    'The vote account\'s vote history as a collapsible section — the "Vote History" heading is',
+                    'lifted out above the card and a toggle collapses the list. The `layout` prop picks how the',
+                    'list renders; everything else is composed from the shared primitives below.',
+                    '',
+                    '## References',
+                    '',
+                    '- [CollapsibleSection](?path=/docs/components-shared-collapsiblesection--docs) — the shared collapsible wrapper: the heading lifted out above the surface, a `Collapse`/`Expand` toggle, and the height animation. Passed `className=""` so the surface comes from the `<Card>` below.',
+                    '- [Card](?path=/docs/components-shared-card-basecard--docs) — the surface holding the list: a Tailwind `variant="tight"` card for `layout="grid"`, or `ui="dashkit"` for `layout="table"`.',
+                    '- [BaseTable](?path=/docs/components-shared-table-basetable--docs) — the `layout="table"` list (the original dashkit surface): a real `<table>` with "Slot" / "Confirmation Count" columns and a "No votes found" empty footer.',
+                    '- Vote grid — the `layout="grid"` list: a pure-Tailwind CSS grid (`clamp(132px,25%,200px) 1fr`) built from `div`s with `role="table"`/`row`/`cell` for a11y, mirroring the transaction Accounts/Token Balances tables. Desktop visuals match the table; the internals differ so mobile can diverge later.',
+                    '- `Slot` — fills the "Slot" cell, rendering each vote\'s slot as a linked slot number.',
+                ].join('\n'),
+            },
+        },
+    },
     tags: ['autodocs', 'test'],
     title: 'Features/Vote/VotesCard',
 };

--- a/app/shared/ui/page-header/PageHeader.tsx
+++ b/app/shared/ui/page-header/PageHeader.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { cn } from '@/app/components/shared/utils';
+import { DSCOMMON_EYEBROW_TO_TITLE } from '@/app/shared/ui/page-spacing/spacing';
+
+type PageHeaderProps = {
+    /** Main page title, rendered as the page's <h1>. */
+    title: React.ReactNode;
+    /** Small muted uppercase eyebrow above the title. Defaults to "Details". */
+    eyebrow?: React.ReactNode;
+    /** Wrapper element — `header` by default for page-level semantics; use `div` when nested. */
+    as?: 'header' | 'div';
+    /** Extra classes on the wrapper, for per-page vertical spacing (py / mb / min-h / etc.). */
+    className?: string;
+};
+
+// The canonical "Details / <title>" page header: a muted uppercase eyebrow above a large title.
+// Shared so the transaction, block, and account pages don't each re-implement — and drift on — the
+// markup, sizes, and colors. Per-page vertical spacing stays a concern of the caller via `className`.
+export function PageHeader({ title, eyebrow = 'Details', as = 'header', className }: PageHeaderProps) {
+    const Wrapper = as as React.ElementType;
+    return (
+        <Wrapper className={cn('flex flex-col', DSCOMMON_EYEBROW_TO_TITLE.className, className)}>
+            <span className="text-xs font-normal uppercase text-muted">{eyebrow}</span>
+            <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">{title}</h1>
+        </Wrapper>
+    );
+}

--- a/app/shared/ui/page-header/__stories__/PageHeader.stories.tsx
+++ b/app/shared/ui/page-header/__stories__/PageHeader.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { expect, within } from 'storybook/test';
+
+import { PageHeader } from '../PageHeader';
+
+// The "Details / <title>" header is identical across the Transaction, Block, and Account pages — only
+// the subtitle (eyebrow, on top) and the title (below) change. So this is one universal story; edit
+// the two texts via the controls instead of duplicating a story per page.
+const meta = {
+    argTypes: {
+        eyebrow: { control: 'text' },
+        title: { control: 'text' },
+    },
+    args: { eyebrow: 'Subtitle', title: 'Title' },
+    component: PageHeader,
+    tags: ['autodocs', 'test'],
+    title: 'Components/Shared/PageHeader',
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Subtitle')).toBeInTheDocument();
+        expect(canvas.getByRole('heading', { level: 1, name: 'Title' })).toBeInTheDocument();
+    },
+};

--- a/app/shared/ui/page-spacing/spacing.ts
+++ b/app/shared/ui/page-spacing/spacing.ts
@@ -1,0 +1,117 @@
+// Design-system COMMON page-spacing tokens (`DSCOMMON_*`) — the canonical vertical/horizontal rhythm
+// of a detail page (Transaction / Block / Account). Single source of truth: pages apply each token's
+// `className`, and the Page Spacing story documents the per-tier values off the same objects.
+//
+// Project breakpoints: xs 375 / sm 576 / md 768 / lg 992 / xl 1200.
+
+export type Bp = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type Tier = 'mobile' | 'tablet' | 'desktop';
+
+export const TIER_ORDER: Tier[] = ['mobile', 'tablet', 'desktop'];
+export const TIER_LABEL: Record<Tier, string> = { desktop: 'Desktop', mobile: 'Mobile', tablet: 'Tablet' };
+
+// Per-page tier boundaries: which breakpoints each tier covers ON THIS (detail) page. A different page
+// can end mobile later or start desktop earlier — change this and every consumer follows. This page's
+// spacing switches at `lg:`, so its mobile range runs through md and the wide values begin at lg.
+export const TIER_BREAKPOINTS: Record<Tier, Bp[]> = {
+    desktop: ['xl'],
+    mobile: ['xs', 'sm', 'md'],
+    tablet: ['lg'],
+};
+
+export function tierRange(t: Tier): string {
+    const bps = TIER_BREAKPOINTS[t];
+    return bps.length === 1 ? bps[0] : `${bps[0]}–${bps[bps.length - 1]}`;
+}
+
+// A spacing value at one tier: the px size, the Tailwind class producing it at that tier, and the fixed
+// band height reproducing it visually in the story (band omitted for non-band gaps).
+export type Val = { px: string; cls: string; band?: string };
+
+// One spacing token. `className` is the responsive Tailwind class a page applies. `marginClassName` is
+// the same size expressed as a per-element bottom margin, for gaps that a page applies as `mb-*` on the
+// preceding block rather than as `space-y-*` on a wrapper. `values` holds the resolved per-tier sizes
+// for the reference table.
+export type Spacing = {
+    name: string;
+    label: string;
+    className?: string;
+    marginClassName?: string;
+    values: Record<Tier, Val>;
+};
+
+export const DSCOMMON_PAGE_PADDING_X: Spacing = {
+    className: 'px-4 lg:px-6',
+    label: 'Page padding (horizontal)',
+    name: 'DSCOMMON_PAGE_PADDING_X',
+    values: {
+        desktop: { cls: 'lg:px-6', px: '24px' },
+        mobile: { cls: 'px-4', px: '16px' },
+        tablet: { cls: 'lg:px-6', px: '24px' },
+    },
+};
+export const DSCOMMON_BEFORE_HEADER: Spacing = {
+    className: 'pt-3 lg:pt-5',
+    label: 'Before header (page top)',
+    name: 'DSCOMMON_BEFORE_HEADER',
+    values: {
+        desktop: { band: 'h-5', cls: 'lg:pt-5', px: '20px' },
+        mobile: { band: 'h-3', cls: 'pt-3', px: '12px' },
+        tablet: { band: 'h-5', cls: 'lg:pt-5', px: '20px' },
+    },
+};
+export const DSCOMMON_EYEBROW_TO_TITLE: Spacing = {
+    className: 'gap-1.5',
+    label: 'Eyebrow → title',
+    name: 'DSCOMMON_EYEBROW_TO_TITLE',
+    values: {
+        desktop: { cls: 'gap-1.5', px: '6px' },
+        mobile: { cls: 'gap-1.5', px: '6px' },
+        tablet: { cls: 'gap-1.5', px: '6px' },
+    },
+};
+// The gap below the page header. Applied as the header wrapper's bottom margin; the header keeps only
+// its top padding (the space above the eyebrow comes from DSCOMMON_BEFORE_HEADER + that top padding).
+export const DSCOMMON_AFTER_HEADER: Spacing = {
+    className: 'mb-9',
+    label: 'After header → first block',
+    name: 'DSCOMMON_AFTER_HEADER',
+    values: {
+        desktop: { band: 'h-9', cls: 'mb-9', px: '36px' },
+        mobile: { band: 'h-9', cls: 'mb-9', px: '36px' },
+        tablet: { band: 'h-9', cls: 'mb-9', px: '36px' },
+    },
+};
+export const DSCOMMON_BETWEEN_BLOCKS: Spacing = {
+    className: 'space-y-9 lg:space-y-12',
+    label: 'Between blocks',
+    marginClassName: 'mb-9 lg:mb-12',
+    name: 'DSCOMMON_BETWEEN_BLOCKS',
+    values: {
+        desktop: { band: 'h-12', cls: 'lg:space-y-12', px: '48px' },
+        mobile: { band: 'h-9', cls: 'space-y-9', px: '36px' },
+        tablet: { band: 'h-12', cls: 'lg:space-y-12', px: '48px' },
+    },
+};
+
+export const DSCOMMON_SPACINGS: Spacing[] = [
+    DSCOMMON_PAGE_PADDING_X,
+    DSCOMMON_BEFORE_HEADER,
+    DSCOMMON_EYEBROW_TO_TITLE,
+    DSCOMMON_AFTER_HEADER,
+    DSCOMMON_BETWEEN_BLOCKS,
+];
+
+// A max-width token: the Tailwind class a page applies + its resolved value for the reference table.
+export type SizeToken = { name: string; label: string; className: string; value: string };
+
+// Content column max width — taken from the transaction page (`max-w-5xl`). Detail pages cap their
+// content column at this width.
+export const DSCOMMON_CONTENT_MAX_WIDTH_M: SizeToken = {
+    className: 'max-w-5xl',
+    label: 'Content column max width',
+    name: 'DSCOMMON_CONTENT_MAX_WIDTH_M',
+    value: '64rem (1024px)',
+};
+
+export const DSCOMMON_MAX_WIDTHS: SizeToken[] = [DSCOMMON_CONTENT_MAX_WIDTH_M];

--- a/app/shared/ui/sticky-header/StickyHeader.tsx
+++ b/app/shared/ui/sticky-header/StickyHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 
 import { cn } from '@/app/components/shared/utils';
 
@@ -11,38 +11,51 @@ type Props = {
     className?: string;
 };
 
+/**
+ * Sticky, full-bleed bar for a page's primary tab navigation (the address and block page tabs).
+ * Stretches its background edge-to-edge, keeps the tabs on the page's content column, and draws the
+ * section underline. Also publishes its height to `--sticky-header-height` (via `useStickyHeaderHeight`)
+ * so anchored content below can clear the bar.
+ *
+ * ── HOW TO EMBED IT (important) ──────────────────────────────────────────────────────────────────
+ * Render `StickyHeader` as a DIRECT CHILD of the page's content column — the same max-width/padding
+ * wrapper that holds the page body (dashkit `PageContainer`, the DSCOMMON content column, …). Do NOT
+ * wrap the tabs in another column container inside it, and do NOT place it at full page width.
+ *
+ * Why: the bar goes full-bleed with `ml/mr-[calc(50%-50vw)]` (stretch to the viewport edges) and then
+ * pulls the tabs back with matching `pl/pr-[calc(50vw-50%)]`. Those `50%` values resolve against the
+ * PARENT's width, so the pull-back only lines the tabs up with the body when the parent IS the content
+ * column. Because it reads the parent's width, it adapts to whatever column system the page uses
+ * without hardcoding a width — but placed anywhere else the tabs will not align with the content below
+ * (and a nested column wrapper would double-constrain them).
+ *
+ *     <PageContentColumn>
+ *         <StickyHeader>
+ *             <NavigationTabs … />   // tabs only — no inner column wrapper
+ *         </StickyHeader>
+ *         … page body …
+ *     </PageContentColumn>
+ *
+ * Underline: the `border-b` is full-bleed into the page margins on mobile/tablet (border on the
+ * full-bleed wrapper) and clipped to the content column at `lg` (border moves to the inner column
+ * wrapper). Spacing below the bar is the caller's — pass it via `className` (e.g. `mb-8`); the
+ * component adds none of its own.
+ */
 export function StickyHeader({ children, className }: Props) {
-    const sentinelRef = useRef<HTMLDivElement>(null);
     const headerRef = useRef<HTMLDivElement>(null);
-    const [isStuck, setIsStuck] = useState(false);
-
-    useEffect(() => {
-        const sentinel = sentinelRef.current;
-        if (!sentinel) return;
-
-        // threshold:1 fires as soon as the sentinel is no longer fully visible,
-        // which is the exact moment the header becomes sticky.
-        const observer = new IntersectionObserver(([entry]) => setIsStuck(!entry.isIntersecting), { threshold: [1] });
-        observer.observe(sentinel);
-
-        return () => observer.disconnect();
-    }, []);
-
     useStickyHeaderHeight(headerRef);
 
     return (
-        <>
-            <div ref={sentinelRef} aria-hidden="true" />
-            <div
-                ref={headerRef}
-                className={cn(
-                    'sticky top-0 z-10 mb-8 border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900',
-                    className,
-                )}
-                style={isStuck ? { marginLeft: 'calc(50% - 50vw)', width: '100vw' } : undefined}
-            >
-                <div className={cn(!isStuck && '-mx-3')}>{children}</div>
-            </div>
-        </>
+        <div
+            ref={headerRef}
+            className={cn(
+                'sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] lg:border-b-0 [&::-webkit-scrollbar]:hidden',
+                className,
+            )}
+        >
+            {/* Desktop (`lg+`): the underline lives here, on the content-column wrapper, so it stops at
+                the column edges instead of bleeding into the page margins. */}
+            <div className="lg:border-0 lg:border-b lg:border-solid lg:border-neutral-800">{children}</div>
+        </div>
     );
 }

--- a/app/shared/ui/sticky-header/__stories__/StickyHeader.stories.tsx
+++ b/app/shared/ui/sticky-header/__stories__/StickyHeader.stories.tsx
@@ -7,6 +7,46 @@ import { StickyHeader } from '@/app/shared/ui/sticky-header/StickyHeader';
 
 const meta: Meta<typeof StickyHeader> = {
     component: StickyHeader,
+    parameters: {
+        docs: {
+            description: {
+                component: [
+                    "Sticky, full-bleed bar for a page's primary tab navigation (address & block page tabs). It",
+                    'stretches its background edge-to-edge, keeps the tabs on the page content column, draws the',
+                    'section underline, and publishes its height to `--sticky-header-height` for anchored content.',
+                    '',
+                    '## How to embed it',
+                    '',
+                    'Render `StickyHeader` as a **direct child of the page content column** — the same',
+                    'max-width/padding wrapper that holds the page body (dashkit `PageContainer`, the DSCOMMON',
+                    'content column, …). Pass the tabs **directly**; do not wrap them in another column container,',
+                    'and do not place the bar at full page width.',
+                    '',
+                    '```tsx',
+                    '<PageContentColumn>',
+                    '    <StickyHeader className="mb-8">',
+                    '        <NavigationTabs … />   {/* tabs only — no inner column wrapper */}',
+                    '    </StickyHeader>',
+                    '    {/* … page body … */}',
+                    '</PageContentColumn>',
+                    '```',
+                    '',
+                    'Why placement matters: the bar goes full-bleed with `ml/mr-[calc(50%-50vw)]` and pulls the tabs',
+                    'back with matching `pl/pr-[calc(50vw-50%)]`. Those `50%` values resolve against the **parent**',
+                    'width, so the pull-back only aligns the tabs with the body when the parent IS the content',
+                    'column. This lets one component adapt to any column system (no hardcoded width) — but placed',
+                    'anywhere else the tabs will not line up with the content below, and a nested column wrapper',
+                    'would double-constrain them.',
+                    '',
+                    '## Underline & spacing',
+                    '',
+                    '- Underline (`border-b`) is full-bleed into the page margins on mobile/tablet and clipped to',
+                    '  the content column at `lg` (desktop).',
+                    '- The component adds **no** bottom spacing of its own — pass it via `className` (e.g. `mb-8`).',
+                ].join('\n'),
+            },
+        },
+    },
     tags: ['autodocs', 'test'],
     title: 'Components/Shared/StickyHeader',
 };
@@ -23,6 +63,8 @@ const TABS: NavigationTab[] = [
 
 const buildHref = (path: string) => `#${path}`;
 
+// The `PageContainer` decorator stands in for the page content column: `StickyHeader` is its direct
+// child, so the full-bleed pull-back lines the tabs up with the (would-be) page body below.
 export const Default: Story = {
     decorators: [
         Story => (
@@ -35,10 +77,8 @@ export const Default: Story = {
         ),
     ],
     render: () => (
-        <StickyHeader>
-            <PageContainer>
-                <BaseNavigationTabs activeValue="" buildHref={buildHref} tabs={TABS} onSelectChange={() => {}} />
-            </PageContainer>
+        <StickyHeader className="mb-8">
+            <BaseNavigationTabs activeValue="" buildHref={buildHref} tabs={TABS} onSelectChange={() => {}} />
         </StickyHeader>
     ),
 };

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -25,6 +25,7 @@ import { generateTokenBalanceRows, TokenBalancesCard } from '@/app/features/tran
 import { AutoRefresh, useAutoRefreshState } from '@/app/shared/lib/use-auto-refresh';
 import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
 import { BaseNavigationTabs } from '@/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs';
+import { PageHeader } from '@/app/shared/ui/page-header/PageHeader';
 import { useLogsPanelScrollSync } from '@/app/tx/[signature]/use-logs-scroll-sync';
 import useTabVisibility from '@/app/utils/use-tab-visibility';
 
@@ -84,10 +85,7 @@ export function TransactionDetailsPageClient({ params: { signature: raw } }: Pro
 
     return (
         <div className="mx-auto flex max-w-5xl flex-col space-y-9 px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:space-y-12 lg:px-6 lg:pt-5">
-            <header className="-mb-6 flex flex-col gap-1.5 pb-3 pt-2 lg:mb-0">
-                <span className="text-xs font-normal uppercase text-muted">Details</span>
-                <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Transaction</h1>
-            </header>
+            <PageHeader title="Transaction" className="-mb-6 pb-3 pt-2 lg:mb-0" />
 
             {signature === undefined ? (
                 <ErrorCard text={`Signature "${raw}" is not valid`} />


### PR DESCRIPTION
## Description

Reworks the vote account page (`/address/<vote>`) and its tabs onto the block/transaction page's layout system, and extracts the shared pieces behind it.

-   **Page header (all address pages)** — the "Details / \<title\>" heading now matches the block and transaction pages: a muted uppercase eyebrow over a larger `h1`, underline removed, content column capped at `max-w-5xl` with `px-4`/`lg:px-6` + `pt-3`/`lg:pt-5`. The tab bar is the shared full-bleed sticky bar (`StickyHeader`, now used by the block page too); its underline runs into the page margins on mobile/tablet and clips to the content column on desktop.
-   **Vote Account card** — rebuilt as the block-overview key/value grid: heading lifted above a visible tight-card surface, long values wrap instead of forcing horizontal scroll, the BLS pubkey is copyable. The Raw view now uses that same grid layout (no more dashkit table), and overview rows no longer double the bottom divider against the card border. Refresh / Raw / Download unchanged.
-   **Vote History** — rendered as a CSS grid with the heading lifted out and 8px corners.
-   **Rewards** — responsive CSS grid that stacks into labelled rows below `sm`; the SOL unit sits in the header and the `◎` glyph in the cells; equal-width columns with Reward and Post Balance right-aligned; heading lifted out; 12px padding around the Load More footer.
-   **Shared** — new `PageHeader` component and `DSCOMMON_*` page-spacing / content-max-width tokens as a single source of truth. `StickyHeader` is now the single sticky tab bar for the address and block pages (full-bleed background, responsive underline), replacing the per-page bespoke bars.
-   **Storybook** — a new _Design System / Sizes_ reference (spacings + max-widths per tier), per-component _References_ sections, and `StickyHeader` docs on how to embed it.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Design update

## Screenshots
<img width="1815" height="2057" alt="rewards_mobile_desktop" src="https://github.com/user-attachments/assets/297623c1-8182-4012-beb0-fc1e665677f8" />


## Testing

Open [vote account](https://explorer-git-development-feat-hoo-939-vote-histo-18183f-hoodies.vercel.app/address/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk), check Vote history and Rewards tab.

## Related Issues

https://linear.app/solana-fndn/issue/HOO-939
https://linear.app/solana-fndn/issue/HOO-931

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information

## Additional Notes

Inner draft PR against `feat/hoo-939-vote-history-mobile-layout`.
